### PR TITLE
Stop the chart legend shuffling as its values change width

### DIFF
--- a/Sources/MonitorCore/Formatting.swift
+++ b/Sources/MonitorCore/Formatting.swift
@@ -101,6 +101,32 @@ public enum Format {
         }
     }
 
+    /// The widest reading `value(_:unit:)` is expected to produce for a unit.
+    ///
+    /// Used to reserve layout width for a live value, so a card's header does
+    /// not shift as digits come and go. Without it, a CPU series climbing from
+    /// `1%` to `100%` widens its own label by two characters, every other entry
+    /// in the legend slides to make room, and the whole header appears to wiggle
+    /// while nothing but the number has changed.
+    ///
+    /// A floor rather than a cap: the caller reserves *at least* this much and
+    /// a genuinely wider reading still gets drawn in full. So being wrong here
+    /// costs a little jitter at an extreme, never a clipped number.
+    public static func widestValue(unit: MetricUnit) -> String {
+        switch unit {
+        case .fraction: "100%"
+        case .bytes: "999 GB"
+        case .bytesPerSecond: "9999 MB/s"
+        case .bitsPerSecond: "9999 Mbit/s"
+        case .operationsPerSecond: "999999/s"
+        case .count: "999999"
+        case .hertz: "9999 Hz"
+        case .celsius: "999 °C"
+        case .watts: "999.9 W"
+        case .seconds: "999.99 s"
+        }
+    }
+
     /// A dial's tick label, which is coarser than the readout on purpose.
     ///
     /// A tick is a landmark, not a measurement — the readout below the needle

--- a/Sources/MonitorUI/ChartCard.swift
+++ b/Sources/MonitorUI/ChartCard.swift
@@ -60,22 +60,46 @@ public struct ChartCard: View {
             // saves a row of chrome per card.
             ForEach(Array(series.enumerated()), id: \.offset) { index, entry in
                 if let latest = entry.points.last {
-                    HStack(spacing: 4) {
-                        Circle()
-                            .fill(Theme.seriesColor(index))
-                            .frame(width: 7, height: 7)
-                        Text(entry.descriptor.name)
-                            .foregroundStyle(Theme.label)
-                            .lineLimit(1)
-                        Text(Format.value(latest.value, unit: entry.descriptor.unit))
-                            .foregroundStyle(Theme.readout)
-                            .monospacedDigit()
-                            .lineLimit(1)
-                    }
-                    .font(.system(size: Theme.Layout.cardLegend, design: .rounded))
+                    legendEntry(entry.descriptor, index: index, latest: latest)
                 }
             }
         }
+    }
+
+    /// One legend entry: colour swatch, series name, current value.
+    ///
+    /// Monospaced, and the value sits in a slot pre-sized to the widest reading
+    /// its unit can produce. Both matter for the same reason: a legend whose
+    /// entries change width is a legend that shuffles sideways while you are
+    /// reading it. A monospaced face stops individual digits from changing width
+    /// as they change value; the reserved slot stops the *number of* digits from
+    /// moving everything else, which is what made a series climbing from `1%` to
+    /// `100%` appear to wiggle the whole card.
+    ///
+    /// `.monospacedDigit()` is not enough on its own — it equalises digit widths
+    /// but reserves nothing, so `1%` and `100%` still occupy different space.
+    private func legendEntry(
+        _ descriptor: MetricDescriptor, index: Int, latest: Sample
+    ) -> some View {
+        HStack(spacing: 4) {
+            Circle()
+                .fill(Theme.seriesColor(index))
+                .frame(width: 7, height: 7)
+            Text(descriptor.name)
+                .foregroundStyle(Theme.label)
+                .lineLimit(1)
+            ZStack(alignment: .leading) {
+                // Reserves the slot. A ZStack takes the width of its widest
+                // child, so a reading wider than the reservation grows the slot
+                // rather than being clipped — the reservation is a floor.
+                Text(Format.widestValue(unit: descriptor.unit))
+                    .hidden()
+                Text(Format.value(latest.value, unit: descriptor.unit))
+                    .foregroundStyle(Theme.readout)
+                    .lineLimit(1)
+            }
+        }
+        .font(.system(size: Theme.Layout.cardLegend, design: .monospaced))
     }
 
     private var unavailableNotice: some View {

--- a/Tests/MonitorCoreTests/GaugeScaleTests.swift
+++ b/Tests/MonitorCoreTests/GaugeScaleTests.swift
@@ -351,6 +351,35 @@ struct FormatTests {
         )
     }
 
