### PR TITLE
Seven-segment gauge readouts, pinned throughput units, decade dials

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ monitor live. Persistence and a background sampler come later — see
 - System APIs: mach (`host_processor_info`, `host_statistics64`), IOKit
   (`IOBlockStorageDriver`, `IOAccelerator`), `getifaddrs`, `sysctl`,
   SystemConfiguration (`SCNetworkInterfaceCopyAll`).
-- Tests use swift-testing (`@Test`, `#expect`), not XCTest — 64 tests in 10 suites.
+- Tests use swift-testing (`@Test`, `#expect`), not XCTest.
 - swiftformat (`.swiftformat`) for lint. CI runs on a self-hosted macOS ARM64
   runner.
 
@@ -51,8 +51,8 @@ Sources/
                    to read.
   MonitorSources/  the readers: CPU, memory, disk, network, GPU, and the registry
                    that lists them. One file per source.
-  MonitorUI/       Theme, GaugeView, SevenSegmentText, ChartCard, DashboardView,
-                   AppModel
+  MonitorUI/       Theme (palette + Layout density), GaugeView, SevenSegmentText,
+                   ChartCard, DashboardView, AppModel
   MonitorStore/    SQLite history and retention. Designed and tested but NOT
                    linked into the app — see "Guardrails" below.
   monitor/         the app target (@main SwiftUI App)
@@ -77,9 +77,10 @@ docs/              README.md is the index
   falls slowly, stepping down only once the value has stayed clear of the next
   scale down for a continuous `decayInterval`.
 - **Throughput units are pinned.** Disk is always MB/s, network always Mbit/s,
-  at every magnitude. The unit under a needle must not change while you are
-  reading it. Network converts bytes to bits *in the source*, so the dial, the
-  chart axis and `monitorctl` cannot disagree about it.
+  at every magnitude, and the gauge readout is a fixed `xxxx.yy` field whose
+  decimal point never moves. The unit under a needle must not change while you
+  are reading it. Network converts bytes to bits *in the source*, so the dial,
+  the chart axis and `monitorctl` cannot disagree about it.
 - **Network counts physical NICs only** — Wi-Fi and wired, via
   `SCNetworkInterfaceCopyAll` filtered to the Ethernet and IEEE80211 types.
   Summing every `getifaddrs` interface double-counts a VPN's traffic (once on

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ monitor live. Persistence and a background sampler come later — see
 - SwiftUI, Swift Charts, `Canvas` for the gauges.
 - System APIs: mach (`host_processor_info`, `host_statistics64`), IOKit
   (`IOBlockStorageDriver`, `IOAccelerator`), `getifaddrs`, `sysctl`.
-- Tests use swift-testing (`@Test`, `#expect`), not XCTest — 33 tests in 7 suites.
+- Tests use swift-testing (`@Test`, `#expect`), not XCTest — 60 tests in 10 suites.
 - swiftformat (`.swiftformat`) for lint. CI runs on a self-hosted macOS ARM64
   runner.
 
@@ -45,11 +45,13 @@ look at it in the app.
 ```
 Sources/
   MonitorCore/     metric model, ring buffer, downsampling, gauge auto-ranging,
-                   formatting, the sampling clock. No macOS APIs — so all of it
-                   is testable without a machine to read.
+                   seven-segment digit mapping, formatting, the sampling clock.
+                   No macOS APIs — so all of it is testable without a machine
+                   to read.
   MonitorSources/  the readers: CPU, memory, disk, network, GPU, and the registry
                    that lists them. One file per source.
-  MonitorUI/       Theme, GaugeView, ChartCard, DashboardView, AppModel
+  MonitorUI/       Theme, GaugeView, SevenSegmentText, ChartCard, DashboardView,
+                   AppModel
   MonitorStore/    SQLite history and retention. Designed and tested but NOT
                    linked into the app — see "Guardrails" below.
   monitor/         the app target (@main SwiftUI App)
@@ -69,8 +71,14 @@ docs/              README.md is the index
   boot. `RateTracker` differentiates them. It returns nil for the first reading
   of a series on purpose, because there is no rate yet and reporting zero would
   draw a dip that did not happen.
-- **`GaugeScale`** auto-ranges a dial and snaps full scale to 1, 2 or 5 times a
-  power of ten. It rises immediately and falls slowly, over a trailing window.
+- **`GaugeScale`** auto-ranges a dial and snaps full scale to a `ScaleLadder` —
+  1-2-5 by default, decades for the throughput dials. It rises immediately and
+  falls slowly, stepping down only once the value has stayed clear of the next
+  scale down for a continuous `decayInterval`.
+- **Throughput units are pinned.** Disk is always MB/s, network always Mbit/s,
+  at every magnitude. The unit under a needle must not change while you are
+  reading it. Network converts bytes to bits *in the source*, so the dial, the
+  chart axis and `monitorctl` cannot disagree about it.
 - **Gauges are for rates, charts are for levels.** A dial answers "how hard is
   this working right now against what it can do" (disk, network throughput). A
   chart answers "what has been happening" (CPU, memory). `AppModel.isGauge`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,8 +20,9 @@ monitor live. Persistence and a background sampler come later — see
   dependencies.
 - SwiftUI, Swift Charts, `Canvas` for the gauges.
 - System APIs: mach (`host_processor_info`, `host_statistics64`), IOKit
-  (`IOBlockStorageDriver`, `IOAccelerator`), `getifaddrs`, `sysctl`.
-- Tests use swift-testing (`@Test`, `#expect`), not XCTest — 60 tests in 10 suites.
+  (`IOBlockStorageDriver`, `IOAccelerator`), `getifaddrs`, `sysctl`,
+  SystemConfiguration (`SCNetworkInterfaceCopyAll`).
+- Tests use swift-testing (`@Test`, `#expect`), not XCTest — 64 tests in 10 suites.
 - swiftformat (`.swiftformat`) for lint. CI runs on a self-hosted macOS ARM64
   runner.
 
@@ -79,6 +80,15 @@ docs/              README.md is the index
   at every magnitude. The unit under a needle must not change while you are
   reading it. Network converts bytes to bits *in the source*, so the dial, the
   chart axis and `monitorctl` cannot disagree about it.
+- **Network counts physical NICs only** — Wi-Fi and wired, via
+  `SCNetworkInterfaceCopyAll` filtered to the Ethernet and IEEE80211 types.
+  Summing every `getifaddrs` interface double-counts a VPN's traffic (once on
+  `utun`, once on the `en` it leaves by) and adds AirDrop and Apple's internal
+  interfaces on top.
+- **CPU load is per cluster, not per core.** One series per `hw.perflevel`,
+  keyed by level because the *name* differs across silicon ("Super" on M4,
+  "Performance" earlier). `host_processor_info` numbers cores in reverse
+  perflevel order — slowest cluster first.
 - **Gauges are for rates, charts are for levels.** A dial answers "how hard is
   this working right now against what it can do" (disk, network throughput). A
   chart answers "what has been happening" (CPU, memory). `AppModel.isGauge`

--- a/Sources/MonitorCore/Formatting.swift
+++ b/Sources/MonitorCore/Formatting.swift
@@ -79,6 +79,21 @@ public enum Format {
         }
     }
 
