### PR TITLE
Report zero disk latency on an idle interval, not nothing

### DIFF
--- a/Sources/MonitorSources/DiskSource.swift
+++ b/Sources/MonitorSources/DiskSource.swift
@@ -84,6 +84,20 @@ public final class DiskSource: MetricSource, @unchecked Sendable {
         // Mean latency over the interval: time spent divided by operations
         // completed, both as deltas. Dividing the cumulative totals instead
         // would give the average since boot, which never moves.
+        //
+        // An interval with no operations reports **zero**, not nothing. With no
+        // operations both deltas are zero, so there is no quotient to take and
+        // zero is a choice rather than a computation — but it is the right one:
+        // no time was spent waiting on the disk. Reporting nothing instead made
+        // latency the only one of this source's six metrics that could go
+        // absent on an idle tick, and the UI reads an absent metric as "not
+        // available on this machine" — a claim about the hardware. That made the
+        // card flap between its chart and that notice twice a second on an idle
+        // machine (#5).
+        //
+        // The consequence, worth knowing: "completed instantly" and "nothing
+        // happened" both draw as zero. The Disk Ops card beside it tells them
+        // apart.
         let readTimeRate = rates.rate(
             for: Self.readLatency,
             total: totals.readTime,
@@ -92,11 +106,14 @@ public final class DiskSource: MetricSource, @unchecked Sendable {
         let writeTimeRate = rates.rate(
             for: Self.writeLatency, total: totals.writeTime, at: timestamp
         )
-        if let readTimeRate, let reads = values[Self.readsPerSecond], reads > 0 {
-            values[Self.readLatency] = readTimeRate / reads / 1_000_000_000
+        // Still nil on the very first tick, when the counters have no previous
+        // reading — there is genuinely no rate yet, which is not the same thing
+        // as an idle interval.
+        if let readTimeRate, let reads = values[Self.readsPerSecond] {
+            values[Self.readLatency] = reads > 0 ? readTimeRate / reads / 1_000_000_000 : 0
         }
-        if let writeTimeRate, let writes = values[Self.writesPerSecond], writes > 0 {
-            values[Self.writeLatency] = writeTimeRate / writes / 1_000_000_000
+        if let writeTimeRate, let writes = values[Self.writesPerSecond] {
+            values[Self.writeLatency] = writes > 0 ? writeTimeRate / writes / 1_000_000_000 : 0
         }
 
         return SampleBatch(timestamp: timestamp, values: values)

--- a/Tests/MonitorSourcesTests/SourceTests.swift
+++ b/Tests/MonitorSourcesTests/SourceTests.swift
@@ -152,6 +152,60 @@ struct SourceTests {
         #expect(filtered.bytesIn > 0, "no physical interface reported any traffic since boot")
     }
 
+    /// Latency must never go absent while the operation counts are present.
+    ///
+    /// It used to be reported only when operations had completed, which made it
+    /// the one metric of this source's six that could vanish on an idle tick.
+    /// The UI reads an absent metric as "not available on this machine", so the
+    /// Disk Latency card flapped between its chart and that notice twice a
+    /// second on an idle machine (#5). This test does not need a busy disk or an
+    /// idle one — the invariant holds either way, which is the point.
+    @Test("disk latency is reported on every tick that has operation counts")
+    func diskLatencyNeverGoesAbsent() throws {
+        let source = DiskSource()
+        _ = try source.read(at: 0)
+        Thread.sleep(forTimeInterval: 0.2)
+        let present = try Set(source.read(at: 0.2).samples.map(\.metric))
+
+        #expect(present.contains(DiskSource.readsPerSecond), "no read rate to compare against")
+        #expect(
+            present.contains(DiskSource.writesPerSecond),
+            "no write rate to compare against"
+        )
+        #expect(present.contains(DiskSource.readLatency), "read latency went absent")
+        #expect(present.contains(DiskSource.writeLatency), "write latency went absent")
+    }
+
+    /// Zero is a legitimate latency, and an idle interval reports it. What it
+    /// must never be is negative or absurd.
+    @Test("disk latency is a plausible non-negative duration")
+    func diskLatencyRange() throws {
+        let source = DiskSource()
+        _ = try source.read(at: 0)
+        Thread.sleep(forTimeInterval: 0.2)
+        let latencies = try source.read(at: 0.2).samples.filter {
+            $0.metric == DiskSource.readLatency || $0.metric == DiskSource.writeLatency
+        }
+        #expect(!latencies.isEmpty)
+        for sample in latencies {
+            #expect(sample.value >= 0, "\(sample.metric) went negative")
+            // A mean latency above a second over a 200 ms window would mean the
+            // arithmetic is wrong, not that the disk is slow.
+            #expect(sample.value < 1, "\(sample.metric) is not a plausible mean latency")
+        }
+    }
+
+    /// The first tick has no previous counter reading, so there is genuinely no
+    /// rate yet — which is not the same thing as an idle interval, and must not
+    /// be reported as a latency of zero.
+    @Test("the first disk read yields no latency at all")
+    func diskLatencyNeedsTwoReadings() throws {
+        let source = DiskSource()
+        let first = try Set(source.read(at: 0).samples.map(\.metric))
+        #expect(!first.contains(DiskSource.readLatency))
+        #expect(!first.contains(DiskSource.writeLatency))
+    }
+
     /// Disk stays in bytes. Drives are quoted in bytes and networks in bits,
     /// and the two dials sitting side by side must not both say "10" while
     /// meaning different things.

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -91,6 +91,23 @@ total time divided by the delta in operation count. Dividing the cumulative
 totals instead would give the average since boot, which never moves and is
 therefore useless.
 
+**An interval with no operations reports a latency of zero, not nothing.** With
+no operations both deltas are zero, so there is no quotient to take, and zero is
+a choice rather than a computation — the right one, because no time was spent
+waiting on the disk. Reporting nothing instead made latency the only one of this
+source's six metrics that could go absent on an idle tick, and the UI reads an
+absent metric as "not available on this machine": a claim about the hardware. The
+Disk Latency card flapped between its chart and that notice twice a second on an
+idle machine as a result (#5).
+
+The consequence worth knowing is that "operations completed instantly" and
+"nothing happened" both draw as zero. The Disk Ops card beside it tells the two
+apart.
+
+Only the *first* tick reports no latency at all, because the counters have no
+previous reading and there is genuinely no rate yet — which is a different thing
+from an idle interval.
+
 The dictionary keys are string literals because the `kIOBlockStorageDriver…`
 constants live in a header that is not in IOKit's Swift module map.
 


### PR DESCRIPTION
Closes #5.

## The bug

`DiskSource` reported latency only when operations had completed, which made it the one metric of the source's six that could go absent on an idle tick:

```
disk.bytes.read          = 0
disk.bytes.written       = 0
disk.ops.read            = 0
disk.ops.write           = 0
disk.latency.read        = ABSENT      <-- the odd one out
disk.latency.write       = ABSENT
```

`AppModel` reads an absent metric as "not available on this machine" — a claim about the *hardware* — so the Disk Latency card flapped between its chart and that notice twice a second on an idle machine, with its own header showing real values (`Read 183 µs`) directly above the notice.

## The fix

An idle interval reports **zero**. With no operations both deltas are zero, so there is no quotient to take and zero is a choice rather than a computation — but it is the right one: no time was spent waiting on the disk. It also makes the six disk metrics consistent with each other, which is what settled it.

The first tick still reports no latency at all: the counters have no previous reading there, so there is genuinely no rate yet, which is a different thing from an idle interval.

## Consequence worth knowing

"Operations completed instantly" and "nothing happened" both draw as zero on the latency chart. That is acceptable for a dashboard you glance at, and the Disk Ops card beside it distinguishes the two.

## Still latent

The conflation underneath survives: `AppModel` infers "not available on this machine" from a metric being absent for a single tick, because `Sampler.tick` returns only a `SampleBatch` and never reports which sources threw. Nothing flaps on it today, so this PR does not touch it — #5 records it as latent, worth fixing by having the sampler report failures so unavailability comes from the source's own signal rather than from inference.

## Verification

Measured on an idle disk with `monitorctl watch --source disk --interval 0.5 --count 12`:

| | latency absent |
|---|---|
| before | 10 of 12 ticks |
| after | 0 of 12 ticks |

Three new tests: latency is present on every tick that has operation counts (holds whether the disk is busy or idle, which is the point); latency is a non-negative, plausible duration; and the first read yields no latency at all.

`swift build && swift test` — 71 tests in 10 suites pass. swiftformat lint clean.
