### PR TITLE
Make monitor a real app: foreground identity and an .app bundle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,7 @@ swift run monitorctl read        # read every metric once
 swift run monitorctl watch --source disk --interval 0.5
 swift run monitorctl watch --json --count 5        # machine-readable, bounded
 swiftformat Sources Tests --lint --cache ignore    # CI lint gate
+Scripts/make-app.sh [dest]       # wrap the release binary in monitor.app
 ```
 
 `monitorctl` exists because sampling is the part most likely to be wrong and the
@@ -69,8 +70,9 @@ Sources/
                    ChartCard, DashboardView, AppModel
   MonitorStore/    SQLite history and retention. Designed and tested but NOT
                    linked into the app — see "Guardrails" below.
-  monitor/         the app target (@main SwiftUI App)
+  monitor/         the app target (@main SwiftUI App) and its AppDelegate
   monitorctl/      headless CLI harness
+Scripts/           make-app.sh, which builds monitor.app
 Tests/             MonitorCoreTests, MonitorSourcesTests, MonitorStoreTests
 docs/              README.md is the index
 .github/workflows/ci.yml   build, test, release build, CLI smoke test, lint
@@ -199,9 +201,12 @@ are no component-level AGENTS.md files.
 
 - **A rate metric shows nothing on the first tick**: correct by design. Counters
   need two readings. `monitorctl read` takes two ticks for this reason.
-- **The window opens behind other apps**: a bare SwiftPM executable has no
-  bundle identity, so macOS does not treat it as a foreground app. A packaging
-  matter, not a bug; a real `.app` bundle fixes it.
+- **The window opens behind other apps, or the app is missing from Cmd-Tab**:
+  the `AppDelegate` in `Sources/monitor/MonitorApp.swift` sets
+  `NSApp.setActivationPolicy(.regular)` at launch, which is what gives an
+  unbundled SwiftPM executable a Dock icon, a Cmd-Tab entry and a menu bar with
+  Cmd-Q. Do not remove it; without it the process launches as an accessory and
+  the only way to stop it is to interrupt the terminal.
 - **GPU card is greyed out**: this macOS version does not publish the
   `PerformanceStatistics` keys the source knows about. Add the new spelling to
   the candidate list in `GPUSource`.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,18 @@ step, not this one. See `docs/roadmap.md`.
 swift run monitor
 ```
 
-No Xcode project needed. That is the development loop.
+No Xcode project needed. That is the development loop. The app claims a
+foreground identity at launch, so it appears in Cmd-Tab and quits with Cmd-Q
+like anything else, even though it is a bare SwiftPM executable.
+
+To install it somewhere you can launch it from, build a real bundle:
+
+```sh
+Scripts/make-app.sh ~/Applications
+```
+
+That produces `monitor.app` — Info.plist, bundle id and an ad-hoc signature.
+It is not signed with a Developer ID or notarized, so it is for this Mac.
 
 There is also a headless CLI, which is how the sampling code gets developed and
 verified without a GUI in the way:

--- a/Scripts/make-app.sh
+++ b/Scripts/make-app.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+#
+# Wrap the release binary in a real .app bundle.
+#
+# The bundle is what gives the app an identity macOS understands: a Dock icon, a
+# Cmd-Tab entry, a name in the menu bar, and a stable bundle id for anything
+# that remembers a per-app decision. `swift run monitor` asks for the same
+# foreground identity at runtime, which is enough to develop against — this is
+# for having the app somewhere you can launch it from.
+#
+# Usage:
+#   Scripts/make-app.sh              # build into .build/monitor.app
+#   Scripts/make-app.sh ~/Applications   # and copy it there
+#
+# No signing identity is used. The bundle is signed ad-hoc, which is what a
+# locally built app needs to keep a stable identity across launches. Shipping it
+# to another Mac needs a Developer ID and notarization, which this does not do.
+
+set -euo pipefail
+
+readonly BUNDLE_ID="wtf.evan.monitor"
+readonly VERSION="1.0"
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$root"
+
+destination="${1:-}"
+app=".build/monitor.app"
+
+echo "Building release…"
+swift build -c release --product monitor
+
+binary="$(swift build -c release --product monitor --show-bin-path)/monitor"
+[ -x "$binary" ] || { echo "no binary at $binary" >&2; exit 1; }
+
+echo "Assembling ${app}…"
+rm -rf "$app"
+mkdir -p "$app/Contents/MacOS" "$app/Contents/Resources"
+cp "$binary" "$app/Contents/MacOS/monitor"
+
+cat > "$app/Contents/Info.plist" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleName</key>
+    <string>Monitor</string>
+    <key>CFBundleDisplayName</key>
+    <string>Monitor</string>
+    <key>CFBundleExecutable</key>
+    <string>monitor</string>
+    <key>CFBundleIdentifier</key>
+    <string>$BUNDLE_ID</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>$VERSION</string>
+    <key>CFBundleVersion</key>
+    <string>$VERSION</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>14.0</string>
+    <key>NSHighResolutionCapable</key>
+    <true/>
+    <!-- The window is designed against a dark ground; see Theme. -->
+    <key>NSRequiresAquaSystemAppearance</key>
+    <false/>
+</dict>
+</plist>
+PLIST
+
+# Ad-hoc signature. Without one the bundle still runs, but macOS treats it as a
+# different app on every rebuild and forgets anything it remembered about it.
+codesign --force --sign - --timestamp=none "$app" >/dev/null 2>&1 \
+    || echo "warning: could not sign $app; it will still run" >&2
+
+echo "Built $app"
+
+if [ -n "$destination" ]; then
+    mkdir -p "$destination"
+    rm -rf "${destination%/}/monitor.app"
+    cp -R "$app" "${destination%/}/monitor.app"
+    echo "Installed ${destination%/}/monitor.app"
+else
+    echo "Run it with: open $app"
+fi