+    /// A chart axis label: the coarse number a tick wants, plus the unit.
+    ///
+    /// Same reasoning as `tickLabel` — an axis is a scale, not a measurement,
+    /// and the current value is spelled out in the card's header anyway. Three
+    /// significant figures up the side of a chart gives `0.00 MB/s` next to
+    /// `20.0 MB/s`, which reads as two different kinds of number.
+    public static func axisLabel(_ value: Double, unit: MetricUnit) -> String {
+        switch unit {
+        case .bytesPerSecond, .bitsPerSecond:
+            "\(tickLabel(value, unit: unit)) \(unitLabel(value, unit: unit))"
+        default:
+            self.value(value, unit: unit)
+        }
+    }
+
     /// Format a value according to its metric's unit.
     public static func value(_ value: Double, unit: MetricUnit) -> String {
         switch unit {

--- a/Sources/MonitorCore/Formatting.swift
+++ b/Sources/MonitorCore/Formatting.swift
@@ -61,6 +61,46 @@ public enum Format {
         return String(format: "%.0f µs", seconds * 1_000_000)
     }
 
+    /// Digits either side of the point in a gauge's readout: `xxxx.yy`.
+    ///
+    /// Four rather than three so the field cannot overflow on real hardware. An
+    /// internal SSD reads at around 5000 MB/s, which a three-digit field could
+    /// not show at all; 9999.99 covers that and a 10 Gbit link, so the overflow
+    /// case is unreachable rather than merely handled.
+    public static let readoutIntegerDigits = 4
+    public static let readoutFractionDigits = 2
+
+    /// A gauge's readout as a fixed field, right-aligned and space-padded, with
+    /// the decimal point in the same place at every magnitude.
+    ///
+    /// The point staying put is the whole reason this is not just `throughput`.
+    /// A readout you glance at is read partly by *position*: if the point slides
+    /// left as the value grows, then `4.23` and `43.7` occupy the same pixels
+    /// with different meanings, and you have to read all of it to know which you
+    /// are looking at. Nailing the point down means the integer part always
+    /// starts and ends in the same place, so the shape of the number carries its
+    /// magnitude.
+    ///
+    /// Padded with spaces rather than zeros: `0004.23` reads as a part number.
+    public static func readout(_ value: Double, unit: MetricUnit) -> String {
+        switch unit {
+        case .bytesPerSecond, .bitsPerSecond:
+            let scaled = value / throughputDivisor
+            let width = readoutIntegerDigits + 1 + readoutFractionDigits
+            // The limit is what rounds *up* out of the field, not what exceeds
+            // it: 9999.996 would print as 10000.00 and shift the point.
+            let ceiling = pow(10, Double(readoutIntegerDigits))
+                - 0.5 * pow(10, -Double(readoutFractionDigits))
+            guard scaled >= 0, scaled < ceiling else {
+                return String(repeating: "-", count: readoutIntegerDigits)
+                    + "." + String(repeating: "-", count: readoutFractionDigits)
+            }
+            return String(format: "%\(width).\(readoutFractionDigits)f", scaled)
+        default:
+            return magnitude(value, unit: unit)
+        }
+    }
+
     /// A dial's tick label, which is coarser than the readout on purpose.
     ///
     /// A tick is a landmark, not a measurement — the readout below the needle

--- a/Sources/MonitorCore/Formatting.swift
+++ b/Sources/MonitorCore/Formatting.swift
@@ -22,6 +22,29 @@ public enum Format {
         return "\(String(format: "%.\(digits)f", magnitude)) \(units[index])\(suffix)"
     }
 
+    /// Throughput is pinned to mega-units and never rescaled: disk in MB/s,
+    /// network in Mbit/s, at every magnitude, including 0.02 and 5000.
+    ///
+    /// Auto-scaling is right for an axis and wrong for an instrument. The unit
+    /// under a needle you are watching must not change while you are reading
+    /// it, and a readout of `900` is unusable until you have also read the word
+    /// underneath — which is a second look, on a display whose whole purpose is
+    /// to be legible in one. Pinning also stops the gauge and its own dial
+    /// labels from landing in different decades.
+    public static let throughputDivisor = 1_000_000.0
+
+    /// The number part of a throughput reading, at three significant figures.
+    ///
+    /// Three keeps the width of the readout near-constant as the value moves —
+    /// `0.02`, `2.35`, `12.4`, `245` — which matters more here than the digits
+    /// given up, because the readout sits inside a fixed inset on the dial.
+    public static func throughput(_ value: Double) -> String {
+        let scaled = value / throughputDivisor
+        if scaled >= 100 { return String(format: "%.0f", scaled) }
+        if scaled >= 10 { return String(format: "%.1f", scaled) }
+        return String(format: "%.2f", scaled)
+    }
+
     public static func fraction(_ value: Double) -> String {
         "\(Int((value * 100).rounded()))%"
     }
@@ -38,12 +61,31 @@ public enum Format {
         return String(format: "%.0f µs", seconds * 1_000_000)
     }
 
+    /// A dial's tick label, which is coarser than the readout on purpose.
+    ///
+    /// A tick is a landmark, not a measurement — the readout below the needle
+    /// is where the digits live. On a 0–10 MB/s dial the ticks want to say
+    /// 0, 5, 10, not 0.00, 5.00, 10.0, which is three characters of noise on a
+    /// face with room for none.
+    public static func tickLabel(_ value: Double, unit: MetricUnit) -> String {
+        switch unit {
+        case .bytesPerSecond, .bitsPerSecond:
+            let scaled = value / throughputDivisor
+            return scaled >= 1 || scaled == 0
+                ? String(format: "%.0f", scaled)
+                : throughput(value)
+        default:
+            return magnitude(value, unit: unit)
+        }
+    }
+
     /// Format a value according to its metric's unit.
     public static func value(_ value: Double, unit: MetricUnit) -> String {
         switch unit {
         case .fraction: fraction(value)
         case .bytes: bytes(value)
-        case .bytesPerSecond: bytes(value, perSecond: true)
+        case .bytesPerSecond, .bitsPerSecond:
+            "\(throughput(value)) \(unitLabel(value, unit: unit))"
         case .operationsPerSecond: rate(value)
         case .count: rate(value, unit: "")
         case .hertz: rate(value, unit: " Hz")
@@ -57,9 +99,11 @@ public enum Format {
     /// from the number because the gauge draws them in different type sizes.
     public static func unitLabel(_ value: Double, unit: MetricUnit) -> String {
         switch unit {
-        case .bytes, .bytesPerSecond:
-            let text = bytes(value, perSecond: unit == .bytesPerSecond)
+        case .bytes:
+            let text = bytes(value)
             return text.split(separator: " ").last.map(String.init) ?? ""
+        case .bytesPerSecond: return "MB/s"
+        case .bitsPerSecond: return "Mbit/s"
         case .fraction: return "%"
         case .operationsPerSecond: return "IO/s"
         case .seconds: return value >= 1 ? "s" : (value >= 0.001 ? "ms" : "µs")
@@ -73,9 +117,10 @@ public enum Format {
     /// Just the number part, for a gauge readout whose unit is drawn separately.
     public static func magnitude(_ value: Double, unit: MetricUnit) -> String {
         switch unit {
-        case .bytes, .bytesPerSecond:
-            let text = bytes(value, perSecond: false)
+        case .bytes:
+            let text = bytes(value)
             return text.split(separator: " ").first.map(String.init) ?? "0"
+        case .bytesPerSecond, .bitsPerSecond: return throughput(value)
         case .fraction: return "\(Int((value * 100).rounded()))"
         case .seconds:
             if value >= 1 { return String(format: "%.2f", value) }

--- a/Sources/MonitorCore/GaugeScale.swift
+++ b/Sources/MonitorCore/GaugeScale.swift
@@ -1,5 +1,78 @@
 import Foundation
 
+/// The set of values a dial's full scale is allowed to take.
+///
+/// Two ladders, because the two situations are genuinely different. When the
+/// range is unknown, 1-2-5 keeps the needle in a useful part of the sweep — a
+/// dial fixed at decades spends most of its life below a fifth of full scale.
+/// When the reader already has the ladder in their head, which for MB/s and
+/// Mbit/s they do, decades are worth the lost resolution: full scale becomes
+/// predictable, so a glance at the needle is enough and the number underneath
+/// is confirmation rather than a prerequisite.
+public enum ScaleLadder: Sendable {
+    /// 1, 2 or 5 times a power of ten: … 10, 20, 50, 100, 200, 500 …
+    case oneTwoFive
+    /// Powers of ten only: … 10, 100, 1000 …
+    case decade
+
+    /// The smallest step on this ladder that is at least `value`.
+    public func snap(_ value: Double) -> Double {
+        guard value > 0, value.isFinite else { return 1 }
+        let (magnitude, normalized) = ScaleLadder.decompose(value)
+        switch self {
+        case .oneTwoFive:
+            let step: Double =
+                if normalized <= 1 {
+                    1
+                } else if normalized <= 2 {
+                    2
+                } else if normalized <= 5 {
+                    5
+                } else {
+                    10
+                }
+            return step * magnitude
+        case .decade:
+            // `normalized` is in 1..<10, so anything above an exact power of
+            // ten belongs on the next decade up.
+            return normalized <= 1 ? magnitude : magnitude * 10
+        }
+    }
+
+    /// The largest step on this ladder that is strictly below `value`.
+    ///
+    /// Defined whether or not `value` is itself on the ladder, so it answers
+    /// "what would the next scale down be" for any dial.
+    public func step(below value: Double) -> Double? {
+        guard value > 0, value.isFinite else { return nil }
+        let (magnitude, normalized) = ScaleLadder.decompose(value)
+        switch self {
+        case .oneTwoFive:
+            if normalized > 5 { return 5 * magnitude }
+            if normalized > 2 { return 2 * magnitude }
+            if normalized > 1 { return magnitude }
+            // Exactly on a power of ten, so the rung below is in the decade
+            // underneath: 100 → 50.
+            return magnitude / 2
+        case .decade:
+            return normalized > 1 ? magnitude : magnitude / 10
+        }
+    }
+
+    /// Splits a positive value into a power of ten and a mantissa in 1..<10.
+    ///
+    /// `log10` is not exact for every power of ten on every platform, and a
+    /// mantissa that comes back as 9.999999 instead of 1 would put a scale a
+    /// whole decade wrong. The two corrections below cost nothing and remove
+    /// the class of bug entirely.
+    private static func decompose(_ value: Double) -> (magnitude: Double, normalized: Double) {
+        var magnitude = pow(10, log10(value).rounded(.down))
+        if value / magnitude >= 10 { magnitude *= 10 }
+        if value / magnitude < 1 { magnitude /= 10 }
+        return (magnitude, value / magnitude)
+    }
+}
+
 /// Picks the full-scale value for an analog gauge.
 ///
 /// A benchmark gauge has it easy: the tester knows a disk tops out around
@@ -10,13 +83,15 @@ import Foundation
 /// So full scale auto-ranges, with two rules that make the needle readable
 /// rather than merely correct:
 ///
-///  - **Snap to 1, 2 or 5 times a power of ten.** An arbitrary full scale means
-///    tick labels like 3.7 GB/s, which nobody can read at a glance. Snapping
-///    means the ticks are always round numbers.
+///  - **Snap to a ladder.** An arbitrary full scale means tick labels like
+///    3.7 GB/s, which nobody can read at a glance. Snapping means the ticks are
+///    always round numbers. Which ladder is a per-gauge choice — see
+///    `ScaleLadder`.
 ///  - **Rise immediately, fall slowly.** A needle whose dial rescales the
 ///    instant traffic drops is unreadable — the needle appears to move when the
 ///    value did not. Full scale jumps up at once when the value exceeds it, and
-///    only steps down after the peak has stayed low for `decayInterval`.
+///    only steps down once the value has stayed clear of the next scale down
+///    for a continuous `decayInterval`.
 ///
 /// This is a value type in MonitorCore, not a view, so the behaviour is
 /// testable without rendering anything.
@@ -27,42 +102,94 @@ public struct GaugeScale: Sendable {
     /// How long the peak must stay below the next scale down before the dial
     /// rescales.
     public let decayInterval: TimeInterval
+    /// Which values full scale is allowed to take.
+    public let ladder: ScaleLadder
+    /// How far below the next scale down the peak must sit before the dial
+    /// takes it — 0.9 means "below 9 on the way down from 10".
+    ///
+    /// This is hysteresis, and without it a workload that happens to sit at
+    /// exactly full scale rescales the dial every window, forever. The needle
+    /// then moves constantly while the value does not, which is the one thing a
+    /// gauge must never do.
+    public let releaseFraction: Double
 
     public private(set) var fullScale: Double
-    /// Highest value seen in the current decay window — what the redline marks.
+    /// The high-water mark that explains the current scale: the highest reading
+    /// since full scale last changed. Drawn as the memory mark on the dial, so
+    /// a dial sitting on a scale nothing currently needs still shows why.
     public private(set) var peak: Double = 0
-    /// Start of the current decay window.
-    private var windowStart: TimeInterval?
+    /// When the value last dropped below the release threshold, or nil if it is
+    /// above it now. This is what the decay measures against.
+    private var quietSince: TimeInterval?
+    /// Highest reading since `quietSince`, which decides how far the scale
+    /// falls once the quiet period is up.
+    private var quietPeak: Double = 0
 
-    public init(floor: Double, decayInterval: TimeInterval = 15) {
+    public init(
+        floor: Double,
+        decayInterval: TimeInterval = 15,
+        ladder: ScaleLadder = .oneTwoFive,
+        releaseFraction: Double = 0.9
+    ) {
         self.floor = floor
         self.decayInterval = decayInterval
-        fullScale = GaugeScale.snap(floor)
+        self.ladder = ladder
+        self.releaseFraction = releaseFraction
+        fullScale = ladder.snap(floor)
     }
 
     /// Feed a reading. Returns the current full scale.
     @discardableResult
     public mutating func update(value: Double, at timestamp: TimeInterval) -> Double {
-        if windowStart == nil { windowStart = timestamp }
+        if value > fullScale {
+            fullScale = ladder.snap(max(value, floor))
+            // A new scale gets a fresh high-water mark, and the clock on
+            // coming back down starts from the spike that caused it.
+            peak = value
+            quietSince = nil
+            quietPeak = 0
+            return fullScale
+        }
+
         peak = max(peak, value)
 
-        if value > fullScale {
-            fullScale = GaugeScale.snap(max(value, floor))
+        // Nothing to fall to: already on the bottom rung.
+        guard let lower = ladder.step(below: fullScale), lower >= floor else {
+            quietSince = nil
             return fullScale
         }
 
-        // The peak is over a trailing window, not since the app launched. An
-        // all-time peak never decays, so one 900 MB/s spike at breakfast would
-        // pin the dial at 1 GB/s for the rest of the day and every reading
-        // after it would sit uselessly against the stop.
-        guard let start = windowStart, timestamp - start >= decayInterval else {
+        // The decay measures how long the value has been *continuously* below
+        // the threshold, not the peak of a fixed window. A tumbling window
+        // cannot express this: the window that contains the spike also contains
+        // the evidence against coming down, so the dial would need two full
+        // windows — twenty minutes for a ten-minute rule — before it moved.
+        let threshold = lower * releaseFraction
+        guard value < threshold else {
+            quietSince = nil
+            quietPeak = 0
             return fullScale
         }
-        let target = GaugeScale.snap(max(peak, floor))
-        if target < fullScale { fullScale = target }
-        // Start the next window from the reading that just arrived.
-        peak = value
-        windowStart = timestamp
+
+        if quietSince == nil { quietSince = timestamp }
+        quietPeak = max(quietPeak, value)
+
+        guard let since = quietSince, timestamp - since >= decayInterval else {
+            return fullScale
+        }
+        // Descend as far as the quiet period justifies rather than one rung at
+        // a time. Ten quiet minutes should take a dial from 1000 back to 10,
+        // not start a half-hour walk down during which every reading is
+        // squashed against the bottom of the sweep.
+        while let next = ladder.step(below: fullScale),
+              next >= floor,
+              quietPeak < next * releaseFraction
+        {
+            fullScale = next
+        }
+        peak = quietPeak
+        quietSince = timestamp
+        quietPeak = value
         return fullScale
     }
 
@@ -74,20 +201,6 @@ public struct GaugeScale: Sendable {
 
     /// Rounds up to the next 1, 2 or 5 times a power of ten.
     public static func snap(_ value: Double) -> Double {
-        guard value > 0, value.isFinite else { return 1 }
-        let exponent = log10(value).rounded(.down)
-        let magnitude = pow(10, exponent)
-        let normalized = value / magnitude
-        let step: Double =
-            if normalized <= 1 {
-                1
-            } else if normalized <= 2 {
-                2
-            } else if normalized <= 5 {
-                5
-            } else {
-                10
-            }
-        return step * magnitude
+        ScaleLadder.oneTwoFive.snap(value)
     }
 }

--- a/Sources/MonitorCore/Metric.swift
+++ b/Sources/MonitorCore/Metric.swift
@@ -16,7 +16,11 @@ public enum MetricUnit: String, Sendable, Codable {
     /// 0...1. Charts fix the y-axis to that range rather than to the data.
     case fraction
     case bytes
+    /// Disk throughput. Always shown in MB/s — drives are quoted in bytes.
     case bytesPerSecond
+    /// Network throughput. Always shown in Mbit/s — links are quoted in bits,
+    /// so reporting bytes forces a division by eight on every reading.
+    case bitsPerSecond
     case operationsPerSecond
     case count
     case hertz

--- a/Sources/MonitorCore/SevenSegment.swift
+++ b/Sources/MonitorCore/SevenSegment.swift
@@ -1,0 +1,101 @@
+import Foundation
+
+/// Which of a seven-segment cell's bars a character lights.
+///
+/// This lives in MonitorCore rather than beside the view because "a 4 lights
+/// b, c, f and g" is a fact about the display, not about drawing: it can be
+/// stated and tested without a screen, and it is the half of the readout most
+/// likely to be quietly wrong. Segment geometry — where the bars sit, how they
+/// taper — belongs to the view.
+///
+/// Segments carry their traditional names, going clockwise from the top bar
+/// with the middle bar last:
+///
+///     ┌── a ──┐
+///     f       b
+///     ├── g ──┤
+///     e       c
+///     └── d ──┘
+public enum SevenSegment {
+    public struct Mask: OptionSet, Hashable, Sendable {
+        public let rawValue: UInt8
+        public init(rawValue: UInt8) { self.rawValue = rawValue }
+
+        public static let a = Mask(rawValue: 1 << 0)
+        public static let b = Mask(rawValue: 1 << 1)
+        public static let c = Mask(rawValue: 1 << 2)
+        public static let d = Mask(rawValue: 1 << 3)
+        public static let e = Mask(rawValue: 1 << 4)
+        public static let f = Mask(rawValue: 1 << 5)
+        public static let g = Mask(rawValue: 1 << 6)
+
+        /// Every bar lit: an `8`, and the shape the unlit ghosts trace.
+        public static let all: Mask = [.a, .b, .c, .d, .e, .f, .g]
+    }
+
+    /// One cell of the display: the bars it lights, and whether the dot to its
+    /// right is on.
+    public struct Glyph: Hashable, Sendable {
+        public let mask: Mask
+        public let point: Bool
+
+        public init(mask: Mask, point: Bool = false) {
+            self.mask = mask
+            self.point = point
+        }
+    }
+
+    /// The bars a character lights, or nil for anything this display cannot
+    /// show. A `.` is not a character here — it belongs to the cell before it,
+    /// which is what `glyphs(for:)` handles.
+    public static func mask(for character: Character) -> Mask? {
+        switch character {
+        case "0": [.a, .b, .c, .d, .e, .f]
+        case "1": [.b, .c]
+        case "2": [.a, .b, .d, .e, .g]
+        case "3": [.a, .b, .c, .d, .g]
+        case "4": [.b, .c, .f, .g]
+        case "5": [.a, .c, .d, .f, .g]
+        case "6": [.a, .c, .d, .e, .f, .g]
+        case "7": [.a, .b, .c]
+        case "8": .all
+        case "9": [.a, .b, .c, .d, .f, .g]
+        case "-": .g
+        case " ": []
+        default: nil
+        }
+    }
+
+    /// Lay a string out as cells.
+    ///
+    /// A decimal point takes no cell of its own — it lights the dot belonging
+    /// to the digit it follows, exactly as hardware does. That is what keeps
+    /// "2.35" and "235" the same width, so the readout does not shift sideways
+    /// as a value crosses a decade. A leading point, having no digit to attach
+    /// to, gets a blank cell to sit on.
+    ///
+    /// Characters the display cannot show are dropped rather than substituted:
+    /// a wrong glyph in a readout is worse than a missing one.
+    public static func glyphs(for text: String) -> [Glyph] {
+        var result: [Glyph] = []
+        for character in text {
+            if character == "." || character == "," {
+                if result.isEmpty {
+                    result.append(Glyph(mask: [], point: true))
+                } else if result[result.count - 1].point {
+                    // Two points in a row cannot share a cell.
+                    result.append(Glyph(mask: [], point: true))
+                } else {
+                    result[result.count - 1] = Glyph(
+                        mask: result[result.count - 1].mask, point: true
+                    )
+                }
+                continue
+            }
+            if let mask = mask(for: character) {
+                result.append(Glyph(mask: mask))
+            }
+        }
+        return result
+    }
+}

--- a/Sources/MonitorSources/CPUSource.swift
+++ b/Sources/MonitorSources/CPUSource.swift
@@ -2,22 +2,26 @@ import Darwin
 import Foundation
 import MonitorCore
 
-/// Per-core and aggregate CPU load, from `host_processor_info`.
+/// Aggregate and per-cluster CPU load, from `host_processor_info`.
 ///
 /// The kernel reports cumulative ticks per core in four states, so load is the
 /// difference between two readings — the first `read` therefore produces
 /// nothing but a baseline. That is why the sampler must not treat an empty
 /// batch as an error.
 ///
-/// Apple silicon has efficiency and performance cores with different ceilings.
-/// This source reports every core separately and lets the UI group them; it
-/// does not try to average a P-core and an E-core into one number, because that
-/// number would not mean anything.
+/// Apple silicon has clusters of cores with different ceilings, and load is
+/// reported as one series per cluster. Averaging *across* clusters would be
+/// meaningless — a pinned efficiency core and a pinned performance core are not
+/// the same amount of work — but averaging *within* one is exactly right, since
+/// a cluster's cores are interchangeable to the scheduler. A line per core says
+/// less: at ten cores the chart is unreadable and its legend does not fit.
 public final class CPUSource: MetricSource, @unchecked Sendable {
     public let id = "cpu"
 
     /// Ticks from the previous reading, one entry per core.
     private var previous: [ProcessorTicks] = []
+    /// Resolved once: the topology cannot change while the process runs.
+    private let clusters = CPUSource.readClusters()
 
     struct ProcessorTicks {
         var user: UInt32
@@ -33,7 +37,15 @@ public final class CPUSource: MetricSource, @unchecked Sendable {
     public static let total = MetricID("cpu.total")
     public static let user = MetricID("cpu.user")
     public static let system = MetricID("cpu.system")
-    public static func core(_ index: Int) -> MetricID { MetricID("cpu.core.\(index)") }
+
+    /// Keyed by performance level, not by the cluster's marketing name.
+    ///
+    /// `hw.perflevel0` is always the fastest cluster on any machine that has
+    /// them, so the id means the same thing everywhere and stays stable. The
+    /// name does not: this M4 calls level 0 "Super" where earlier silicon calls
+    /// it "Performance", and a `cpu.cluster.performance` id would have to be
+    /// either a lie or a rename.
+    public static func cluster(_ level: Int) -> MetricID { MetricID("cpu.perflevel.\(level)") }
 
     public var descriptors: [MetricDescriptor] {
         var result = [
@@ -49,15 +61,87 @@ public final class CPUSource: MetricSource, @unchecked Sendable {
                 nominalMaximum: 1
             ),
         ]
-        for index in 0..<ProcessInfo.processInfo.activeProcessorCount {
+        for cluster in clusters {
             result.append(
                 MetricDescriptor(
-                    id: Self.core(index), name: "Core \(index)", group: "CPU Cores",
+                    id: Self.cluster(cluster.level), name: cluster.name, group: "CPU Cores",
                     unit: .fraction, nominalMaximum: 1
                 )
             )
         }
         return result
+    }
+
+    /// One cluster of interchangeable cores.
+    struct Cluster {
+        /// `hw.perflevel` index: 0 is always the fastest cluster.
+        let level: Int
+        /// The kernel's own name for it — "Super", "Performance", "Efficiency".
+        let name: String
+        /// The core indices `host_processor_info` reports it under.
+        let cores: Range<Int>
+    }
+
+    /// Maps `hw.perflevel*` onto the core indices the kernel reports.
+    ///
+    /// `host_processor_info` numbers cores in **reverse** performance-level
+    /// order: the slowest cluster comes first. Verified on this M4 (10 cores,
+    /// 4 at level 0 named "Super", 6 at level 1 named "Efficiency") by pinning
+    /// four `userInteractive` threads, which the scheduler puts on the fast
+    /// cluster: cores 6–9 went to 99% and cores 0–5 stayed idle.
+    ///
+    /// Returns empty on a machine with fewer than two levels — an Intel Mac has
+    /// one uniform cluster, and a single "cluster" series would just duplicate
+    /// `cpu.total`. Also returns empty if the level sizes do not add up to the
+    /// core count, because a wrong split is worse than no split: it would label
+    /// real load as coming from the wrong kind of core.
+    static func readClusters() -> [Cluster] {
+        let levels = sysctlInt("hw.nperflevels") ?? 1
+        guard levels > 1 else { return [] }
+
+        var descending: [(level: Int, name: String, count: Int)] = []
+        for level in 0..<levels {
+            guard let count = sysctlInt("hw.perflevel\(level).logicalcpu"), count > 0 else {
+                return []
+            }
+            let name = sysctlString("hw.perflevel\(level).name") ?? "Level \(level)"
+            descending.append((level, name, count))
+        }
+
+        let total = descending.reduce(0) { $0 + $1.count }
+        guard total == ProcessInfo.processInfo.activeProcessorCount else { return [] }
+
+        var result: [Cluster] = []
+        var start = 0
+        for entry in descending.reversed() {
+            result.append(
+                Cluster(
+                    level: entry.level,
+                    name: entry.name,
+                    cores: start..<(start + entry.count)
+                )
+            )
+            start += entry.count
+        }
+        // Fastest cluster first, so it takes the first series colour and reads
+        // at the top of the legend.
+        return result.sorted { $0.level < $1.level }
+    }
+
+    static func sysctlInt(_ name: String) -> Int? {
+        var value = 0
+        var size = MemoryLayout<Int>.size
+        guard sysctlbyname(name, &value, &size, nil, 0) == 0 else { return nil }
+        return value
+    }
+
+    static func sysctlString(_ name: String) -> String? {
+        var size = 0
+        guard sysctlbyname(name, nil, &size, nil, 0) == 0, size > 0 else { return nil }
+        var buffer = [UInt8](repeating: 0, count: size)
+        guard sysctlbyname(name, &buffer, &size, nil, 0) == 0 else { return nil }
+        // sysctl includes the null terminator in the byte count it reports.
+        return String(decoding: buffer.prefix(while: { $0 != 0 }), as: UTF8.self)
     }
 
     public func read(at timestamp: TimeInterval) throws -> SampleBatch {
@@ -72,6 +156,8 @@ public final class CPUSource: MetricSource, @unchecked Sendable {
 
         var values: [MetricID: Double] = [:]
         var userTicks = 0.0, systemTicks = 0.0, totalTicks = 0.0
+        // Busy fraction per core, for the cluster averages below.
+        var busy = [Double?](repeating: nil, count: current.count)
 
         for (index, now) in current.enumerated() {
             let before = previous[index]
@@ -82,10 +168,20 @@ public final class CPUSource: MetricSource, @unchecked Sendable {
             let system = Double(now.system &- before.system)
             let idle = Double(now.idle &- before.idle)
 
-            values[Self.core(index)] = (elapsed - idle) / elapsed
+            busy[index] = (elapsed - idle) / elapsed
             userTicks += user
             systemTicks += system
             totalTicks += elapsed
+        }
+
+        // The mean over a cluster's cores. Cores that reported no elapsed ticks
+        // are left out of both halves of the average rather than counted as
+        // idle: a core the kernel did not advance this tick has no load to
+        // report, and calling that zero would drag the cluster down.
+        for cluster in clusters {
+            let loads = cluster.cores.compactMap { $0 < busy.count ? busy[$0] : nil }
+            guard !loads.isEmpty else { continue }
+            values[Self.cluster(cluster.level)] = loads.reduce(0, +) / Double(loads.count)
         }
 
         if totalTicks > 0 {

--- a/Sources/MonitorSources/DiskSource.swift
+++ b/Sources/MonitorSources/DiskSource.swift
@@ -44,11 +44,11 @@ public final class DiskSource: MetricSource, @unchecked Sendable {
                 unit: .operationsPerSecond
             ),
             MetricDescriptor(
-                id: Self.readLatency, name: "Read latency", group: "Disk Latency",
+                id: Self.readLatency, name: "Read", group: "Disk Latency",
                 unit: .seconds
             ),
             MetricDescriptor(
-                id: Self.writeLatency, name: "Write latency", group: "Disk Latency",
+                id: Self.writeLatency, name: "Write", group: "Disk Latency",
                 unit: .seconds
             ),
         ]

--- a/Sources/MonitorSources/NetworkSource.swift
+++ b/Sources/MonitorSources/NetworkSource.swift
@@ -1,12 +1,27 @@
 import Darwin
 import Foundation
 import MonitorCore
+import SystemConfiguration
 
-/// Network throughput, summed over every physical interface.
+/// Network throughput, summed over the machine's physical interfaces.
 ///
 /// `getifaddrs` reports cumulative byte counts per interface, so the values are
-/// differentiated into rates. Loopback is excluded — it is real traffic, but it
-/// is the machine talking to itself and it swamps the chart during a build.
+/// differentiated into rates.
+///
+/// **Only real NICs are counted — Wi-Fi and wired.** This matters more than it
+/// sounds. A Mac carries a crowd of interfaces that are not the network: `lo0`
+/// is the machine talking to itself and swamps the chart during a build;
+/// `utun0…8` are VPN and per-app tunnels, and traffic through one is counted
+/// *twice* if you sum both the tunnel and the `en0` it leaves by; `awdl0` is
+/// AirDrop; `llw0`, `anpi0`, `ap1` are Apple's own link-local and internal
+/// interfaces. Summing everything `getifaddrs` returns therefore reports more
+/// traffic than crossed the wire.
+///
+/// The list comes from `SCNetworkInterfaceCopyAll`, filtered to the Ethernet and
+/// IEEE 802.11 types, which is the supported way to ask "what would a person
+/// call a network interface on this Mac". A Thunderbolt Bridge is deliberately
+/// excluded along with the tunnels: it is real hardware underneath but the
+/// bridge itself is a virtual interface.
 ///
 /// Throughput is reported in **bits**, not bytes. Every number anyone quotes
 /// about a network is in bits — a 1 Gbit port, a 300 Mbit service, an 866 Mbit
@@ -23,6 +38,16 @@ public final class NetworkSource: MetricSource, @unchecked Sendable {
     public static let packetsOut = MetricID("net.packets.out")
 
     private var rates = RateTracker()
+
+    /// BSD names of the physical NICs, cached.
+    ///
+    /// `SCNetworkInterfaceCopyAll` costs about 0.8 ms — fine occasionally,
+    /// far too much at two reads a second when the whole sampling pass is
+    /// supposed to come in under a millisecond. Re-resolved every
+    /// `topologyInterval` so a dongle plugged in mid-session still appears.
+    private var physical: Set<String> = []
+    private var resolvedAt: TimeInterval?
+    private static let topologyInterval: TimeInterval = 10
 
     public init() {}
 
@@ -46,7 +71,11 @@ public final class NetworkSource: MetricSource, @unchecked Sendable {
     }
 
     public func read(at timestamp: TimeInterval) throws -> SampleBatch {
-        let totals = try Self.readInterfaceTotals()
+        if resolvedAt.map({ timestamp - $0 >= Self.topologyInterval }) ?? true {
+            physical = try Self.physicalInterfaceNames()
+            resolvedAt = timestamp
+        }
+        let totals = try Self.readInterfaceTotals(matching: physical)
         var values: [MetricID: Double] = [:]
         // Convert the byte counters to bits before differentiating rather than
         // after. Both give the same answer, but scaling the cumulative total
@@ -73,7 +102,41 @@ public final class NetworkSource: MetricSource, @unchecked Sendable {
         var packetsOut = 0.0
     }
 
-    static func readInterfaceTotals() throws -> InterfaceTotals {
+    /// The BSD names of the Wi-Fi and wired interfaces on this machine.
+    ///
+    /// Deliberately an allow-list of interface *types* rather than a deny-list
+    /// of name prefixes. A deny-list has to be extended every time Apple ships
+    /// another `anpi`-style internal interface, and the failure mode of missing
+    /// one is silently over-reporting traffic — the kind of wrong number nobody
+    /// checks.
+    static func physicalInterfaceNames() throws -> Set<String> {
+        guard let all = SCNetworkInterfaceCopyAll() as? [SCNetworkInterface] else {
+            throw MetricSourceError.readFailed("network interface list", code: 0)
+        }
+        var names: Set<String> = []
+        for interface in all {
+            guard let type = SCNetworkInterfaceGetInterfaceType(interface) as String?,
+                  type == (kSCNetworkInterfaceTypeEthernet as String)
+                  || type == (kSCNetworkInterfaceTypeIEEE80211 as String),
+                  let name = SCNetworkInterfaceGetBSDName(interface) as String?
+            else { continue }
+            names.insert(name)
+        }
+        return names
+    }
+
+    /// Every interface `getifaddrs` reports, physical or not. Exists so a test
+    /// can show that the filter narrows the set rather than merely matching it.
+    static func allInterfaceNames() -> [String] {
+        var head: UnsafeMutablePointer<ifaddrs>?
+        guard getifaddrs(&head) == 0, let head else { return [] }
+        defer { freeifaddrs(head) }
+        return sequence(first: head, next: { $0.pointee.ifa_next })
+            .filter { $0.pointee.ifa_addr?.pointee.sa_family == UInt8(AF_LINK) }
+            .map { String(cString: $0.pointee.ifa_name) }
+    }
+
+    static func readInterfaceTotals(matching names: Set<String>) throws -> InterfaceTotals {
         var head: UnsafeMutablePointer<ifaddrs>?
         guard getifaddrs(&head) == 0, let head else {
             throw MetricSourceError.readFailed("interface list", code: errno)
@@ -86,7 +149,7 @@ public final class NetworkSource: MetricSource, @unchecked Sendable {
             // AF_LINK carries the counters; the AF_INET entry for the same
             // interface does not, and counting both would double every byte.
             guard interface.ifa_addr?.pointee.sa_family == UInt8(AF_LINK) else { continue }
-            guard (interface.ifa_flags & UInt32(IFF_LOOPBACK)) == 0 else { continue }
+            guard names.contains(String(cString: interface.ifa_name)) else { continue }
             guard let raw = interface.ifa_data else { continue }
 
             let data = raw.assumingMemoryBound(to: if_data.self).pointee

--- a/Sources/MonitorSources/NetworkSource.swift
+++ b/Sources/MonitorSources/NetworkSource.swift
@@ -7,11 +7,18 @@ import MonitorCore
 /// `getifaddrs` reports cumulative byte counts per interface, so the values are
 /// differentiated into rates. Loopback is excluded — it is real traffic, but it
 /// is the machine talking to itself and it swamps the chart during a build.
+///
+/// Throughput is reported in **bits**, not bytes. Every number anyone quotes
+/// about a network is in bits — a 1 Gbit port, a 300 Mbit service, an 866 Mbit
+/// Wi-Fi link — so a monitor reporting bytes makes the reader divide by eight
+/// before they can tell whether the link is busy. The conversion happens here,
+/// at the source, rather than in the gauge, so that the dial, the chart axis
+/// and `monitorctl` cannot disagree about it.
 public final class NetworkSource: MetricSource, @unchecked Sendable {
     public let id = "network"
 
-    public static let bytesIn = MetricID("net.bytes.in")
-    public static let bytesOut = MetricID("net.bytes.out")
+    public static let bitsIn = MetricID("net.bits.in")
+    public static let bitsOut = MetricID("net.bits.out")
     public static let packetsIn = MetricID("net.packets.in")
     public static let packetsOut = MetricID("net.packets.out")
 
@@ -22,10 +29,10 @@ public final class NetworkSource: MetricSource, @unchecked Sendable {
     public var descriptors: [MetricDescriptor] {
         [
             MetricDescriptor(
-                id: Self.bytesIn, name: "In", group: "Network", unit: .bytesPerSecond
+                id: Self.bitsIn, name: "In", group: "Network", unit: .bitsPerSecond
             ),
             MetricDescriptor(
-                id: Self.bytesOut, name: "Out", group: "Network", unit: .bytesPerSecond
+                id: Self.bitsOut, name: "Out", group: "Network", unit: .bitsPerSecond
             ),
             MetricDescriptor(
                 id: Self.packetsIn, name: "Packets in", group: "Network Packets",
@@ -41,9 +48,13 @@ public final class NetworkSource: MetricSource, @unchecked Sendable {
     public func read(at timestamp: TimeInterval) throws -> SampleBatch {
         let totals = try Self.readInterfaceTotals()
         var values: [MetricID: Double] = [:]
+        // Convert the byte counters to bits before differentiating rather than
+        // after. Both give the same answer, but scaling the cumulative total
+        // keeps a single definition of the counter this metric tracks, and
+        // `RateTracker` never sees a quantity in units the metric does not use.
         let pairs: [(MetricID, Double)] = [
-            (Self.bytesIn, totals.bytesIn),
-            (Self.bytesOut, totals.bytesOut),
+            (Self.bitsIn, totals.bytesIn * 8),
+            (Self.bitsOut, totals.bytesOut * 8),
             (Self.packetsIn, totals.packetsIn),
             (Self.packetsOut, totals.packetsOut),
         ]

--- a/Sources/MonitorUI/AppModel.swift
+++ b/Sources/MonitorUI/AppModel.swift
@@ -44,7 +44,7 @@ public final class AppModel {
         sampler = Sampler(sources: sources, sinks: [], interval: 0.5)
 
         for descriptor in all where Self.isGauge(descriptor) {
-            scales[descriptor.id] = GaugeScale(floor: Self.gaugeFloor(descriptor))
+            scales[descriptor.id] = Self.makeScale(descriptor)
         }
     }
 
@@ -120,18 +120,51 @@ public final class AppModel {
     /// needle would just wobble.
     static func isGauge(_ descriptor: MetricDescriptor) -> Bool {
         switch descriptor.unit {
-        case .bytesPerSecond, .operationsPerSecond: true
+        case .bytesPerSecond, .bitsPerSecond, .operationsPerSecond: true
         default: false
         }
     }
 
     /// A sensible smallest full scale per unit, so an idle gauge does not sit
     /// pinned at the top of a dial reading 200 bytes a second.
+    ///
+    /// Throughput starts at ten mega-somethings: 0–10 MB/s and 0–10 Mbit/s.
+    /// Those are the scales an idle machine spends nearly all its time on, so
+    /// they are the ones worth being able to read without checking.
     static func gaugeFloor(_ descriptor: MetricDescriptor) -> Double {
         switch descriptor.unit {
-        case .bytesPerSecond: 10_000_000
+        case .bytesPerSecond, .bitsPerSecond: 10_000_000
         case .operationsPerSecond: 100
         default: 1
+        }
+    }
+
+    /// How long a throughput dial holds a scale it was pushed up to.
+    ///
+    /// Ten minutes is long by the standards of the 15-second decay the other
+    /// gauges use, and deliberately so: the point of the high-water mark is
+    /// that a transfer you were watching does not erase its own evidence the
+    /// moment it finishes.
+    static let throughputDecay: TimeInterval = 600
+
+    /// Throughput dials climb decades and hold a high-water mark; everything
+    /// else keeps the 1-2-5 ladder and the short decay.
+    ///
+    /// The split is about whether the reader has the ladder in their head.
+    /// MB/s and Mbit/s come in tens, hundreds and thousands and are quoted that
+    /// way, so a decade dial is predictable enough to read from needle position
+    /// alone. Operations per second have no such convention, and pinning them
+    /// to decades would waste most of the sweep.
+    static func makeScale(_ descriptor: MetricDescriptor) -> GaugeScale {
+        switch descriptor.unit {
+        case .bytesPerSecond, .bitsPerSecond:
+            GaugeScale(
+                floor: gaugeFloor(descriptor),
+                decayInterval: throughputDecay,
+                ladder: .decade
+            )
+        default:
+            GaugeScale(floor: gaugeFloor(descriptor))
         }
     }
 }

--- a/Sources/MonitorUI/ChartCard.swift
+++ b/Sources/MonitorUI/ChartCard.swift
@@ -27,7 +27,7 @@ public struct ChartCard: View {
     }
 
     public var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .leading, spacing: 5) {
             header
             if isUnavailable {
                 unavailableNotice
@@ -35,10 +35,10 @@ public struct ChartCard: View {
                 chart
             }
         }
-        .padding(14)
-        .background(Theme.panel, in: RoundedRectangle(cornerRadius: 10))
+        .padding(Theme.Layout.cardPadding)
+        .background(Theme.panel, in: RoundedRectangle(cornerRadius: Theme.Layout.cardCorner))
         .overlay(
-            RoundedRectangle(cornerRadius: 10)
+            RoundedRectangle(cornerRadius: Theme.Layout.cardCorner)
                 .strokeBorder(Theme.panelEdge.opacity(0.5), lineWidth: 1)
         )
     }
@@ -46,9 +46,15 @@ public struct ChartCard: View {
     private var header: some View {
         HStack(alignment: .firstTextBaseline) {
             Text(title)
-                .font(.system(size: 13, weight: .semibold, design: .rounded))
+                .font(.system(
+                    size: Theme.Layout.cardTitle,
+                    weight: .semibold,
+                    design: .rounded
+                ))
                 .foregroundStyle(Theme.readout)
-            Spacer()
+                .lineLimit(1)
+                .fixedSize()
+            Spacer(minLength: 4)
             // Current values in the header rather than in a legend below the
             // chart: the number and its colour swatch belong together, and it
             // saves a row of chrome per card.
@@ -60,11 +66,13 @@ public struct ChartCard: View {
                             .frame(width: 7, height: 7)
                         Text(entry.descriptor.name)
                             .foregroundStyle(Theme.label)
+                            .lineLimit(1)
                         Text(Format.value(latest.value, unit: entry.descriptor.unit))
                             .foregroundStyle(Theme.readout)
                             .monospacedDigit()
+                            .lineLimit(1)
                     }
-                    .font(.system(size: 11, design: .rounded))
+                    .font(.system(size: Theme.Layout.cardLegend, design: .rounded))
                 }
             }
         }
@@ -77,9 +85,9 @@ public struct ChartCard: View {
             Image(systemName: "exclamationmark.triangle")
             Text("Not available on this machine")
         }
-        .font(.system(size: 11))
+        .font(.system(size: Theme.Layout.cardLegend))
         .foregroundStyle(Theme.label)
-        .frame(maxWidth: .infinity, minHeight: 120)
+        .frame(maxWidth: .infinity, minHeight: Theme.Layout.chartMinHeight)
     }
 
     /// Points inside the visible window, per series.
@@ -133,21 +141,21 @@ public struct ChartCard: View {
                        let unit = series.first?.descriptor.unit
                     {
                         Text(Format.axisLabel(value, unit: unit))
-                            .font(.system(size: 9, design: .rounded))
+                            .font(.system(size: Theme.Layout.axisLabel, design: .rounded))
                             .foregroundStyle(Theme.label)
                     }
                 }
             }
         }
         .chartXAxis {
-            AxisMarks { _ in
+            AxisMarks(values: .automatic(desiredCount: 3)) { _ in
                 AxisGridLine().foregroundStyle(Theme.panelEdge.opacity(0.3))
-                AxisValueLabel()
-                    .font(.system(size: 9, design: .rounded))
+                AxisValueLabel(format: .dateTime.hour().minute(), centered: false)
+                    .font(.system(size: Theme.Layout.axisLabel, design: .rounded))
                     .foregroundStyle(Theme.label)
             }
         }
-        .frame(minHeight: 140)
+        .frame(minHeight: Theme.Layout.chartMinHeight)
     }
 
     /// The visible time span, as raw timestamps.

--- a/Sources/MonitorUI/ChartCard.swift
+++ b/Sources/MonitorUI/ChartCard.swift
@@ -82,9 +82,29 @@ public struct ChartCard: View {
         .frame(maxWidth: .infinity, minHeight: 120)
     }
 
+    /// Points inside the visible window, per series.
+    ///
+    /// The buffer holds ten minutes and the window is usually one or two, so
+    /// most of what it holds is off the left of the chart. Swift Charts does not
+    /// drop marks outside the x domain — it draws them anyway, outside the plot
+    /// area and straight through the axis labels and the card's own edge — so
+    /// they have to be filtered out here rather than left to the scale.
+    /// `chartPlotStyle` clips what remains; this keeps the mark count honest as
+    /// well, since drawing 1200 points to show 240 is nine-tenths wasted.
+    private var visible: [(descriptor: MetricDescriptor, points: [Sample])] {
+        let range = xRange
+        return series.map { entry in
+            (entry.descriptor, entry.points.filter { $0.timestamp >= range.start })
+        }
+    }
+
     private var chart: some View {
-        Chart {
-            ForEach(Array(series.enumerated()), id: \.offset) { index, entry in
+        // Bound once rather than referenced inside the result builder: the
+        // tuple-typed series makes the builder expensive enough to type-check
+        // that the compiler warns about it.
+        let entries = visible
+        return Chart {
+            ForEach(Array(entries.enumerated()), id: \.offset) { index, entry in
                 ForEach(entry.points, id: \.timestamp) { sample in
                     LineMark(
                         x: .value("Time", Date(timeIntervalSince1970: sample.timestamp)),
@@ -100,6 +120,11 @@ public struct ChartCard: View {
         .chartLegend(.hidden)
         .chartXScale(domain: xDomain)
         .chartYScale(domain: yDomain)
+        // Belt and braces with the filtering in `visible`: a sample can still
+        // sit fractionally outside the domain at either edge, and an
+        // unclipped line drawn past the plot rect runs over the axis labels
+        // and out through the side of the card.
+        .chartPlotStyle { $0.clipped() }
         .chartYAxis {
             AxisMarks(position: .leading) { mark in
                 AxisGridLine().foregroundStyle(Theme.panelEdge.opacity(0.4))
@@ -107,7 +132,7 @@ public struct ChartCard: View {
                     if let value = mark.as(Double.self),
                        let unit = series.first?.descriptor.unit
                     {
-                        Text(Format.value(value, unit: unit))
+                        Text(Format.axisLabel(value, unit: unit))
                             .font(.system(size: 9, design: .rounded))
                             .foregroundStyle(Theme.label)
                     }
@@ -125,10 +150,16 @@ public struct ChartCard: View {
         .frame(minHeight: 140)
     }
 
+    /// The visible time span, as raw timestamps.
+    private var xRange: (start: TimeInterval, end: TimeInterval) {
+        let end = series.compactMap { $0.points.last?.timestamp }.max()
+            ?? Date().timeIntervalSince1970
+        return (end - window, end)
+    }
+
     private var xDomain: ClosedRange<Date> {
-        let end = series.compactMap { $0.points.last?.timestamp }.max() ?? Date()
-            .timeIntervalSince1970
-        return Date(timeIntervalSince1970: end - window)...Date(timeIntervalSince1970: end)
+        let range = xRange
+        return Date(timeIntervalSince1970: range.start)...Date(timeIntervalSince1970: range.end)
     }
 
     /// A fraction metric is pinned to 0...1 so a quiet CPU draws a flat line at
@@ -139,7 +170,10 @@ public struct ChartCard: View {
             if descriptor.unit == .fraction { return 0...1 }
             if let maximum = descriptor.nominalMaximum { return 0...maximum }
         }
-        let peak = series.flatMap { $0.points.map(\.value) }.max() ?? 1
+        // Scaled to what is on screen, not to the whole buffer. Otherwise a
+        // spike eight minutes off the left of a two-minute window flattens
+        // everything you can actually see.
+        let peak = visible.flatMap { $0.points.map(\.value) }.max() ?? 1
         return 0...max(peak * 1.15, .leastNonzeroMagnitude)
     }
 }

--- a/Sources/MonitorUI/DashboardView.swift
+++ b/Sources/MonitorUI/DashboardView.swift
@@ -40,8 +40,8 @@ public struct DashboardView: View {
         [
             MetricID("disk.bytes.read"),
             MetricID("disk.bytes.written"),
-            MetricID("net.bytes.in"),
-            MetricID("net.bytes.out"),
+            MetricID("net.bits.in"),
+            MetricID("net.bits.out"),
         ].filter { model.descriptor($0) != nil }
     }
 

--- a/Sources/MonitorUI/DashboardView.swift
+++ b/Sources/MonitorUI/DashboardView.swift
@@ -18,12 +18,12 @@ public struct DashboardView: View {
 
     public var body: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: 16) {
+            VStack(alignment: .leading, spacing: Theme.Layout.gridSpacing) {
                 gaugeWall
                 Divider().overlay(Theme.panelEdge)
                 charts
             }
-            .padding(20)
+            .padding(Theme.Layout.pagePadding)
         }
         .background(Theme.background)
         .toolbar { toolbar }
@@ -47,12 +47,18 @@ public struct DashboardView: View {
 
     private var gaugeWall: some View {
         LazyVGrid(
-            columns: [GridItem(.adaptive(minimum: 160, maximum: 240), spacing: 16)],
-            spacing: 16
+            columns: [GridItem(
+                .adaptive(
+                    minimum: Theme.Layout.gaugeMinimum,
+                    maximum: Theme.Layout.gaugeMaximum
+                ),
+                spacing: Theme.Layout.gridSpacing
+            )],
+            spacing: Theme.Layout.gridSpacing
         ) {
             ForEach(gaugeMetrics, id: \.self) { metric in
                 if let descriptor = model.descriptor(metric) {
-                    VStack(spacing: 4) {
+                    VStack(spacing: 2) {
                         GaugeView(
                             title: gaugeTitle(descriptor),
                             value: model.latest(metric),
@@ -63,10 +69,19 @@ public struct DashboardView: View {
                             // it is still moving when the next sample arrives.
                             travelTime: model.interval
                         )
-                        Text(Format.value(model.latest(metric), unit: descriptor.unit))
-                            .font(.system(size: 11, design: .rounded))
-                            .monospacedDigit()
+                        // The dial's label, not its value. The readout on the
+                        // face already carries the number and its unit, so
+                        // repeating it here was the only thing under the dial
+                        // — and the label had to come off the face, where at
+                        // 130pt across "Network Out" ran into the ticks.
+                        Text(gaugeTitle(descriptor).uppercased())
+                            .font(.system(
+                                size: Theme.Layout.gaugeCaption,
+                                weight: .medium,
+                                design: .rounded
+                            ))
                             .foregroundStyle(Theme.label)
+                            .lineLimit(1)
                     }
                 }
             }
@@ -108,8 +123,10 @@ public struct DashboardView: View {
 
     private var charts: some View {
         LazyVGrid(
-            columns: [GridItem(.adaptive(minimum: 380), spacing: 16)],
-            spacing: 16
+            columns: [GridItem(
+                .adaptive(minimum: Theme.Layout.chartMinimum), spacing: Theme.Layout.gridSpacing
+            )],
+            spacing: Theme.Layout.gridSpacing
         ) {
             ForEach(chartGroups, id: \.name) { group in
                 ChartCard(

--- a/Sources/MonitorUI/DashboardView.swift
+++ b/Sources/MonitorUI/DashboardView.swift
@@ -82,12 +82,27 @@ public struct DashboardView: View {
 
     // MARK: - Charts
 
+    /// Which groups get a chart card, in the order they appear.
+    ///
+    /// Named explicitly rather than derived, for the same reason as the gauge
+    /// list: cards that move between launches are cards you have to hunt for.
+    /// Deriving it also cannot express the two decisions encoded here — that
+    /// disk and network throughput deserve a chart *as well as* a dial, since a
+    /// needle cannot tell you a transfer has been running for a minute; and
+    /// that "Disk Ops", "Network Packets" and "Memory Paging" are diagnostic
+    /// detail that belongs in `monitorctl`, not on a dashboard you glance at.
+    private static let chartGroupOrder = [
+        "CPU", "CPU Cores", "Memory", "Disk", "Network", "GPU", "Disk Latency",
+    ]
+
     private var chartGroups: [(name: String, metrics: [MetricID])] {
-        model.groups().filter { group in
-            group.metrics.contains { metric in
-                guard let descriptor = model.descriptor(metric) else { return false }
-                return !AppModel.isGauge(descriptor)
-            }
+        let available = Dictionary(
+            model.groups().map { ($0.name, $0.metrics) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        return Self.chartGroupOrder.compactMap { name in
+            guard let metrics = available[name], !metrics.isEmpty else { return nil }
+            return (name: name, metrics: metrics)
         }
     }
 

--- a/Sources/MonitorUI/GaugeView.swift
+++ b/Sources/MonitorUI/GaugeView.swift
@@ -154,7 +154,6 @@ public struct GaugeView: View {
                     .animation(.easeOut(duration: travelTime), value: fraction)
 
                 hub(radius: radius)
-                title(radius: radius)
                 readout(radius: radius)
             }
             .frame(width: geometry.size.width, height: geometry.size.height)
@@ -174,16 +173,14 @@ public struct GaugeView: View {
             .frame(width: radius * 0.2, height: radius * 0.2)
     }
 
-    private func title(radius: Double) -> some View {
-        Text(title.uppercased())
-            .font(.system(size: max(9, radius * 0.15), weight: .medium, design: .rounded))
-            .foregroundStyle(Theme.readout)
-            .offset(y: -radius * 0.42)
-    }
-
     /// The digital inset: seven-segment digits over a recessed panel, with the
     /// unit spelled out underneath in ordinary type because "Mbit/s" is not
     /// expressible in seven segments.
+    ///
+    /// Wide, because the field is fixed at `xxxx.yy` — six cells whether or not
+    /// the value needs them, so the decimal point never moves. That is most of
+    /// the width of the dial face, which is why the dial's own label sits under
+    /// the dial rather than on it.
     ///
     /// There is no `.contentTransition(.numericText())` here, unlike the type
     /// this replaced. `Canvas` draws imperatively from what its closure reads,
@@ -191,20 +188,20 @@ public struct GaugeView: View {
     /// pretending to be an LCD should snap to its new value anyway. The needle
     /// beside it carries the continuity.
     private func readout(radius: Double) -> some View {
-        VStack(spacing: radius * 0.015) {
-            SevenSegmentText(Format.magnitude(value, unit: unit))
-                .frame(width: radius * 0.56, height: radius * 0.19)
+        VStack(spacing: radius * 0.01) {
+            SevenSegmentText(Format.readout(value, unit: unit))
+                .frame(width: radius * 0.80, height: radius * 0.16)
             Text(Format.unitLabel(value, unit: unit))
-                .font(.system(size: radius * 0.09, design: .rounded))
+                .font(.system(size: radius * 0.085, design: .rounded))
                 .foregroundStyle(Theme.label)
         }
-        .frame(width: radius * 0.68, height: radius * 0.36)
+        .frame(width: radius * 0.86, height: radius * 0.32)
         .background(Theme.lcdPanel, in: RoundedRectangle(cornerRadius: radius * 0.05))
         .overlay(
             RoundedRectangle(cornerRadius: radius * 0.05)
                 .strokeBorder(Color(white: 0.30), lineWidth: 1)
         )
-        .offset(y: radius * 0.46)
+        .offset(y: radius * 0.50)
     }
 
     // MARK: - Static face
@@ -266,12 +263,17 @@ public struct GaugeView: View {
 
         // Label only the ends and the middle. A dial labelled at every tick is
         // a table with a needle on it.
+        //
+        // 0.54 rather than further out because the end labels sit at the lower
+        // left and lower right, where the readout is: at 0.62 they ran under it,
+        // and the fixed `xxxx.yy` field is too wide to give the horizontal room
+        // back. Here they clear it vertically instead.
         for fraction in [0.0, 0.5, 1.0] {
             let labelAngle = dialStart + Angle(degrees: dialSweep.degrees * fraction)
             let text = Text(Format.tickLabel(fullScale * fraction, unit: unit))
                 .font(.system(size: max(8, radius * 0.09), design: .rounded))
                 .foregroundStyle(Theme.label)
-            context.draw(text, at: point(center, radius * 0.55, labelAngle))
+            context.draw(text, at: point(center, radius * 0.54, labelAngle))
         }
     }
 

--- a/Sources/MonitorUI/GaugeView.swift
+++ b/Sources/MonitorUI/GaugeView.swift
@@ -181,23 +181,25 @@ public struct GaugeView: View {
             .offset(y: -radius * 0.42)
     }
 
+    /// The digital inset: seven-segment digits over a recessed panel, with the
+    /// unit spelled out underneath in ordinary type because "Mbit/s" is not
+    /// expressible in seven segments.
+    ///
+    /// There is no `.contentTransition(.numericText())` here, unlike the type
+    /// this replaced. `Canvas` draws imperatively from what its closure reads,
+    /// so SwiftUI cannot interpolate between two readings — and a display
+    /// pretending to be an LCD should snap to its new value anyway. The needle
+    /// beside it carries the continuity.
     private func readout(radius: Double) -> some View {
-        VStack(spacing: 0) {
-            Text(Format.magnitude(value, unit: unit))
-                // Monospaced digits so the readout does not twitch sideways as
-                // the value changes width, and a numeric transition so it rolls
-                // rather than snapping.
-                .font(.system(size: radius * 0.2, weight: .semibold, design: .rounded))
-                .monospacedDigit()
-                .contentTransition(.numericText())
-                .foregroundStyle(Theme.readout)
+        VStack(spacing: radius * 0.015) {
+            SevenSegmentText(Format.magnitude(value, unit: unit))
+                .frame(width: radius * 0.56, height: radius * 0.19)
             Text(Format.unitLabel(value, unit: unit))
-                .font(.system(size: radius * 0.1, design: .rounded))
+                .font(.system(size: radius * 0.09, design: .rounded))
                 .foregroundStyle(Theme.label)
         }
-        .animation(.easeOut(duration: travelTime), value: value)
         .frame(width: radius * 0.68, height: radius * 0.36)
-        .background(Color(white: 0.08), in: RoundedRectangle(cornerRadius: radius * 0.05))
+        .background(Theme.lcdPanel, in: RoundedRectangle(cornerRadius: radius * 0.05))
         .overlay(
             RoundedRectangle(cornerRadius: radius * 0.05)
                 .strokeBorder(Color(white: 0.30), lineWidth: 1)
@@ -266,7 +268,7 @@ public struct GaugeView: View {
         // a table with a needle on it.
         for fraction in [0.0, 0.5, 1.0] {
             let labelAngle = dialStart + Angle(degrees: dialSweep.degrees * fraction)
-            let text = Text(Format.magnitude(fullScale * fraction, unit: unit))
+            let text = Text(Format.tickLabel(fullScale * fraction, unit: unit))
                 .font(.system(size: max(8, radius * 0.09), design: .rounded))
                 .foregroundStyle(Theme.label)
             context.draw(text, at: point(center, radius * 0.55, labelAngle))
@@ -289,14 +291,18 @@ public struct GaugeView: View {
 #Preview {
     HStack(spacing: 24) {
         GaugeView(
-            title: "Write", value: 420_000_000, fullScale: 1_000_000_000,
-            peak: 830_000_000, unit: .bytesPerSecond
+            title: "Disk Write", value: 4_230_000, fullScale: 10_000_000,
+            peak: 8_300_000, unit: .bytesPerSecond
         )
         GaugeView(
-            title: "Read", value: 90_000_000, fullScale: 1_000_000_000, unit: .bytesPerSecond
+            title: "Net In", value: 92_400_000, fullScale: 100_000_000,
+            peak: 96_000_000, unit: .bitsPerSecond
+        )
+        GaugeView(
+            title: "Net Out", value: 240_000, fullScale: 10_000_000, unit: .bitsPerSecond
         )
     }
     .padding(32)
-    .frame(width: 520, height: 280)
+    .frame(width: 780, height: 300)
     .background(Theme.background)
 }

--- a/Sources/MonitorUI/SevenSegmentText.swift
+++ b/Sources/MonitorUI/SevenSegmentText.swift
@@ -46,7 +46,12 @@ public struct SevenSegmentText: View {
                     glyph: glyph, at: Double(index) * Geometry.advance,
                     origin: origin, scale: scale,
                     lit: &lit, unlit: &unlit,
-                    includeUnlit: ghost != nil,
+                    // A blank cell is a *position*, not a digit, so it gets no
+                    // ghosts. Ghosting it draws a faint 8 where no digit is,
+                    // and in a fixed field like `   4.23` the three leading
+                    // blanks then read as digits at a glance. The cell still
+                    // takes its width, so the field stays fixed either way.
+                    includeUnlit: ghost != nil && !glyph.mask.isEmpty,
                     // A ghost dot after the final digit reads as a lit decimal
                     // point at a glance, turning `245` into `245.`. Nothing can
                     // follow it, so nothing needs to hold its place.
@@ -93,6 +98,10 @@ public struct SevenSegmentText: View {
         /// to neither, and `2.35` becomes a number you have to look at twice;
         /// tucked against the digit it follows, it is unambiguous.
         static let pointInset = 0.012
+        /// Diameter of the decimal point, a little fatter than a bar. On a
+        /// small dial the readout renders at about 12pt and a point the width
+        /// of a segment disappears — which turns `5012.66` into `501266`.
+        static let pointSize = 0.19
         /// Horizontal shift at the top of a cell: the lean of an LCD digit.
         static let slant = 0.07
 
@@ -193,8 +202,8 @@ public struct SevenSegmentText: View {
             // The decimal point sits on the baseline, tucked against the digit
             // it belongs to.
             let dot = CGRect(
-                origin: map(width + pointInset, 1 - thickness),
-                size: CGSize(width: thickness * scale, height: thickness * scale)
+                origin: map(width + pointInset, 1 - pointSize),
+                size: CGSize(width: pointSize * scale, height: pointSize * scale)
             )
             let dotPath = Path(ellipseIn: dot)
             if glyph.point {

--- a/Sources/MonitorUI/SevenSegmentText.swift
+++ b/Sources/MonitorUI/SevenSegmentText.swift
@@ -1,0 +1,219 @@
+import MonitorCore
+import SwiftUI
+
+/// A run of seven-segment digits, drawn rather than typeset.
+///
+/// macOS ships no seven-segment face and this project takes no third-party
+/// dependencies, but a font would be the wrong tool anyway. A font cannot draw
+/// the *unlit* segments, and those are what make a readout look like a panel
+/// with a display in it rather than a stencil typeface — they also fix the
+/// width of every cell, so the number stops shifting sideways as it changes.
+///
+/// The view fills whatever frame it is given, preserving aspect. A gauge
+/// readout has a fixed inset to live in and the string in it varies from `0.02`
+/// to `5000`, so scaling to fit is what keeps the widest reading inside the
+/// box without shrinking the common ones to nothing.
+public struct SevenSegmentText: View {
+    public let text: String
+    public var color: Color
+    /// Unlit segments. Nil draws none.
+    public var ghost: Color?
+
+    public init(_ text: String, color: Color = Theme.lcd, ghost: Color? = Theme.lcdGhost) {
+        self.text = text
+        self.color = color
+        self.ghost = ghost
+    }
+
+    public var body: some View {
+        Canvas { context, size in
+            let glyphs = SevenSegment.glyphs(for: text)
+            let natural = Geometry.naturalWidth(of: glyphs)
+            guard natural > 0, size.width > 0, size.height > 0 else { return }
+
+            // Unit space is one cell high, so the scale factor is also the
+            // rendered cell height.
+            let scale = min(size.width / natural, size.height)
+            let origin = CGPoint(
+                x: (size.width - natural * scale) / 2,
+                y: (size.height - scale) / 2
+            )
+
+            var lit = Path()
+            var unlit = Path()
+            for (index, glyph) in glyphs.enumerated() {
+                Geometry.append(
+                    glyph: glyph, at: Double(index) * Geometry.advance,
+                    origin: origin, scale: scale,
+                    lit: &lit, unlit: &unlit,
+                    includeUnlit: ghost != nil,
+                    // A ghost dot after the final digit reads as a lit decimal
+                    // point at a glance, turning `245` into `245.`. Nothing can
+                    // follow it, so nothing needs to hold its place.
+                    includeUnlitPoint: ghost != nil && index < glyphs.count - 1
+                )
+            }
+
+            if let ghost {
+                context.fill(unlit, with: .color(ghost))
+            }
+            // A soft bloom under the crisp segments. Lit LCD and VFD segments
+            // do bleed a little into the panel around them, and without it the
+            // readout reads as flat vector art.
+            context.drawLayer { layer in
+                layer.addFilter(.blur(radius: scale * 0.06))
+                layer.fill(lit, with: .color(color.opacity(0.55)))
+            }
+            context.fill(lit, with: .color(color))
+        }
+    }
+
+    /// Where the bars sit inside a cell.
+    ///
+    /// Every dimension is a fraction of the cell height, so the whole display
+    /// scales from one number. The proportions are those of a physical
+    /// seven-segment part: cells taller than they are wide, bars about a
+    /// seventh of the height, mitred ends meeting at a visible gap.
+    enum Geometry {
+        static let cellWidth = 0.60
+        static let thickness = 0.145
+        /// Gap between the mitred ends of adjacent bars.
+        static let gap = 0.022
+        /// Room to the right of every cell for its decimal point.
+        ///
+        /// Reserved on every cell, lit or not, exactly as a physical part
+        /// does: each digit owns a point position whether or not it uses it.
+        /// Claiming the space only when the point is lit would make `2.35`
+        /// wider than `235` — and a readout that changes width as its value
+        /// crosses a decade is the thing this display exists to stop.
+        static let pointAdvance = 0.26
+        /// How far right of its own cell the decimal point sits.
+        ///
+        /// Small on purpose. A point sitting midway between two digits belongs
+        /// to neither, and `2.35` becomes a number you have to look at twice;
+        /// tucked against the digit it follows, it is unambiguous.
+        static let pointInset = 0.012
+        /// Horizontal shift at the top of a cell: the lean of an LCD digit.
+        static let slant = 0.07
+
+        static let advance = cellWidth + pointAdvance
+
+        static func naturalWidth(of glyphs: [SevenSegment.Glyph]) -> Double {
+            guard let last = glyphs.last else { return 0 }
+            // The last cell claims its point's width only if the point is lit.
+            // Nothing follows it, so the reserved space would just be a margin
+            // that pushes the run off centre. Numbers never end in a point, so
+            // this does not reintroduce the width variance the reservation
+            // exists to prevent.
+            let trailing = last.point ? 0 : pointAdvance
+            // The slant pushes the top of every cell right of its own box.
+            return Double(glyphs.count) * advance - trailing + slant
+        }
+
+        /// Adds one cell's bars to the lit and unlit paths.
+        ///
+        /// `x` is the cell's left edge in unit space; `origin` and `scale` map
+        /// unit space to points. The mapping is applied here, point by point,
+        /// rather than through the context's transform, so that blur radii and
+        /// any other pixel-space effects stay predictable.
+        static func append(
+            glyph: SevenSegment.Glyph,
+            at x: Double,
+            origin: CGPoint,
+            scale: Double,
+            lit: inout Path,
+            unlit: inout Path,
+            includeUnlit: Bool,
+            includeUnlitPoint: Bool
+        ) {
+            func map(_ px: Double, _ py: Double) -> CGPoint {
+                // Lean the digit: full shift at the top of the cell, none at
+                // the bottom, so the baseline stays put.
+                CGPoint(
+                    x: origin.x + (x + px + slant * (1 - py)) * scale,
+                    y: origin.y + py * scale
+                )
+            }
+
+            let half = thickness / 2
+            let width = cellWidth
+
+            /// A bar as a mitred hexagon, from one end to the other.
+            func bar(
+                from start: (Double, Double), to end: (Double, Double), horizontal: Bool
+            ) -> Path {
+                var path = Path()
+                let points: [(Double, Double)] =
+                    horizontal
+                        ? [
+                            (start.0, start.1),
+                            (start.0 + half, start.1 - half),
+                            (end.0 - half, end.1 - half),
+                            (end.0, end.1),
+                            (end.0 - half, end.1 + half),
+                            (start.0 + half, start.1 + half),
+                        ]
+                        : [
+                            (start.0, start.1),
+                            (start.0 + half, start.1 + half),
+                            (end.0 + half, end.1 - half),
+                            (end.0, end.1),
+                            (end.0 - half, end.1 - half),
+                            (start.0 - half, start.1 + half),
+                        ]
+                path.move(to: map(points[0].0, points[0].1))
+                for point in points.dropFirst() { path.addLine(to: map(point.0, point.1)) }
+                path.closeSubpath()
+                return path
+            }
+
+            let bars: [(SevenSegment.Mask, Path)] = [
+                (.a, bar(from: (gap, half), to: (width - gap, half), horizontal: true)),
+                (.g, bar(from: (gap, 0.5), to: (width - gap, 0.5), horizontal: true)),
+                (.d, bar(from: (gap, 1 - half), to: (width - gap, 1 - half), horizontal: true)),
+                (.f, bar(from: (half, gap), to: (half, 0.5 - gap), horizontal: false)),
+                (.b, bar(
+                    from: (width - half, gap), to: (width - half, 0.5 - gap), horizontal: false
+                )),
+                (.e, bar(from: (half, 0.5 + gap), to: (half, 1 - gap), horizontal: false)),
+                (.c, bar(
+                    from: (width - half, 0.5 + gap), to: (width - half, 1 - gap),
+                    horizontal: false
+                )),
+            ]
+
+            for (segment, path) in bars {
+                if glyph.mask.contains(segment) {
+                    lit.addPath(path)
+                } else if includeUnlit {
+                    unlit.addPath(path)
+                }
+            }
+
+            // The decimal point sits on the baseline, tucked against the digit
+            // it belongs to.
+            let dot = CGRect(
+                origin: map(width + pointInset, 1 - thickness),
+                size: CGSize(width: thickness * scale, height: thickness * scale)
+            )
+            let dotPath = Path(ellipseIn: dot)
+            if glyph.point {
+                lit.addPath(dotPath)
+            } else if includeUnlitPoint {
+                unlit.addPath(dotPath)
+            }
+        }
+    }
+}
+
+#Preview {
+    VStack(spacing: 16) {
+        SevenSegmentText("0.02")
+        SevenSegmentText("12.4")
+        SevenSegmentText("5000")
+        SevenSegmentText("1234567890")
+    }
+    .frame(width: 260, height: 220)
+    .padding(24)
+    .background(Theme.lcdPanel)
+}

--- a/Sources/MonitorUI/Theme.swift
+++ b/Sources/MonitorUI/Theme.swift
@@ -7,6 +7,58 @@ import SwiftUI
 /// your eye all day is tiring, and a light needle on a dark dial is the higher
 /// contrast pairing for a thin moving element.
 public enum Theme {
+    /// Every size that decides how much of the dashboard fits on screen.
+    ///
+    /// Gathered here rather than spread across the views because they are one
+    /// decision, not eight: the panel is either dense enough to take in at a
+    /// glance without scrolling, or it is legible at arm's length, and moving
+    /// between those two means moving all of these together.
+    ///
+    /// Every size that decides how much of the dashboard fits on screen.
+    ///
+    /// What made only four cards visible was not card height — it was the
+    /// column count. A 380pt minimum in a 1156pt content width fits **two**
+    /// columns, so seven cards needed four rows. Halving that minimum gives
+    /// four columns and the same seven cards land in two rows, which is why the
+    /// charts here are barely shorter than they were: the width came down by
+    /// half, the height did not have to.
+    ///
+    /// That matters because the premise of the app is charts big enough to
+    /// read. Activity Monitor's are not, and shrinking far enough lands in the
+    /// same place — a literal half-of-both left five cramped columns, wrapped
+    /// legends, colliding time labels and a third of the window empty.
+    public enum Layout {
+        /// Gauge dials are square, so this is their height too.
+        public static let gaugeMinimum = 100.0
+        public static let gaugeMaximum = 130.0
+        /// Minimum chart card width. The grid fits as many columns as it can,
+        /// so this is really a column count in disguise: 260 gives four columns
+        /// at 1180pt and three at 900.
+        public static let chartMinimum = 260.0
+        /// The plot area alone, not counting the card's header and padding.
+        ///
+        /// Sized so that two rows of cards plus the gauge wall fill a 1180×900
+        /// window rather than leaving the bottom third empty. It is a *minimum*,
+        /// so a shorter window scrolls — which is the right way round: the
+        /// charts stay readable and the window decides how many you see at once.
+        public static let chartMinHeight = 250.0
+
+        public static let gridSpacing = 12.0
+        public static let pagePadding = 14.0
+        public static let cardPadding = 10.0
+        public static let cardCorner = 9.0
+
+        /// Type inside a card. At four columns a 13pt title and a row of legend
+        /// entries no longer share a line.
+        public static let cardTitle = 12.0
+        public static let cardLegend = 10.0
+        public static let axisLabel = 8.0
+        /// The dial's label, which sits under the dial rather than on its face:
+        /// at 130pt across there is no room on the face for "Network Out"
+        /// without it running into the ticks.
+        public static let gaugeCaption = 10.0
+    }
+
     public static let background = Color(red: 0.07, green: 0.07, blue: 0.08)
     public static let panel = Color(red: 0.12, green: 0.12, blue: 0.13)
     public static let panelEdge = Color(red: 0.28, green: 0.28, blue: 0.30)

--- a/Sources/MonitorUI/Theme.swift
+++ b/Sources/MonitorUI/Theme.swift
@@ -17,6 +17,22 @@ public enum Theme {
     public static let label = Color(white: 0.62)
     public static let readout = Color(white: 0.93)
 
+    /// The seven-segment readout inset in a dial face.
+    ///
+    /// Amber rather than the blue of the needle, so that at a glance the two
+    /// carry different information instead of reading as one blue smear. It is
+    /// also the one warm colour on the panel, which is what makes the readout
+    /// findable on a wall of otherwise identical dials.
+    public static let lcd = Color(red: 1.00, green: 0.71, blue: 0.24)
+    /// Unlit segments. Faint, but not invisible: seeing where the bars *would*
+    /// be is what makes the thing read as a display rather than as a stencil,
+    /// and it fixes the width of the readout so it cannot shift sideways as
+    /// digits come and go.
+    public static let lcdGhost = Color(red: 1.00, green: 0.71, blue: 0.24).opacity(0.11)
+    /// Behind the segments. Slightly warm and darker than the dial face, the
+    /// way a recessed panel actually looks.
+    public static let lcdPanel = Color(red: 0.07, green: 0.06, blue: 0.05)
+
     /// The needle. One colour for every gauge — a needle that changes colour
     /// per metric turns a dashboard into a fruit salad and stops the eye from
     /// reading position, which is the only thing a needle is for.

--- a/Tests/MonitorCoreTests/GaugeScaleTests.swift
+++ b/Tests/MonitorCoreTests/GaugeScaleTests.swift
@@ -29,22 +29,21 @@ struct GaugeScaleTests {
     }
 
     /// The dial must not rescale the instant traffic stops, or the needle
-    /// appears to move when the value did not.
-    @Test("does not scale down until the peak has been quiet")
+    /// appears to move when the value did not. The clock starts when the value
+    /// drops below the threshold, so quiet time is counted from t=5 here.
+    @Test("does not scale down until the value has been quiet")
     func fallsSlowly() {
         var scale = GaugeScale(floor: 10, decayInterval: 15)
         scale.update(value: 900, at: 0)
         #expect(scale.fullScale == 1000)
 
         scale.update(value: 5, at: 5)
-        #expect(scale.fullScale == 1000, "scaled down while the peak was still recent")
+        #expect(scale.fullScale == 1000, "scaled down the instant traffic dropped")
 
-        // The window that contained the spike still holds the dial up.
-        scale.update(value: 5, at: 20)
-        #expect(scale.fullScale == 1000)
+        scale.update(value: 5, at: 19)
+        #expect(scale.fullScale == 1000, "scaled down before the interval was up")
 
-        // The next quiet window lets it fall.
-        scale.update(value: 5, at: 40)
+        scale.update(value: 5, at: 21)
         #expect(scale.fullScale < 1000)
     }
 
@@ -66,6 +65,194 @@ struct GaugeScaleTests {
         scale.update(value: 50, at: 0)
         #expect(scale.deflection(for: -5) == 0)
         #expect(scale.deflection(for: 1_000_000) == 1)
+    }
+}
+
+@Suite("ScaleLadder")
+struct ScaleLadderTests {
+    @Test("the decade ladder rounds up to a power of ten")
+    func decadeSnapping() {
+        #expect(ScaleLadder.decade.snap(10_000_000) == 10_000_000)
+        #expect(ScaleLadder.decade.snap(10_000_001) == 100_000_000)
+        #expect(ScaleLadder.decade.snap(90_000_000) == 100_000_000)
+        #expect(ScaleLadder.decade.snap(100_000_000) == 100_000_000)
+        #expect(ScaleLadder.decade.snap(101_000_000) == 1_000_000_000)
+    }
+
+    @Test("the step below is the next rung down, on or off the ladder")
+    func stepBelow() {
+        #expect(ScaleLadder.decade.step(below: 1000) == 100)
+        #expect(ScaleLadder.decade.step(below: 100) == 10)
+        // A value between rungs still has a well-defined rung below it.
+        #expect(ScaleLadder.decade.step(below: 150) == 100)
+
+        #expect(ScaleLadder.oneTwoFive.step(below: 1000) == 500)
+        #expect(ScaleLadder.oneTwoFive.step(below: 500) == 200)
+        #expect(ScaleLadder.oneTwoFive.step(below: 200) == 100)
+        #expect(ScaleLadder.oneTwoFive.step(below: 370) == 200)
+        #expect(ScaleLadder.oneTwoFive.step(below: 0) == nil)
+    }
+
+    /// `log10` is not exact for every power of ten, and a mantissa that came
+    /// back as 9.999999 instead of 1 would put a scale a whole decade wrong.
+    @Test("powers of ten do not fall through a floating point crack")
+    func exactPowers() {
+        for exponent in 0...12 {
+            let value = pow(10.0, Double(exponent))
+            #expect(ScaleLadder.decade.snap(value) == value, "snap moved 1e\(exponent)")
+            #expect(
+                ScaleLadder.decade.step(below: value) == value / 10,
+                "step below 1e\(exponent) was wrong"
+            )
+        }
+    }
+}
+
+/// The behaviour the throughput dials are specified by: start at ten, climb by
+/// decades, and hold the scale you were pushed to for ten minutes.
+@Suite("Decade gauge scale")
+struct DecadeGaugeScaleTests {
+    /// Ten megabits a second, the scale a network dial starts and mostly lives
+    /// on. Written in full because the thresholds under test are the product
+    /// decision, not an implementation detail.
+    private let mega = 1_000_000.0
+
+    private func networkScale() -> GaugeScale {
+        GaugeScale(floor: 10_000_000, decayInterval: 600, ladder: .decade)
+    }
+
+    /// Hold a value for a stretch, at the rate the app actually samples.
+    ///
+    /// The decay is about how long a value has been low, so a test that jumped
+    /// straight from t=0 to t=601 would be describing a machine that samples
+    /// twice an hour, and would prove nothing about this one.
+    private func hold(
+        _ scale: inout GaugeScale,
+        at value: Double,
+        from start: TimeInterval,
+        to end: TimeInterval,
+        every interval: TimeInterval = 0.5
+    ) {
+        for timestamp in stride(from: start, through: end, by: interval) {
+            scale.update(value: value, at: timestamp)
+        }
+    }
+
+    @Test("starts at ten")
+    func startsAtTen() {
+        let scale = networkScale()
+        #expect(scale.fullScale == 10 * mega)
+    }
+
+    @Test("climbs a decade at a time as traffic exceeds the scale")
+    func climbs() {
+        var scale = networkScale()
+        scale.update(value: 9 * mega, at: 0)
+        #expect(scale.fullScale == 10 * mega, "a reading under full scale moved the dial")
+
+        scale.update(value: 11 * mega, at: 1)
+        #expect(scale.fullScale == 100 * mega)
+
+        scale.update(value: 90 * mega, at: 2)
+        #expect(scale.fullScale == 100 * mega, "90 fits on the 100 scale")
+
+        scale.update(value: 150 * mega, at: 3)
+        #expect(scale.fullScale == 1000 * mega)
+    }
+
+    @Test("holds the raised scale for the full ten minutes")
+    func holds() {
+        var scale = networkScale()
+        scale.update(value: 90 * mega, at: 0)
+        #expect(scale.fullScale == 100 * mega)
+
+        hold(&scale, at: 1 * mega, from: 0.5, to: 599)
+        #expect(scale.fullScale == 100 * mega, "the dial came down early")
+    }
+
+    @Test("comes back down after ten quiet minutes")
+    func comesDown() {
+        var scale = networkScale()
+        scale.update(value: 90 * mega, at: 0)
+        hold(&scale, at: 1 * mega, from: 0.5, to: 620)
+        #expect(scale.fullScale == 10 * mega)
+    }
+
+    /// Without the hysteresis band, a workload sitting just under full scale
+    /// rescales the dial forever, and the needle moves while the value does
+    /// not.
+    @Test("traffic close to the lower scale keeps the higher one")
+    func hysteresis() {
+        var scale = networkScale()
+        scale.update(value: 90 * mega, at: 0)
+        // 9.5 is below the 10 rung, but not below 90% of it.
+        hold(&scale, at: 9.5 * mega, from: 0.5, to: 1800)
+        #expect(scale.fullScale == 100 * mega, "the dial flapped down on a near-threshold load")
+
+        hold(&scale, at: 8 * mega, from: 1800.5, to: 2420)
+        #expect(scale.fullScale == 10 * mega, "the dial never came down once traffic was clear")
+    }
+
+    /// Ten minutes of quiet should return the dial to the bottom, not start a
+    /// half-hour walk down during which every reading is squashed flat.
+    @Test("descends as far as the quiet justifies, not one rung at a time")
+    func descendsAllTheWay() {
+        var scale = networkScale()
+        scale.update(value: 900 * mega, at: 0)
+        #expect(scale.fullScale == 1000 * mega)
+
+        hold(&scale, at: 0.5 * mega, from: 0.5, to: 620)
+        #expect(scale.fullScale == 10 * mega)
+    }
+
+    @Test("never falls below its floor")
+    func floor() {
+        var scale = networkScale()
+        hold(&scale, at: 0, from: 0, to: 3000, every: 10)
+        #expect(scale.fullScale == 10 * mega)
+    }
+
+    /// The ten minutes is measured from the moment traffic dropped, so a spike
+    /// arriving late in a quiet stretch gets its own full ten minutes rather
+    /// than inheriting whatever was left of the previous one.
+    @Test("a spike restarts the quiet period")
+    func spikeRestartsTheQuietPeriod() {
+        var scale = networkScale()
+        hold(&scale, at: 1 * mega, from: 0, to: 598)
+        scale.update(value: 90 * mega, at: 599)
+        #expect(scale.fullScale == 100 * mega)
+
+        hold(&scale, at: 1 * mega, from: 599.5, to: 1100)
+        #expect(scale.fullScale == 100 * mega, "the spike inherited the earlier quiet period")
+
+        hold(&scale, at: 1 * mega, from: 1100.5, to: 1220)
+        #expect(scale.fullScale == 10 * mega)
+    }
+
+    /// A brief burst part-way through the quiet period resets it. Otherwise a
+    /// dial could drop its scale moments after traffic that needed it.
+    @Test("traffic during the quiet period restarts the clock")
+    func trafficResetsTheClock() {
+        var scale = networkScale()
+        scale.update(value: 90 * mega, at: 0)
+        hold(&scale, at: 1 * mega, from: 0.5, to: 550)
+        scale.update(value: 50 * mega, at: 551)
+        hold(&scale, at: 1 * mega, from: 551.5, to: 1100)
+        #expect(scale.fullScale == 100 * mega, "a burst at 551 s did not restart the clock")
+
+        hold(&scale, at: 1 * mega, from: 1100.5, to: 1180)
+        #expect(scale.fullScale == 10 * mega)
+    }
+
+    /// The mark shows why the dial is on the scale it is on, which is the only
+    /// thing that makes a raised scale readable when nothing is happening.
+    @Test("the memory mark holds the reading that raised the scale")
+    func peakExplainsTheScale() {
+        var scale = networkScale()
+        scale.update(value: 90 * mega, at: 0)
+        hold(&scale, at: 1 * mega, from: 0.5, to: 400)
+        #expect(scale.peak == 90 * mega)
+        #expect(scale.deflection(for: scale.peak) == 0.9)
     }
 }
 
@@ -92,5 +279,45 @@ struct FormatTests {
     func durations() {
         #expect(Format.duration(0.04) == "40.0 ms")
         #expect(Format.duration(0.000004) == "4 µs")
+    }
+
+    /// The unit under a needle must not change while you are reading it, so
+    /// throughput never rescales: disk is MB/s and network is Mbit/s at every
+    /// magnitude, from a trickle to a saturated link.
+    @Test("throughput units never rescale")
+    func pinnedThroughput() {
+        #expect(Format.value(20000, unit: .bytesPerSecond) == "0.02 MB/s")
+        #expect(Format.value(2_350_000, unit: .bytesPerSecond) == "2.35 MB/s")
+        #expect(Format.value(5_000_000_000, unit: .bytesPerSecond) == "5000 MB/s")
+
+        #expect(Format.value(940_000_000, unit: .bitsPerSecond) == "940 Mbit/s")
+        #expect(Format.value(0, unit: .bitsPerSecond) == "0.00 Mbit/s")
+    }
+
+    /// Three significant figures keeps the readout near-constant in width,
+    /// which matters because it sits in a fixed inset on the dial face.
+    @Test("throughput readouts hold three significant figures")
+    func throughputPrecision() {
+        #expect(Format.throughput(2_350_000) == "2.35")
+        #expect(Format.throughput(12_400_000) == "12.4")
+        #expect(Format.throughput(245_000_000) == "245")
+    }
+
+    /// Memory is a level, not a throughput. It keeps auto-scaling, because
+    /// "17179.87 MB" of RAM helps nobody.
+    @Test("byte levels still scale to a readable unit")
+    func levelsStillScale() {
+        #expect(Format.value(17_179_869_184, unit: .bytes) == "17 GB")
+        #expect(Format.value(1_500_000, unit: .bytes) == "1.5 MB")
+    }
+
+    /// A tick is a landmark, not a measurement — the digits live in the
+    /// readout below the needle.
+    @Test("dial ticks are coarser than the readout")
+    func tickLabels() {
+        #expect(Format.tickLabel(0, unit: .bitsPerSecond) == "0")
+        #expect(Format.tickLabel(5_000_000, unit: .bitsPerSecond) == "5")
+        #expect(Format.tickLabel(10_000_000, unit: .bitsPerSecond) == "10")
+        #expect(Format.tickLabel(500_000_000, unit: .bytesPerSecond) == "500")
     }
 }

--- a/Tests/MonitorCoreTests/GaugeScaleTests.swift
+++ b/Tests/MonitorCoreTests/GaugeScaleTests.swift
@@ -311,6 +311,46 @@ struct FormatTests {
         #expect(Format.value(1_500_000, unit: .bytes) == "1.5 MB")
     }
 
+    /// The property the fixed field exists for: whatever the magnitude, the
+    /// readout is the same width and the point is in the same column. A point
+    /// that slides means `4.23` and `43.7` occupy the same pixels with different
+    /// meanings, so you have to read the whole number to know which it is.
+    @Test("the readout is a fixed field with an immovable decimal point")
+    func fixedReadoutField() {
+        let values = [0.0, 20000.0, 4_230_000.0, 43_700_000.0, 999_000_000.0, 5_012_660_000.0]
+        let fields = values.map { Format.readout($0, unit: .bytesPerSecond) }
+
+        #expect(fields == ["   0.00", "   0.02", "   4.23", "  43.70", " 999.00", "5012.66"])
+        #expect(Set(fields.map(\.count)).count == 1, "the field changed width")
+        #expect(
+            Set(fields.map { $0.distance(from: $0.startIndex, to: $0.firstIndex(of: ".")!) })
+                .count == 1,
+            "the decimal point moved"
+        )
+    }
+
+    /// Space-padded, not zero-padded: `0004.23` reads as a part number.
+    @Test("the readout pads with blanks rather than zeros")
+    func readoutPadding() {
+        #expect(Format.readout(4_230_000, unit: .bitsPerSecond).hasPrefix("   "))
+        #expect(!Format.readout(4_230_000, unit: .bitsPerSecond).hasPrefix("000"))
+    }
+
+    /// Four integer digits so an SSD at 5000 MB/s fits. The overflow pattern is
+    /// there for completeness rather than because anything reaches it — and it
+    /// keeps the field width, so the display cannot jump if it ever does.
+    @Test("the readout field holds a fast SSD, and says so when it cannot")
+    func readoutCeiling() {
+        #expect(Format.readout(9_999_000_000, unit: .bytesPerSecond) == "9999.00")
+        #expect(Format.readout(10_000_000_000, unit: .bytesPerSecond) == "----.--")
+        // Would round up to 10000.00 and shift the point, so it counts as over.
+        #expect(Format.readout(9_999_996_000, unit: .bytesPerSecond) == "----.--")
+        #expect(
+            Format.readout(10_000_000_000, unit: .bytesPerSecond).count
+                == Format.readout(0, unit: .bytesPerSecond).count
+        )
+    }
+
     /// A tick is a landmark, not a measurement — the digits live in the
     /// readout below the needle.
     @Test("dial ticks are coarser than the readout")

--- a/Tests/MonitorCoreTests/SevenSegmentTests.swift
+++ b/Tests/MonitorCoreTests/SevenSegmentTests.swift
@@ -73,6 +73,21 @@ struct SevenSegmentTests {
         #expect(glyphs[1].mask == SevenSegment.mask(for: "5"))
     }
 
+    /// A blank holds its cell. That is what lets the gauge's `xxxx.yy` field
+    /// keep the decimal point in one place: the leading blanks of `   4.23`
+    /// occupy the same three cells that `5012` fills.
+    @Test("a blank takes a cell so a fixed field stays aligned")
+    func blanksHoldTheirCell() {
+        let small = SevenSegment.glyphs(for: "   4.23")
+        let large = SevenSegment.glyphs(for: "5012.66")
+        #expect(small.count == large.count)
+        #expect(small.firstIndex(where: \.point) == large.firstIndex(where: \.point))
+        // Hoisted out of `#expect`: the macro expansion cannot digest a nested
+        // key path, and swiftformat rewrites the equivalent closure into one.
+        let leadingCellsAreBlank = small.prefix(3).allSatisfy(\.mask.isEmpty)
+        #expect(leadingCellsAreBlank)
+    }
+
     @Test("unshowable characters are dropped from a run")
     func runSkipsUnknown() {
         #expect(SevenSegment.glyphs(for: "12 MB").map(\.mask) == [

--- a/Tests/MonitorCoreTests/SevenSegmentTests.swift
+++ b/Tests/MonitorCoreTests/SevenSegmentTests.swift
@@ -1,0 +1,84 @@
+@testable import MonitorCore
+import Testing
+
+@Suite("SevenSegment")
+struct SevenSegmentTests {
+    /// The whole point of putting the mapping in Core is that it can be checked
+    /// exhaustively without a screen. A wrong bar makes a 6 read as an 8, which
+    /// is the kind of error a monitoring tool must not have.
+    @Test("digits light the traditional segments")
+    func digits() {
+        #expect(SevenSegment.mask(for: "0") == [.a, .b, .c, .d, .e, .f])
+        #expect(SevenSegment.mask(for: "1") == [.b, .c])
+        #expect(SevenSegment.mask(for: "2") == [.a, .b, .d, .e, .g])
+        #expect(SevenSegment.mask(for: "3") == [.a, .b, .c, .d, .g])
+        #expect(SevenSegment.mask(for: "4") == [.b, .c, .f, .g])
+        #expect(SevenSegment.mask(for: "5") == [.a, .c, .d, .f, .g])
+        #expect(SevenSegment.mask(for: "6") == [.a, .c, .d, .e, .f, .g])
+        #expect(SevenSegment.mask(for: "7") == [.a, .b, .c])
+        #expect(SevenSegment.mask(for: "8") == .all)
+        #expect(SevenSegment.mask(for: "9") == [.a, .b, .c, .d, .f, .g])
+    }
+
+    /// Every digit must differ from every other. Two digits sharing a mask
+    /// would be indistinguishable on the panel.
+    @Test("no two digits share a mask")
+    func digitsAreDistinct() {
+        let masks = (0...9).compactMap { SevenSegment.mask(for: Character("\($0)")) }
+        #expect(masks.count == 10)
+        #expect(Set(masks).count == 10)
+    }
+
+    @Test("a 6 and a 9 keep the bars that tell them from 8")
+    func sixAndNine() {
+        let six = SevenSegment.mask(for: "6")
+        let nine = SevenSegment.mask(for: "9")
+        #expect(six?.contains(.b) == false, "a 6 with its top-right bar lit is an 8")
+        #expect(nine?.contains(.e) == false, "a 9 with its bottom-left bar lit is an 8")
+    }
+
+    @Test("a minus is the middle bar alone, a space is nothing")
+    func punctuation() {
+        #expect(SevenSegment.mask(for: "-") == .g)
+        #expect(SevenSegment.mask(for: " ") == [])
+    }
+
+    @Test("characters the display cannot show are refused rather than faked")
+    func unknown() {
+        #expect(SevenSegment.mask(for: "%") == nil)
+        #expect(SevenSegment.mask(for: "M") == nil)
+    }
+
+    /// The property the whole readout rests on: a decimal point rides the cell
+    /// before it, so a value keeps the same number of cells whether or not it
+    /// has a fractional part. Otherwise the readout jumps sideways every time
+    /// the value crosses a decade.
+    @Test("a decimal point takes no cell of its own")
+    func decimalPoint() {
+        let withPoint = SevenSegment.glyphs(for: "2.35")
+        let without = SevenSegment.glyphs(for: "235")
+        #expect(withPoint.count == 3)
+        #expect(withPoint.count == without.count)
+        #expect(withPoint[0].point)
+        #expect(withPoint[1].point == false)
+        #expect(withPoint.map(\.mask) == without.map(\.mask))
+    }
+
+    @Test("a leading point gets a blank cell to sit on")
+    func leadingPoint() {
+        let glyphs = SevenSegment.glyphs(for: ".5")
+        #expect(glyphs.count == 2)
+        #expect(glyphs[0].mask == [])
+        #expect(glyphs[0].point)
+        #expect(glyphs[1].mask == SevenSegment.mask(for: "5"))
+    }
+
+    @Test("unshowable characters are dropped from a run")
+    func runSkipsUnknown() {
+        #expect(SevenSegment.glyphs(for: "12 MB").map(\.mask) == [
+            SevenSegment.mask(for: "1"),
+            SevenSegment.mask(for: "2"),
+            SevenSegment.mask(for: " "),
+        ].compactMap(\.self))
+    }
+}

--- a/Tests/MonitorSourcesTests/SourceTests.swift
+++ b/Tests/MonitorSourcesTests/SourceTests.swift
@@ -29,6 +29,40 @@ struct SourceTests {
         }
     }
 
+    /// A wrong split would label real load as coming from the wrong kind of
+    /// core, which is worse than no split at all — so the source reports no
+    /// clusters rather than guess. What it must never do is claim a topology
+    /// that does not add up.
+    @Test("CPU clusters cover every core exactly once, fastest first")
+    func cpuClusters() {
+        let clusters = CPUSource.readClusters()
+        guard !clusters.isEmpty else { return } // uniform machine: no split
+        let cores = ProcessInfo.processInfo.activeProcessorCount
+
+        #expect(clusters.map(\.level) == clusters.map(\.level).sorted(), "not fastest first")
+        #expect(Set(clusters.map(\.level)).count == clusters.count, "a level appeared twice")
+
+        let covered = clusters.flatMap { Array($0.cores) }
+        #expect(covered.count == cores, "clusters do not account for every core")
+        #expect(Set(covered).count == cores, "a core belongs to two clusters")
+        #expect(covered.allSatisfy { $0 >= 0 && $0 < cores })
+        #expect(clusters.allSatisfy { !$0.name.isEmpty })
+    }
+
+    /// The cluster average must be an average, not a sum: a fully loaded
+    /// cluster reads 100%, not 400%.
+    @Test("cluster load stays a fraction")
+    func cpuClusterRange() throws {
+        let source = CPUSource()
+        _ = try source.read(at: 0)
+        Thread.sleep(forTimeInterval: 0.2)
+        let batch = try source.read(at: 0.2)
+        let levels = Set(CPUSource.readClusters().map { CPUSource.cluster($0.level) })
+        for sample in batch.samples where levels.contains(sample.metric) {
+            #expect(sample.value >= 0 && sample.value <= 1, "\(sample.metric) out of range")
+        }
+    }
+
     @Test("memory readings are positive and bounded by physical RAM")
     func memory() throws {
         let source = MemorySource()
@@ -72,7 +106,9 @@ struct SourceTests {
         #expect(Set(throughput.map(\.id)) == [NetworkSource.bitsIn, NetworkSource.bitsOut])
 
         // Eight times the byte counter, read back from the same interfaces.
-        let bytes = try NetworkSource.readInterfaceTotals()
+        let bytes = try NetworkSource.readInterfaceTotals(
+            matching: NetworkSource.physicalInterfaceNames()
+        )
         _ = try source.read(at: 0)
         Thread.sleep(forTimeInterval: 0.2)
         let batch = try source.read(at: 0.2)
@@ -82,6 +118,38 @@ struct SourceTests {
             // times eight in total since boot.
             #expect(sample.value <= bytes.bytesIn * 8 + 1)
         }
+    }
+
+    /// Counting the tunnels and Apple's internal interfaces reports more
+    /// traffic than crossed the wire — a VPN's bytes appear on both `utun` and
+    /// the `en` they leave by. Over-reporting is the worst kind of wrong here,
+    /// because the number stays plausible.
+    @Test("only Wi-Fi and wired interfaces are counted")
+    func networkExcludesVirtualInterfaces() throws {
+        let names = try NetworkSource.physicalInterfaceNames()
+        #expect(!names.isEmpty, "no physical interface found on a Mac that has one")
+
+        // Loopback, VPN and per-app tunnels, AirDrop, Apple's link-local and
+        // internal interfaces, bridges, and the IPv6 transition pseudo-devices.
+        let excluded = ["lo", "utun", "awdl", "llw", "anpi", "ap", "bridge", "gif", "stf"]
+        for name in names {
+            let match = excluded.first { name.hasPrefix($0) }
+            #expect(match == nil, "\(name) is not a physical NIC")
+        }
+    }
+
+    /// Filtering must actually narrow the set. If it silently matched nothing
+    /// the gauges would read a flat zero, which looks exactly like an idle
+    /// machine.
+    @Test("interface filtering narrows the set without emptying it")
+    func networkFilterIsSelective() throws {
+        let physical = try NetworkSource.physicalInterfaceNames()
+        let filtered = try NetworkSource.readInterfaceTotals(matching: physical)
+        let everything = try NetworkSource.readInterfaceTotals(
+            matching: Set(NetworkSource.allInterfaceNames())
+        )
+        #expect(everything.bytesIn >= filtered.bytesIn, "filtering added traffic")
+        #expect(filtered.bytesIn > 0, "no physical interface reported any traffic since boot")
     }
 
     /// Disk stays in bytes. Drives are quoted in bytes and networks in bits,

--- a/Tests/MonitorSourcesTests/SourceTests.swift
+++ b/Tests/MonitorSourcesTests/SourceTests.swift
@@ -59,6 +59,41 @@ struct SourceTests {
         }
     }
 
+    /// The conversion lives in the source so that the dial, the chart axis and
+    /// `monitorctl` cannot disagree about whether a link is busy. If the
+    /// descriptor ever says bytes again, every one of those reads eight times
+    /// low without anything looking broken.
+    @Test("network throughput is declared and reported in bits")
+    func networkReportsBits() throws {
+        let source = NetworkSource()
+        let throughput = source.descriptors.filter { $0.group == "Network" }
+        #expect(throughput.count == 2)
+        #expect(throughput.allSatisfy { $0.unit == .bitsPerSecond })
+        #expect(Set(throughput.map(\.id)) == [NetworkSource.bitsIn, NetworkSource.bitsOut])
+
+        // Eight times the byte counter, read back from the same interfaces.
+        let bytes = try NetworkSource.readInterfaceTotals()
+        _ = try source.read(at: 0)
+        Thread.sleep(forTimeInterval: 0.2)
+        let batch = try source.read(at: 0.2)
+        for sample in batch.samples where sample.metric == NetworkSource.bitsIn {
+            // A rate, not a total, so this only bounds it: the machine cannot
+            // have received more bits since the first read than it had bytes
+            // times eight in total since boot.
+            #expect(sample.value <= bytes.bytesIn * 8 + 1)
+        }
+    }
+
+    /// Disk stays in bytes. Drives are quoted in bytes and networks in bits,
+    /// and the two dials sitting side by side must not both say "10" while
+    /// meaning different things.
+    @Test("disk throughput stays in bytes")
+    func diskReportsBytes() {
+        let throughput = DiskSource().descriptors.filter { $0.group == "Disk" }
+        #expect(throughput.count == 2)
+        #expect(throughput.allSatisfy { $0.unit == .bytesPerSecond })
+    }
+
     /// The GPU source reads undocumented IOKit keys, so it is allowed to be
     /// unavailable. What it is not allowed to do is invent a number.
     @Test("GPU either reads a plausible value or reports unavailable")

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -18,13 +18,37 @@ difference between two readings. The first read produces nothing but a baseline.
 | `cpu.total` | busy fraction across all cores |
 | `cpu.user` | user + nice |
 | `cpu.system` | system |
-| `cpu.core.N` | busy fraction of one core |
+| `cpu.perflevel.N` | mean busy fraction across performance level N's cores |
 
 All are `fraction`, pinned to 0–1 on a chart.
 
-Cores are reported separately and never averaged into a single "CPU speed". On
-Apple silicon a performance core and an efficiency core have different ceilings,
-so their mean describes nothing physical.
+Load is reported **per cluster**, one series per `hw.perflevel`, and never
+averaged across them: on Apple silicon a performance core and an efficiency core
+have different ceilings, so their mean describes nothing physical. Within a
+cluster the mean is exactly right, because those cores are interchangeable to
+the scheduler.
+
+A line per core says less than a line per cluster. At ten cores the chart is
+unreadable spaghetti and its legend does not fit, and the question a dashboard
+answers is "is the fast cluster working", not "which of these four".
+
+Two details about the mapping:
+
+- The id is keyed by performance level, not by the cluster's name.
+  `hw.perflevel0` is always the fastest cluster on any machine that has them, so
+  the id means the same thing everywhere. The name does not: an M4 calls level 0
+  "Super" where earlier silicon calls it "Performance".
+- `host_processor_info` numbers cores in **reverse** performance-level order —
+  the *slowest* cluster comes first. Verified on an M4 (10 cores, 4 at level 0
+  "Super", 6 at level 1 "Efficiency") by pinning four `userInteractive` threads,
+  which the scheduler puts on the fast cluster: cores 6–9 hit 99% while 0–5
+  stayed idle.
+
+A machine with fewer than two performance levels — any Intel Mac — gets no
+cluster series at all, since one uniform "cluster" would just duplicate
+`cpu.total`. The source also reports none if the level sizes do not add up to
+the core count: a wrong split would attribute real load to the wrong kind of
+core, which is worse than no split.
 
 ## Memory — `MemorySource`
 
@@ -72,7 +96,7 @@ constants live in a header that is not in IOKit's Swift module map.
 
 ## Network — `NetworkSource`
 
-`getifaddrs`, `AF_LINK` entries only, loopback excluded.
+`getifaddrs`, `AF_LINK` entries only, restricted to physical interfaces.
 
 | id | Meaning |
 |----|---------|
@@ -80,8 +104,31 @@ constants live in a header that is not in IOKit's Swift module map.
 | `net.packets.in`, `net.packets.out` | packet rate |
 
 Only `AF_LINK` entries carry counters; an interface also has an `AF_INET` entry
-and counting both would double every byte. Loopback is excluded because it is
-the machine talking to itself and it swamps the chart during a build.
+and counting both would double every byte.
+
+**Only real NICs are counted — Wi-Fi and wired.** A Mac carries a crowd of
+interfaces that are not the network, and summing everything `getifaddrs` returns
+reports more traffic than crossed the wire:
+
+| interface | what it is |
+|-----------|------------|
+| `lo0` | the machine talking to itself; swamps the chart during a build |
+| `utun0…8` | VPN and per-app tunnels. Traffic through one is counted **twice** if you sum both the tunnel and the `en0` it leaves by |
+| `awdl0` | AirDrop / AirPlay |
+| `llw0`, `anpi0`, `ap1` | Apple's link-local and internal interfaces |
+| `bridge0` | Thunderbolt Bridge — real hardware underneath, virtual interface on top |
+| `gif0`, `stf0` | IPv6 transition pseudo-devices |
+
+The list of real interfaces comes from `SCNetworkInterfaceCopyAll`, filtered to
+the `Ethernet` and `IEEE80211` types. That is an allow-list of interface *types*,
+deliberately, rather than a deny-list of name prefixes: a deny-list has to be
+extended every time Apple ships another `anpi`-style internal interface, and the
+failure mode of missing one is silently over-reporting traffic — the kind of
+wrong number nobody checks.
+
+`SCNetworkInterfaceCopyAll` costs about 0.8 ms, which is far too much at two
+reads a second, so the result is cached and re-resolved every 10 seconds. A
+dongle plugged in mid-session appears within that window.
 
 The byte counters are multiplied by 8 and reported as bits. Every number anyone
 quotes about a network is in bits — a 1 Gbit port, a 300 Mbit service, an

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -76,12 +76,19 @@ constants live in a header that is not in IOKit's Swift module map.
 
 | id | Meaning |
 |----|---------|
-| `net.bytes.in`, `net.bytes.out` | throughput |
+| `net.bits.in`, `net.bits.out` | throughput, in **bits** per second |
 | `net.packets.in`, `net.packets.out` | packet rate |
 
 Only `AF_LINK` entries carry counters; an interface also has an `AF_INET` entry
 and counting both would double every byte. Loopback is excluded because it is
 the machine talking to itself and it swamps the chart during a build.
+
+The byte counters are multiplied by 8 and reported as bits. Every number anyone
+quotes about a network is in bits — a 1 Gbit port, a 300 Mbit service, an
+866 Mbit Wi-Fi link — so reporting bytes makes the reader divide by eight before
+they can tell whether a link is busy. The conversion happens in the source, not
+in the gauge, so the dial, the chart axis and `monitorctl` cannot disagree
+about it.
 
 ## GPU — `GPUSource`
 
@@ -103,7 +110,16 @@ two GPUs, one pinned and one idle is not "half loaded".
 | Unit | Axis behaviour |
 |------|----------------|
 | `fraction` | pinned to 0–1, never auto-scaled |
-| `bytes`, `bytesPerSecond` | decimal units (kB = 1000), matching Apple |
+| `bytes` | decimal units (kB = 1000), matching Apple, scaled to the data |
+| `bytesPerSecond` | decimal units, **always MB/s** — never rescaled |
+| `bitsPerSecond` | decimal units, **always Mbit/s** — never rescaled |
 | `operationsPerSecond`, `count`, `hertz` | scaled to the data |
 | `seconds` | µs / ms / s by magnitude |
 | `celsius`, `watts` | declared, not yet produced by any source |
+
+Throughput is pinned to mega-units at every magnitude, including `0.02 MB/s`
+and `5000 MB/s`. Auto-scaling suits an axis and not an instrument: the unit
+under a needle you are watching must not change while you are reading it, and a
+readout of `900` is useless until you have also read the word beneath it. The
+readout carries three significant figures, which keeps its width near-constant
+as the value moves — it lives in a fixed inset on the dial face.

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -168,5 +168,6 @@ Throughput is pinned to mega-units at every magnitude, including `0.02 MB/s`
 and `5000 MB/s`. Auto-scaling suits an axis and not an instrument: the unit
 under a needle you are watching must not change while you are reading it, and a
 readout of `900` is useless until you have also read the word beneath it. The
-readout carries three significant figures, which keeps its width near-constant
-as the value moves — it lives in a fixed inset on the dial face.
+A chart axis and the CLI carry three significant figures, which keeps a value's
+width near-constant as it moves. The gauge readout goes further and uses a fixed
+`xxxx.yy` field so the decimal point never moves at all — see `docs/ui.md`.

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -2,7 +2,7 @@
 
 ## Gauges for rates, charts for levels
 
-`AppModel.isGauge` splits them by unit: `bytesPerSecond` and
+`AppModel.isGauge` splits them by unit: `bytesPerSecond`, `bitsPerSecond` and
 `operationsPerSecond` get a dial, everything else gets a chart.
 
 The split is not decorative. A dial answers *"how hard is this working right
@@ -19,19 +19,79 @@ fixed for either is useless for the other.
 
 `GaugeScale` handles it with two rules:
 
-**Snap full scale to 1, 2 or 5 times a power of ten.** An arbitrary full scale
-gives tick labels like 3.7 GB/s, which nobody reads at a glance. Snapping keeps
-them round, and ten major divisions always land on readable numbers.
+**Snap full scale to a ladder.** An arbitrary full scale gives tick labels like
+3.7 GB/s, which nobody reads at a glance. Snapping keeps them round, and ten
+major divisions always land on readable numbers. Which ladder is per-gauge:
+
+- `ScaleLadder.oneTwoFive` — 10, 20, 50, 100, 200, 500 … The default, and the
+  right choice when the range is genuinely unknown, because it keeps the needle
+  in a useful part of the sweep.
+- `ScaleLadder.decade` — 10, 100, 1000 … Used by the throughput dials. It gives
+  up resolution to buy predictability: MB/s and Mbit/s are quoted in tens,
+  hundreds and thousands, so a reader already has the ladder in their head and
+  needle position alone is enough.
 
 **Rise immediately, fall slowly.** Full scale jumps up the instant a reading
-exceeds it, but steps down only after a quiet trailing window (15 s by default).
-Otherwise the dial rescales the moment traffic stops and the needle appears to
-move when the value did not.
+exceeds it, but steps down only once the value has stayed below the next scale
+down for a continuous `decayInterval`. Otherwise the dial rescales the moment
+traffic stops and the needle appears to move when the value did not.
 
-The peak is tracked over a **trailing window, not since launch**. An all-time
-peak never decays, so one 900 MB/s spike at breakfast would pin the dial at
-1 GB/s for the rest of the day and every subsequent reading would sit uselessly
-against the stop. `GaugeScaleTests` pins this.
+## The throughput high-water mark
+
+Disk and network dials start at 0–10 MB/s and 0–10 Mbit/s, the scales an idle
+machine spends nearly all its time on. Past 10 the scale steps to 100, past 100
+to 1000.
+
+Coming down takes **ten minutes below 90% of the next scale down** — below
+9 Mbit on the way off the 100 scale. Two details matter:
+
+- The 10% band is hysteresis. Without it, a workload sitting at exactly full
+  scale rescales the dial forever, and the needle moves while the value does
+  not, which is the one thing a gauge must never do.
+- The clock measures *continuous* time below the threshold, not the peak of a
+  fixed window. A tumbling window cannot express this rule: the window holding
+  the spike also holds the evidence against coming down, so the dial would need
+  two full windows — twenty minutes for a ten-minute rule — before it moved.
+
+Once the quiet period is up the dial descends as far as the period's peak
+justifies, not one rung at a time: ten quiet minutes takes it from 1000 straight
+back to 10 rather than starting a half-hour walk down.
+
+None of it persists. A restart begins at 0–10 again, because v1 writes nothing
+to disk.
+
+The `peak` the dial marks is the highest reading since full scale last changed —
+the high-water mark that *explains* the current scale, which is what makes a
+raised scale readable when nothing is happening. `GaugeScaleTests` and
+`DecadeGaugeScaleTests` pin all of this.
+
+## The seven-segment readout
+
+The digital inset in each dial face is drawn as segments, not typeset. macOS
+ships no seven-segment font and this project takes no third-party dependencies,
+but a font would be the wrong tool regardless: it cannot draw the *unlit*
+segments, and those are what make the inset read as a panel with a display in it
+rather than a stencil typeface.
+
+`SevenSegment` in MonitorCore holds the character-to-segment mapping, because
+"a 4 lights b, c, f and g" is a fact about the display rather than about drawing
+and can be tested without a screen. `SevenSegmentText` in MonitorUI draws it.
+
+Two details are load-bearing:
+
+- **Every cell reserves room for its decimal point**, lit or not, exactly as a
+  physical part does. Claiming the space only when the point is lit would make
+  `2.35` wider than `235`, and a readout that changes width as its value crosses
+  a decade is the thing the display exists to prevent. The final cell is the one
+  exception — a ghost dot with nothing after it reads as a lit point, turning
+  `245` into `245.`.
+- **There is no `.contentTransition(.numericText())`.** `Canvas` draws
+  imperatively from what its closure reads, so SwiftUI cannot interpolate
+  between two readings. The value snaps, which is what an LCD does; the needle
+  beside it carries the continuity.
+
+The unit beneath the digits stays ordinary type, because "Mbit/s" is not
+expressible in seven segments.
 
 ## Why the needle is a Shape and not part of the Canvas
 

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -93,6 +93,35 @@ Two details are load-bearing:
 The unit beneath the digits stays ordinary type, because "Mbit/s" is not
 expressible in seven segments.
 
+## Which cards appear, and what they are bounded by
+
+`DashboardView.chartGroupOrder` names the chart cards explicitly, in order, for
+the same reason the gauge list is explicit: cards that move between launches are
+cards you have to hunt for. It also carries two decisions that deriving the list
+could not express — that disk and network throughput deserve a chart *as well as*
+a dial, because a needle cannot tell you a transfer has been running for a
+minute; and that `Disk Ops`, `Network Packets` and `Memory Paging` are diagnostic
+detail belonging in `monitorctl` rather than on a dashboard you glance at.
+
+Two things bound a chart to its card:
+
+- **Marks are filtered to the visible window.** Swift Charts does not drop marks
+  that fall outside the x domain — it draws them anyway, outside the plot area
+  and straight through the axis labels and the card's own edge. The buffer holds
+  ten minutes and the window is usually one or two, so most of what it holds has
+  to be filtered out before it reaches the chart. This is also nine-tenths less
+  drawing.
+- **`chartPlotStyle { $0.clipped() }`** catches what is left, since a sample can
+  still sit fractionally outside the domain at either edge.
+
+The y-axis scales to what is on screen, not to the whole buffer. Otherwise a
+spike eight minutes off the left of a two-minute window flattens everything you
+can actually see.
+
+Axis labels use `Format.axisLabel`, which is coarser than the readout: `20 MB/s`
+up the side rather than `20.0 MB/s` next to `0.00 MB/s`. An axis is a scale, not
+a measurement, and the current value is spelled out in the card's header anyway.
+
 ## Why the needle is a Shape and not part of the Canvas
 
 The face — bezel, ticks, labels, redline — is drawn in a `Canvas`, because none

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -77,7 +77,26 @@ rather than a stencil typeface.
 "a 4 lights b, c, f and g" is a fact about the display rather than about drawing
 and can be tested without a screen. `SevenSegmentText` in MonitorUI draws it.
 
-Two details are load-bearing:
+### The field is fixed at `xxxx.yy`
+
+`Format.readout` right-aligns into four integer digits, a point, and two
+decimals — `   4.23`, `  43.70`, `5012.66` — padded with blanks, never zeros
+(`0004.23` reads as a part number).
+
+The point never moving is the whole point. A readout you glance at is read partly
+by *position*: if the point slides left as the value grows, `4.23` and `43.7`
+occupy the same pixels with different meanings and you have to read all of it to
+know which you are looking at. Nailed down, the shape of the number carries its
+magnitude.
+
+Four integer digits rather than three so the field cannot overflow on real
+hardware — an internal SSD reads at around 5000 MB/s, which three digits could
+not show at all. 9999.99 covers that and a 10 Gbit link, so the overflow pattern
+(`----.--`, same width, so the display cannot jump) exists for completeness
+rather than because anything reaches it. This is also why disk can stay pinned to
+MB/s instead of switching to GB/s at the top end.
+
+Three details are load-bearing:
 
 - **Every cell reserves room for its decimal point**, lit or not, exactly as a
   physical part does. Claiming the space only when the point is lit would make
@@ -85,6 +104,10 @@ Two details are load-bearing:
   a decade is the thing the display exists to prevent. The final cell is the one
   exception — a ghost dot with nothing after it reads as a lit point, turning
   `245` into `245.`.
+- **A blank cell gets no ghosts.** A blank is a *position*, not a digit, and
+  ghosting it draws a faint 8 where no digit is — so the three leading blanks of
+  `   4.23` read as digits at a glance. The cell still claims its width, so the
+  field stays fixed either way.
 - **There is no `.contentTransition(.numericText())`.** `Canvas` draws
   imperatively from what its closure reads, so SwiftUI cannot interpolate
   between two readings. The value snaps, which is what an LCD does; the needle
@@ -92,6 +115,36 @@ Two details are load-bearing:
 
 The unit beneath the digits stays ordinary type, because "Mbit/s" is not
 expressible in seven segments.
+
+Six cells is most of the width of the dial face, which has two consequences.
+The dial's **label sits under the dial** rather than on its face — at 130pt
+across, "Network Out" on the face ran into the ticks — and it replaced the value
+caption that used to sit there, which only repeated what the readout already
+says. And the dial's end tick labels moved in to `0.54r`: at `0.62r` they ran
+underneath the readout, and the fixed field is too wide to give the horizontal
+room back, so they clear it vertically instead.
+
+## Density: how much fits on screen
+
+`Theme.Layout` gathers every size that decides how much of the dashboard is
+visible at once, because they are one decision rather than eight.
+
+What made only four cards visible was not card height — it was the **column
+count**. A 380pt minimum card width in a 1156pt content area fits *two* columns,
+so seven cards needed four rows. Halving that minimum gives four columns and the
+same seven cards land in two rows. So the charts are barely shorter than they
+were: the width came down by half, the height did not have to.
+
+That distinction matters because the premise of the app is charts big enough to
+read. Activity Monitor's are not, and shrinking far enough lands in the same
+place — a literal half-of-both-dimensions left five cramped columns, legends
+wrapped to `Tota l` and `Efficien cy`, time labels colliding into
+`9:56:46 AM9:57:16 AM`, and a third of the window empty.
+
+`chartMinimum` is the number to raise first if the density has gone too far,
+since chart width is what the time axis needs. `chartMinHeight` is a *minimum*,
+so a shorter window scrolls rather than squashing the charts — the right way
+round: the charts stay readable and the window decides how many you see at once.
 
 ## Which cards appear, and what they are bounded by
 


### PR DESCRIPTION
Closes #1, closes #2, closes #3.

Three changes to the throughput gauges, all aimed at a dial you can read at a glance.

## Seven-segment readout (#1)

The digital inset is drawn as segments instead of typeset. macOS ships no seven-segment font and this project takes no dependencies — but a font would be the wrong tool anyway, since it cannot draw the *unlit* segments, and those are what make the inset read as a display rather than a stencil typeface.

`SevenSegment` in MonitorCore holds the character-to-segment mapping ("a 4 lights b, c, f and g" is a fact about the display, testable without a screen). `SevenSegmentText` in MonitorUI draws tapered hexagonal bars with a slight slant, ghost segments and a soft bloom.

Two details are load-bearing:
- Every cell reserves room for its decimal point, lit or not, as a physical part does — otherwise `2.35` is wider than `235` and the readout jumps sideways when a value crosses a decade. The final cell is the exception: a ghost dot with nothing after it reads as a lit point, turning `245` into `245.`.
- `.contentTransition(.numericText())` is gone. `Canvas` draws imperatively, so SwiftUI cannot interpolate it. The value snaps, which is what an LCD does; the needle carries the continuity.

## Pinned throughput units (#2)

Disk is always MB/s, network always Mbit/s, at every magnitude from `0.02` to `5000`. Auto-scaling suits an axis, not an instrument — the unit under a needle must not change while you are reading it, and `900` is useless until you have also read the word beneath it. Three significant figures keeps the readout near-constant in width.

Network converts bytes to bits **in the source**, not in the gauge, so the dial, chart axis and `monitorctl` cannot disagree. That renames `net.bytes.{in,out}` to `net.bits.{in,out}`; renaming a `MetricID` normally orphans stored history, but v1 writes nothing and `MonitorStore` is not linked, so this was the last moment it was free.

Memory keeps auto-scaling — it is a level, not a throughput.

## Decade high-water-mark dials (#3)

Throughput dials start at 0–10 MB/s and 0–10 Mbit/s and step up by decades: 10 → 100 → 1000. They come down after **ten continuous minutes below 90% of the next scale down**.

- The 10% band is hysteresis. Without it a load sitting at exactly full scale rescales the dial forever, and the needle moves while the value does not.
- The clock measures continuous time below the threshold, not the peak of a fixed window. A tumbling window cannot express the rule: the window holding the spike also holds the evidence against coming down, so the dial would need two windows — twenty minutes for a ten-minute rule.
- Once the quiet period is up it descends as far as that period's peak justifies, so ten quiet minutes takes a dial from 1000 straight back to 10.
- Nothing persists; a restart begins at 0–10.

Other gauges keep the 1-2-5 ladder, which is right when the range is genuinely unknown. `ScaleLadder` makes the choice per gauge.

## Verification

- `swift build && swift test` — 60 tests in 10 suites pass (was 33 in 7).
- swiftformat lint clean. Note: the installed swiftformat rejects `wrapIfStatementBodies` in `.swiftformat` as an unknown rule; that predates this branch and reproduces on clean `main`, so it is a version mismatch rather than something introduced here.
- Bits conversion checked against the kernel's own counters under sustained load: **34.5 Mbit/s** measured vs **33.7 Mbit/s** from `netstat -ib` over the same window.
- Gauges rendered offscreen and inspected by eye — `screencapture` is not permitted in this environment, so the live window could not be photographed.