+    /// The legend reserves width from `widestValue`, so if a real reading is
+    /// wider than the reservation the header jitters at that magnitude. This
+    /// checks the reservation actually covers the range each unit produces.
+    @Test("the reserved legend width covers the readings a unit produces")
+    func widestValueCoversItsRange() {
+        let cases: [(MetricUnit, [Double])] = [
+            (.fraction, [0, 0.01, 0.5, 0.999, 1]),
+            (.bytes, [0, 1500, 1_500_000, 17_179_869_184, 999_000_000_000]),
+            (.bytesPerSecond, [0, 20000, 2_350_000, 5_000_000_000, 9_000_000_000]),
+            (.bitsPerSecond, [0, 20000, 34_500_000, 940_000_000, 9_000_000_000]),
+            (.operationsPerSecond, [0, 9.9, 250, 10672, 150_000]),
+            (.seconds, [0.000004, 0.04, 0.5, 9.99]),
+            (.hertz, [0, 60, 3200]),
+            (.celsius, [0, 45, 100]),
+            (.watts, [0, 3.4, 120]),
+            (.count, [0, 42, 99999]),
+        ]
+        for (unit, values) in cases {
+            let reserved = Format.widestValue(unit: unit).count
+            for value in values {
+                let rendered = Format.value(value, unit: unit)
+                #expect(
+                    rendered.count <= reserved,
+                    "\(unit): \"\(rendered)\" (\(rendered.count)) exceeds reserved \(reserved)"
+                )
+            }
+        }
+    }
+
     /// A tick is a landmark, not a measurement — the digits live in the
     /// readout below the needle.
     @Test("dial ticks are coarser than the readout")

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -146,6 +146,33 @@ since chart width is what the time axis needs. `chartMinHeight` is a *minimum*,
 so a shorter window scrolls rather than squashing the charts — the right way
 round: the charts stay readable and the window decides how many you see at once.
 
+## A legend that does not shuffle
+
+Each card's header carries the current value per series. Two things keep it
+still while those values change:
+
+- **Monospaced type**, so an individual digit does not change width as it
+  changes value.
+- **A slot pre-sized to the widest reading the unit can produce**
+  (`Format.widestValue`), so the *number of* digits cannot move anything either.
+
+`.monospacedDigit()` alone is not enough: it equalises digit widths but reserves
+nothing, so `1%` and `100%` still occupy different space and every entry beside
+them slides to make room. Measured on a CPU card, a series climbing from 1% to
+100% used to move the first swatch 42px and the others 14–28px; with the slot
+reserved, all three sit at identical pixel columns at every magnitude.
+
+The reservation is a floor, not a cap — it is held by a hidden placeholder in a
+`ZStack`, which takes the width of its widest child, so a reading wider than the
+reservation grows the slot rather than being clipped. Getting `widestValue` wrong
+costs a little jitter at an extreme, never a truncated number.
+
+One shift this does not address: on a chart whose y-axis auto-scales, the axis
+label width changes when the domain rescales (`0 MB/s` … `8 MB/s` versus
+`0 MB/s` … `600 MB/s`), which moves the plot's left edge. That happens on a
+rescale rather than on every sample, and fraction charts are pinned to 0–1 so
+their labels never change at all.
+
 ## Which cards appear, and what they are bounded by
 
 `DashboardView.chartGroupOrder` names the chart cards explicitly, in order, for


### PR DESCRIPTION
A series climbing from 1% to 100% widened its own label by two characters, every other entry in the legend slid to make room, and the whole card header appeared to wiggle while nothing but the number had changed.

## The fix

Two changes, both about width rather than value:

- **Monospaced legend type**, so an individual digit no longer changes width as it changes value.
- **A slot pre-sized to the widest reading each unit can produce** (`Format.widestValue`), so the *number of* digits cannot move anything either.

`.monospacedDigit()` was already on the value and wasn't enough on its own — it equalises digit widths but reserves nothing, so `1%` and `100%` still occupied different space.

The reservation is a **floor, not a cap**: it's held by a hidden placeholder in a `ZStack`, which takes the width of its widest child, so a reading wider than the reservation grows the slot rather than being clipped. Getting `widestValue` wrong costs a little jitter at an extreme, never a truncated number.

## Verification

Rendered a card offscreen at several magnitudes and located each legend swatch by pixel, so this is a measurement rather than an impression:

| value | swatch x — before | swatch x — after |
|---|---|---|
| 1% | 103, 164, 225 | 60, 139, 212 |
| 50% | 96, 164, 225 | 60, 139, 212 |
| 100% | 61, 136, 211 | 60, 139, 212 |
| 0.02 MB/s | 100, 198 | 84, 188 |
| 5000 MB/s | 97, 198 | 84, 188 |

Going 1% → 100% used to move the first swatch 42px and the others 14–28px. After, every magnitude lands on identical pixel columns.

A new test asserts the reservation actually covers the range each unit produces — `Format.value` output must never be wider than `Format.widestValue` for that unit, across ten units and their realistic ranges. That's the invariant that keeps the floor honest as formatting changes.

`swift build && swift test` — 72 tests in 10 suites pass. swiftformat lint clean.

## Not addressed

One shift this does not fix, because it's a different mechanism: on a chart whose y-axis auto-scales, the axis label width changes when the domain rescales (`0 MB/s` … `8 MB/s` versus `0 MB/s` … `600 MB/s`), which moves the plot's left edge. That happens on a rescale rather than on every sample, and fraction charts — the case in the report — are pinned to 0–1 so their labels never change at all. Say the word if you want the axis reserved too.