--- a/Sources/monitor/MonitorApp.swift
+++ b/Sources/monitor/MonitorApp.swift
@@ -1,14 +1,18 @@
+import AppKit
 import MonitorUI
 import SwiftUI
 
 /// The app.
 ///
 /// A plain SwiftPM executable, so `swift run monitor` puts a window on screen
-/// with no Xcode project in the way. That is the fast development loop. A
-/// proper `.app` bundle — icon, Info.plist, signing, a Dock identity — comes
-/// with packaging, and does not need to exist to look at a gauge.
+/// with no Xcode project in the way. That is the fast development loop.
+/// `Scripts/make-app.sh` wraps the same binary in a real `.app` bundle when one
+/// is wanted; the delegate below makes the unbundled build behave like an app
+/// in the meantime.
 @main
 struct MonitorApp: App {
+    @NSApplicationDelegateAdaptor(AppDelegate.self) private var delegate
+
     var body: some Scene {
         Window("Monitor", id: "monitor") {
             DashboardView()
@@ -18,4 +22,26 @@ struct MonitorApp: App {
         // ground and a light mode is a separate palette, not a toggle.
         .defaultSize(width: 1000, height: 760)
     }
+}
+
+/// Claims a foreground identity for the process.
+///
+/// macOS decides what an app *is* from its bundle, and a bare SwiftPM
+/// executable has no bundle: it launches as an accessory, which means no Dock
+/// icon, no Cmd-Tab entry, no menu bar and therefore no Cmd-Q. The window
+/// appears behind whatever is already open and the only way to stop it is to
+/// interrupt the terminal that started it.
+///
+/// Asking for `.regular` at launch buys all of that back without a bundle. The
+/// call is harmless in a bundled build, where the policy is already regular.
+final class AppDelegate: NSObject, NSApplicationDelegate {
+    func applicationDidFinishLaunching(_: Notification) {
+        NSApp.setActivationPolicy(.regular)
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
+    /// One window and no documents: closing it means "I am done watching", so
+    /// the process should not outlive it. Without this a closed window leaves a
+    /// sampler running with nothing to draw on.
+    func applicationShouldTerminateAfterLastWindowClosed(_: NSApplication) -> Bool { true }
 }

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -23,10 +23,14 @@ Batched writes are mandatory, not optional. The endurance arithmetic is in
 
 ## A real `.app` bundle
 
-Today `monitor` is a bare SwiftPM executable. It works and it is a fast
-development loop, but it has no bundle identity, so macOS does not treat it as a
-foreground app and the window opens behind whatever is in front. A proper
-bundle brings an icon, an Info.plist, signing, notarization and a Dock identity.
+Mostly done. `Scripts/make-app.sh` wraps the release binary in `monitor.app`
+with an Info.plist and an ad-hoc signature, and the app asks for a foreground
+activation policy at launch, so even the bare `swift run monitor` build gets a
+Dock icon, a Cmd-Tab entry and Cmd-Q.
+
+What is left is distribution rather than behaviour: an icon, a Developer ID
+signature and notarization, which are what another Mac needs before it will open
+the app without a warning.
 
 ## Per-process attribution
 


### PR DESCRIPTION
## The problem

`swift run monitor` put a window on screen but not an app. A bare SwiftPM executable has no bundle, so macOS launched it as an *accessory*: no Dock icon, no Cmd-Tab entry, no menu bar, and therefore no Cmd-Q. The window opened behind whatever was already in front, and the only way to stop it was to Ctrl-C the terminal that started it.

## The fix, in two parts

**1. Foreground identity at launch.** An `AppDelegate` sets `NSApp.setActivationPolicy(.regular)` and activates. That is all macOS needs to give an unbundled executable a Dock icon, a Cmd-Tab entry and a full menu bar with Quit. `applicationShouldTerminateAfterLastWindowClosed` returns `true`, so closing the window stops the sampler instead of leaving it running with nothing to draw on.

**2. `Scripts/make-app.sh`.** Wraps the release binary in `monitor.app` — Info.plist, `wtf.evan.monitor` bundle id matching the logger subsystem, `LSMinimumSystemVersion 14.0`, and an ad-hoc signature so the app keeps a stable identity across rebuilds. Optional argument installs it: `Scripts/make-app.sh ~/Applications`.

The two are complementary: part 1 keeps `swift run monitor` the fast dev loop, part 2 gives something launchable from Spotlight.

## Verification

Both paths checked on macOS 26.5.2 by driving the running app through System Events, not just by building:

- Unbundled (`swift run monitor`) — visible foreground process; menu bar reads `Apple, monitor, Edit, View, Window, Help`; clicking **Quit monitor** terminates it.
- Bundled (`open .build/monitor.app`) — same, with the menu titled **Monitor** from `CFBundleName`; `codesign -dv` reports `Identifier=wtf.evan.monitor`, adhoc.

`swift build`, `swift test` (72 tests, 10 suites) and `swiftformat --lint` all pass.

## Docs

`docs/roadmap.md` listed the `.app` bundle as pending; it now records what is actually left, which is distribution only — an icon, a Developer ID signature and notarization. `README.md` gains the bundle instructions. `AGENTS.md` gains the script in Commands and `Scripts/` in the layout, and its "window opens behind other apps" troubleshooting entry becomes a warning not to remove the activation-policy call.