### PR TITLE
Add a sensor section, and wrap legends instead of truncating them

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,10 +64,11 @@ Sources/
                    seven-segment digit mapping, formatting, the sampling clock.
                    No macOS APIs — so all of it is testable without a machine
                    to read.
-  MonitorSources/  the readers: CPU, memory, disk, network, GPU, and the registry
-                   that lists them. One file per source.
+  MonitorSources/  the readers: CPU, memory, disk, network, GPU, SMC sensors
+                   (temperature, fans, power), and the registry that lists them.
+                   One file per source, plus SMC.swift for the SMC transport.
   MonitorUI/       Theme (palette + Layout density), GaugeView, SevenSegmentText,
-                   ChartCard, DashboardView, AppModel
+                   ChartCard, FlowLayout, DashboardView, AppModel
   MonitorStore/    SQLite history and retention. Designed and tested but NOT
                    linked into the app — see "Guardrails" below.
   monitor/         the app target (@main SwiftUI App) and its AppDelegate
@@ -118,6 +119,14 @@ are no component-level AGENTS.md files.
   batch lines up on the x-axis. A source that throws is logged and skipped for
   that tick only. `AppModel` samples at 0.5 s into a 1200-point ring buffer —
   ten minutes of history, all of it in memory.
+- **Sensors are found, not assumed.** `SMCSource` scans the SMC's key table at
+  launch and declares a metric only if this machine publishes sensors for it —
+  so a fanless Mac shows no Fans card rather than one reading zero, and an Intel
+  `TC0P` feeds the same CPU metric as Apple silicon's `Tp01`. Everything it
+  reads is unprivileged; root is needed only to *write* a key, which it cannot.
+  `docs/sensors.md` is the survey of what a Mac exposes and what it costs.
+- **The panel has two sections.** Performance above the rule, sensors below.
+  The sensor section vanishes on a machine that reports none of it.
 - **A missing sample means unavailable.** `AppModel` marks any descriptor that
   produced no sample this tick, minus the first-tick warm-up for rate metrics.
   That is how a card gets greyed out instead of drawing a flat zero line.
@@ -190,6 +199,10 @@ are no component-level AGENTS.md files.
 - `Sources/MonitorSources/CPUSource.swift` — `host_processor_info` allocates
   into the task's VM and the caller owns it. The `vm_deallocate` in the `defer`
   is not optional; without it the app leaks on every tick.
+- `Sources/MonitorSources/SMC.swift` — `SMCParameters` must match the driver's
+  struct byte for byte; a field added or reordered silently reads the wrong
+  offsets. Only two of the SMC's fifty-odd power keys are named, because only
+  those two were checked against an independent measurement (`docs/sensors.md`).
 - `Sources/MonitorSources/DiskSource.swift` — the statistics keys are string
   literals because the `kIOBlockStorageDriver…` constants live in a header that
   is not in IOKit's Swift module map. They are not typos.

--- a/Sources/MonitorCore/Formatting.swift
+++ b/Sources/MonitorCore/Formatting.swift
@@ -123,6 +123,7 @@ public enum Format {
         case .hertz: "9999 Hz"
         case .celsius: "999 °C"
         case .watts: "999.9 W"
+        case .rpm: "9999 rpm"
         case .seconds: "999.99 s"
         }
     }
@@ -172,6 +173,7 @@ public enum Format {
         case .hertz: rate(value, unit: " Hz")
         case .celsius: String(format: "%.0f °C", value)
         case .watts: String(format: "%.1f W", value)
+        case .rpm: String(format: "%.0f rpm", value)
         case .seconds: duration(value)
         }
     }
@@ -192,6 +194,7 @@ public enum Format {
         case .hertz: return "Hz"
         case .celsius: return "°C"
         case .watts: return "W"
+        case .rpm: return "rpm"
         }
     }
 

--- a/Sources/MonitorCore/Metric.swift
+++ b/Sources/MonitorCore/Metric.swift
@@ -26,6 +26,9 @@ public enum MetricUnit: String, Sendable, Codable {
     case hertz
     case celsius
     case watts
+    /// Fan speed. Its own unit rather than `count`, because "3200" and
+    /// "3200 rpm" are not the same reading on a chart axis.
+    case rpm
     case seconds
 }
 

--- a/Sources/MonitorSources/SMC.swift
+++ b/Sources/MonitorSources/SMC.swift
@@ -1,0 +1,247 @@
+import Foundation
+import IOKit
+import MonitorCore
+
+/// A connection to the System Management Controller, which is where a Mac
+/// keeps its temperatures, fan speeds and power rails.
+///
+/// The protocol is undocumented — one `IOConnectCallStructMethod` selector and
+/// a struct whose layout has to match the driver's — but it needs no
+/// privileges, which the alternatives do not manage: `powermetrics` wants root
+/// and IOReport is a private framework. Reads are unprivileged on every Mac
+/// this has been tried on; *writes* (setting a fan speed) are the part that
+/// needs root, and this type cannot write.
+///
+/// Separate from `SMCSource` because it is transport, not a metric: it knows
+/// how to name, size and decode a key, and nothing about what any key means.
+final class SMC {
+    /// One SMC key with its type and size already looked up.
+    ///
+    /// Worth caching because reading a key costs two round trips — one to ask
+    /// its type and size, one to fetch the bytes — and the type never changes
+    /// while the machine is running. Halving the calls halves the cost of a
+    /// tick, and a tick happens twice a second for as long as the app is open.
+    struct Key {
+        let code: UInt32
+        let name: String
+        let type: UInt32
+        let size: Int
+    }
+
+    private let connection: io_connect_t
+
+    init() throws {
+        let service = IOServiceGetMatchingService(
+            kIOMainPortDefault, IOServiceMatching("AppleSMC")
+        )
+        guard service != 0 else {
+            throw MetricSourceError.unavailable("AppleSMC")
+        }
+        defer { IOObjectRelease(service) }
+
+        var port: io_connect_t = 0
+        let result = IOServiceOpen(service, mach_task_self_, 0, &port)
+        guard result == kIOReturnSuccess else {
+            throw MetricSourceError.readFailed("AppleSMC connection", code: result)
+        }
+        connection = port
+    }
+
+    deinit { IOServiceClose(connection) }
+
+    // MARK: - Keys
+
+    /// Every key whose name begins with `prefix`, in the SMC's own order.
+    ///
+    /// The key table is sorted, so this binary-searches for the start of the
+    /// range and walks forward rather than enumerating all of it: a machine
+    /// publishes a couple of thousand keys and reading every name takes about
+    /// 300 ms, which is too long to spend at launch to find the 150 that are
+    /// temperatures.
+    func keys(withPrefix prefix: String) throws -> [Key] {
+        let count = try keyCount()
+        let lower = Self.code(prefix.padding(toLength: 4, withPad: "\0", startingAt: 0))
+        // The end of the range is the same prefix with its last character
+        // stepped on, so "T" scans up to but not including "U".
+        var upperPrefix = Array(prefix.utf8)
+        upperPrefix[upperPrefix.count - 1] += 1
+        let upper = Self.code(String(decoding: upperPrefix, as: UTF8.self)
+            .padding(toLength: 4, withPad: "\0", startingAt: 0))
+
+        var low = 0
+        var high = count
+        while low < high {
+            let middle = (low + high) / 2
+            guard let code = try? key(atIndex: middle) else { break }
+            if code < lower { low = middle + 1 } else { high = middle }
+        }
+
+        var found: [Key] = []
+        var index = low
+        while index < count, let code = try? key(atIndex: index), code < upper {
+            if let key = try? info(for: code) { found.append(key) }
+            index += 1
+        }
+        return found
+    }
+
+    /// A single key by name, or nil if this machine does not publish it.
+    func key(named name: String) -> Key? {
+        try? info(for: Self.code(name))
+    }
+
+    private func keyCount() throws -> Int {
+        guard let key = try? info(for: Self.code("#KEY")),
+              let value = try? readRaw(key)
+        else { throw MetricSourceError.unavailable("SMC key count") }
+        return Int(value.reduce(UInt32(0)) { $0 << 8 | UInt32($1) })
+    }
+
+    private func key(atIndex index: Int) throws -> UInt32 {
+        var input = SMCParameters()
+        input.data8 = Self.commandKeyFromIndex
+        input.data32 = UInt32(index)
+        guard let output = call(input) else {
+            throw MetricSourceError.readFailed("SMC key index \(index)", code: 0)
+        }
+        return output.key
+    }
+
+    private func info(for code: UInt32) throws -> Key {
+        var input = SMCParameters()
+        input.key = code
+        input.data8 = Self.commandKeyInfo
+        guard let output = call(input) else {
+            throw MetricSourceError.unavailable("SMC key \(Self.name(code))")
+        }
+        return Key(
+            code: code,
+            name: Self.name(code),
+            type: output.keyInfo.dataType,
+            size: Int(output.keyInfo.dataSize)
+        )
+    }
+
+    // MARK: - Reading
+
+    /// A key's current value, converted to a plain number by its SMC type.
+    ///
+    /// Returns nil for a type this does not know how to decode rather than
+    /// guessing: the types are a fixed-point zoo — `sp78` on Intel, `flt` on
+    /// Apple silicon, `fpe2` for fan speeds — and reading one as another
+    /// produces a number that looks like a temperature and is not.
+    func value(of key: Key) -> Double? {
+        guard let bytes = try? readRaw(key) else { return nil }
+        switch Self.name(key.type) {
+        case "flt":
+            guard bytes.count >= 4 else { return nil }
+            // Little-endian, unlike every integer type the SMC reports.
+            let raw = UInt32(bytes[0]) | UInt32(bytes[1]) << 8
+                | UInt32(bytes[2]) << 16 | UInt32(bytes[3]) << 24
+            return Double(Float(bitPattern: raw))
+        case "ui8", "ui16", "ui32", "ui64":
+            return Double(bytes.reduce(UInt64(0)) { $0 << 8 | UInt64($1) })
+        case "si8", "si16":
+            var value: Int64 = 0
+            for byte in bytes { value = value << 8 | Int64(byte) }
+            return Double(value)
+        case "sp78":
+            guard bytes.count >= 2 else { return nil }
+            return Double(Int16(bitPattern: UInt16(bytes[0]) << 8 | UInt16(bytes[1]))) / 256
+        case "fp88":
+            guard bytes.count >= 2 else { return nil }
+            return Double(UInt16(bytes[0]) << 8 | UInt16(bytes[1])) / 256
+        case "fpe2":
+            guard bytes.count >= 2 else { return nil }
+            return Double(UInt16(bytes[0]) << 8 | UInt16(bytes[1])) / 4
+        default:
+            return nil
+        }
+    }
+
+    private func readRaw(_ key: Key) throws -> [UInt8] {
+        var input = SMCParameters()
+        input.key = key.code
+        input.data8 = Self.commandReadKey
+        input.keyInfo.dataSize = IOByteCount32(key.size)
+        input.keyInfo.dataType = key.type
+        guard let output = call(input) else {
+            throw MetricSourceError.readFailed("SMC key \(key.name)", code: 0)
+        }
+        let size = max(0, min(32, key.size))
+        return withUnsafeBytes(of: output.bytes) { Array($0.prefix(size)) }
+    }
+
+    private func call(_ input: SMCParameters) -> SMCParameters? {
+        var input = input
+        var output = SMCParameters()
+        var size = MemoryLayout<SMCParameters>.stride
+        let result = IOConnectCallStructMethod(
+            connection, Self.selectorHandleEvent,
+            &input, MemoryLayout<SMCParameters>.stride, &output, &size
+        )
+        // `result` is the kernel's verdict on the call; `output.result` is the
+        // SMC's own on the key, and a missing key fails only in the second.
+        guard result == kIOReturnSuccess, output.result == 0 else { return nil }
+        return output
+    }
+
+    // MARK: - Four-character codes
+
+    /// SMC keys and types are four-character codes packed into a `UInt32`.
+    static func code(_ name: String) -> UInt32 {
+        name.unicodeScalars.prefix(4).reduce(UInt32(0)) { $0 << 8 | UInt32($1.value) }
+    }
+
+    static func name(_ code: UInt32) -> String {
+        let bytes = [UInt8(code >> 24 & 0xFF), UInt8(code >> 16 & 0xFF),
+                     UInt8(code >> 8 & 0xFF), UInt8(code & 0xFF)]
+        let text = String(bytes: bytes.filter { $0 != 0 }, encoding: .ascii) ?? ""
+        // Type codes are space-padded ("flt "), key names are not.
+        return text.trimmingCharacters(in: .whitespaces)
+    }
+
+    // MARK: - The wire format
+
+    /// The one user-client selector the SMC exposes; the command lives in the
+    /// struct's `data8` field rather than in the selector.
+    private static let selectorHandleEvent: UInt32 = 2
+    private static let commandReadKey: UInt8 = 5
+    private static let commandKeyFromIndex: UInt8 = 8
+    private static let commandKeyInfo: UInt8 = 9
+
+    /// Must match the driver's struct byte for byte. The names are the ones
+    /// used in Apple's own SMC sample code, kept so the layout can be checked
+    /// against it.
+    private struct SMCParameters {
+        var key: UInt32 = 0
+        var versionMajor: UInt8 = 0
+        var versionMinor: UInt8 = 0
+        var versionBuild: UInt8 = 0
+        var versionReserved: UInt8 = 0
+        var versionRelease: UInt16 = 0
+        var limitVersion: UInt16 = 0
+        var limitLength: UInt16 = 0
+        var limitCPU: UInt32 = 0
+        var limitGPU: UInt32 = 0
+        var limitMemory: UInt32 = 0
+        var keyInfo = SMCKeyInfo()
+        var padding: UInt16 = 0
+        var result: UInt8 = 0
+        var status: UInt8 = 0
+        var data8: UInt8 = 0
+        var data32: UInt32 = 0
+        var bytes: (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
+                    UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
+                    UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
+                    UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8) =
+            (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+    }
+
+    private struct SMCKeyInfo {
+        var dataSize: IOByteCount32 = 0
+        var dataType: UInt32 = 0
+        var dataAttributes: UInt8 = 0
+    }
+}

--- a/Sources/MonitorSources/SMCSource.swift
+++ b/Sources/MonitorSources/SMCSource.swift
@@ -1,0 +1,232 @@
+import Foundation
+import MonitorCore
+
+/// Temperatures, fan speeds and power draw, from the SMC.
+///
+/// Every reading here is unprivileged: no helper tool, no root, no
+/// `powermetrics`. The cost is that the SMC publishes a couple of thousand
+/// four-character keys with no documentation of what any of them measure, so
+/// this file is mostly about deciding which keys are safe to name.
+///
+/// Two rules keep it honest:
+///
+///  - **Sensors are found, not assumed.** The key table is scanned once at
+///    launch for the temperature and fan ranges, and a metric exists only if
+///    this machine actually publishes sensors for it. A fanless Mac gets no
+///    fan card at all rather than a card reading zero, and an Intel Mac's
+///    `TC0P` lands in the same CPU metric as Apple silicon's `Tp01`.
+///  - **A key is only named if its meaning was checked.** The two power keys
+///    were confirmed against independent sources on Apple silicon: `PDTR`
+///    equals `VD0R × ID0R`, the DC input rail's own volts and amps, and `PHPS`
+///    tracks IOReport's Energy Model total for CPU + GPU + DRAM to within a
+///    few percent under load. Keys that merely look like power — and there are
+///    fifty — are left alone, because a plausible wrong watt figure is worse
+///    than no watt figure.
+///
+/// Fan speed is read-only here. Reading the SMC needs no privileges; *writing*
+/// it — setting a fan speed — does, and this type has no code path that writes.
+public final class SMCSource: MetricSource, @unchecked Sendable {
+    public let id = "sensors"
+
+    public static let cpuTemperature = MetricID("sensor.temperature.cpu")
+    public static let gpuTemperature = MetricID("sensor.temperature.gpu")
+    public static let storageTemperature = MetricID("sensor.temperature.storage")
+    public static let batteryTemperature = MetricID("sensor.temperature.battery")
+    public static let enclosureTemperature = MetricID("sensor.temperature.enclosure")
+    public static let ambientTemperature = MetricID("sensor.temperature.ambient")
+    public static let inputPower = MetricID("sensor.power.input")
+    public static let socPower = MetricID("sensor.power.soc")
+
+    public static func fanSpeed(_ index: Int) -> MetricID {
+        MetricID("sensor.fan.\(index).speed")
+    }
+
+    /// A metric and the keys that feed it.
+    private struct Sensor {
+        let descriptor: MetricDescriptor
+        let keys: [SMC.Key]
+        /// Temperatures take the hottest of their keys; everything else has
+        /// one key and takes it.
+        let hottest: Bool
+    }
+
+    private let smc: SMC?
+    private let sensors: [Sensor]
+
+    public let descriptors: [MetricDescriptor]
+
+    public init() {
+        guard let smc = try? SMC() else {
+            self.smc = nil
+            sensors = []
+            descriptors = []
+            log.notice("SMC unavailable; sensor metrics will not be offered")
+            return
+        }
+        self.smc = smc
+        sensors = Self.discover(with: smc)
+        descriptors = sensors.map(\.descriptor)
+    }
+
+    public func read(at timestamp: TimeInterval) throws -> SampleBatch {
+        guard let smc else { throw MetricSourceError.unavailable("SMC") }
+        guard !sensors.isEmpty else {
+            throw MetricSourceError.unavailable("SMC sensors")
+        }
+
+        var values: [MetricID: Double] = [:]
+        for sensor in sensors {
+            let readings = sensor.keys.compactMap { key in
+                smc.value(of: key).flatMap { Self.plausible($0, for: sensor) }
+            }
+            guard let value = sensor.hottest ? readings.max() : readings.first else { continue }
+            values[sensor.descriptor.id] = value
+        }
+
+        guard !values.isEmpty else {
+            throw MetricSourceError.unavailable("SMC sensor readings")
+        }
+        return SampleBatch(timestamp: timestamp, values: values)
+    }
+
+    // MARK: - Deciding what this machine has
+
+    /// Which keys feed which metric.
+    ///
+    /// Apple silicon numbers its die sensors `Tp…` for CPU cores, `Te…` for
+    /// efficiency cores on the machines that name them separately, and `Tg…`
+    /// for the GPU; Intel Macs use a handful of fixed names. Both are matched,
+    /// so this is one source rather than two.
+    ///
+    /// The Intel names are listed exactly rather than by prefix on purpose:
+    /// `TC` as a prefix would also swallow `TCHP`, the charger, and report a
+    /// warm power brick as a warm CPU.
+    private static func discover(with smc: SMC) -> [Sensor] {
+        let temperatures = (try? smc.keys(withPrefix: "T")) ?? []
+        func matching(prefixes: [String], exact: [String] = []) -> [SMC.Key] {
+            let wanted = temperatures.filter { key in
+                prefixes.contains(where: { key.name.hasPrefix($0) }) || exact.contains(key.name)
+            }
+            // Capped because reading a key costs an IOKit round trip and a
+            // machine can publish twenty CPU die sensors. Six of them, read
+            // twice a second forever, is a cost worth paying; twenty is not,
+            // and they move together anyway.
+            return Array(wanted.prefix(maximumKeysPerSensor))
+        }
+
+        var found: [Sensor] = []
+
+        func addTemperature(
+            _ metric: MetricID, _ name: String, keys: [SMC.Key]
+        ) {
+            guard !keys.isEmpty else { return }
+            found.append(Sensor(
+                descriptor: MetricDescriptor(
+                    id: metric, name: name, group: "Temperature", unit: .celsius,
+                    // Pinned rather than scaled to the data, for the same
+                    // reason a CPU chart is pinned to 0–100%: a room-
+                    // temperature machine auto-scaled to its own 2 °C of
+                    // drift looks like something is wrong. 110 is where
+                    // Apple silicon throttles, so the top of the chart means
+                    // something.
+                    nominalMaximum: temperatureCeiling
+                ),
+                keys: keys,
+                hottest: true
+            ))
+        }
+
+        addTemperature(
+            cpuTemperature, "CPU",
+            keys: matching(
+                prefixes: ["Tp", "Te"],
+                exact: ["TC0P", "TC0D", "TC0E", "TC0F", "TCXC", "TCAD"]
+            )
+        )
+        addTemperature(
+            gpuTemperature, "GPU",
+            keys: matching(prefixes: ["Tg"], exact: ["TG0P", "TG0D"])
+        )
+        addTemperature(
+            storageTemperature, "SSD",
+            keys: matching(prefixes: ["TH0"])
+        )
+        addTemperature(
+            batteryTemperature, "Battery",
+            keys: temperatures.filter { $0.name.hasPrefix("TB") && $0.name.hasSuffix("T") }
+        )
+        addTemperature(
+            enclosureTemperature, "Enclosure",
+            keys: temperatures.filter { $0.name.hasPrefix("Ts") && $0.name.hasSuffix("P") }
+        )
+        addTemperature(
+            ambientTemperature, "Ambient",
+            keys: temperatures.filter { $0.name.hasPrefix("TA") && $0.name.hasSuffix("P") }
+        )
+
+        for (metric, name, key) in [
+            (inputPower, "Input", "PDTR"), (socPower, "SoC", "PHPS"),
+        ] {
+            guard let key = smc.key(named: key) else { continue }
+            found.append(Sensor(
+                descriptor: MetricDescriptor(
+                    id: metric, name: name, group: "Power", unit: .watts
+                ),
+                keys: [key],
+                hottest: false
+            ))
+        }
+
+        found.append(contentsOf: fans(with: smc))
+        return found
+    }
+
+    /// Fans, if this machine has any.
+    ///
+    /// `F0Ac` is the first fan's actual speed and `F0Mx` its maximum, which
+    /// becomes the top of the chart — a fan at 2000 rpm means nothing until
+    /// you know whether it tops out at 2500 or 6000. Machines are numbered
+    /// from zero and the count stops at the first gap rather than trusting
+    /// `FNum`, which is missing on some models that do have fans.
+    private static func fans(with smc: SMC) -> [Sensor] {
+        var found: [Sensor] = []
+        for index in 0..<maximumFans {
+            guard let key = smc.key(named: "F\(index)Ac") else { break }
+            let maximum = smc.key(named: "F\(index)Mx").flatMap { smc.value(of: $0) }
+            found.append(Sensor(
+                descriptor: MetricDescriptor(
+                    id: fanSpeed(index + 1),
+                    // One-based in the UI: nobody calls the first fan "Fan 0".
+                    name: "Fan \(index + 1)",
+                    group: "Fans",
+                    unit: .rpm,
+                    nominalMaximum: maximum.flatMap { $0 > 0 ? $0 : nil }
+                ),
+                keys: [key],
+                hottest: false
+            ))
+        }
+        return found
+    }
+
+    /// Rejects readings that cannot be what the sensor claims to measure.
+    ///
+    /// The SMC reports 0 for a sensor a model does not populate — the key
+    /// exists, the hardware behind it does not — and an idle die is never 0 °C
+    /// in a room, so a zero temperature is a missing sensor rather than a cold
+    /// one. Power genuinely is zero when a laptop is running on battery, so
+    /// zero watts is kept.
+    private static func plausible(_ value: Double, for sensor: Sensor) -> Double? {
+        switch sensor.descriptor.unit {
+        case .celsius: (value > 0 && value < 150) ? value : nil
+        case .watts: (value >= 0 && value < 1000) ? value : nil
+        case .rpm: (value >= 0 && value < 20000) ? value : nil
+        default: value
+        }
+    }
+
+    /// Where Apple silicon starts throttling, and so the top of a chart.
+    private static let temperatureCeiling = 110.0
+    private static let maximumKeysPerSensor = 6
+    private static let maximumFans = 4
+}

--- a/Sources/MonitorSources/SMCSource.swift
+++ b/Sources/MonitorSources/SMCSource.swift
@@ -56,15 +56,15 @@ public final class SMCSource: MetricSource, @unchecked Sendable {
     public let descriptors: [MetricDescriptor]
 
     public init() {
-        guard let smc = try? SMC() else {
-            self.smc = nil
+        guard let connection = try? SMC() else {
+            smc = nil
             sensors = []
             descriptors = []
             log.notice("SMC unavailable; sensor metrics will not be offered")
             return
         }
-        self.smc = smc
-        sensors = Self.discover(with: smc)
+        smc = connection
+        sensors = Self.discover(with: connection)
         descriptors = sensors.map(\.descriptor)
     }
 

--- a/Sources/MonitorSources/SourceRegistry.swift
+++ b/Sources/MonitorSources/SourceRegistry.swift
@@ -13,6 +13,7 @@ public enum SourceRegistry {
             DiskSource(),
             NetworkSource(),
             GPUSource(),
+            SMCSource(),
         ]
     }
 

--- a/Sources/MonitorUI/ChartCard.swift
+++ b/Sources/MonitorUI/ChartCard.swift
@@ -43,27 +43,62 @@ public struct ChartCard: View {
         )
     }
 
+    /// Above this many series the legend gets its own line rather than sharing
+    /// one with the title.
+    ///
+    /// Three is what fits beside a title at the narrowest column the grid
+    /// makes. Memory has seven, and squeezed into the space left over they
+    /// wrapped four rows deep — or, before the legend could wrap at all,
+    /// compressed into a row of ellipses, which is what this fixes.
+    private static let inlineLegendLimit = 3
+
     private var header: some View {
-        HStack(alignment: .firstTextBaseline) {
-            Text(title)
-                .font(.system(
-                    size: Theme.Layout.cardTitle,
-                    weight: .semibold,
-                    design: .rounded
-                ))
-                .foregroundStyle(Theme.readout)
-                .lineLimit(1)
-                .fixedSize()
-            Spacer(minLength: 4)
-            // Current values in the header rather than in a legend below the
-            // chart: the number and its colour swatch belong together, and it
-            // saves a row of chrome per card.
+        // Two arrangements, not one that adapts: a card with two series should
+        // keep the compact single line, and only the crowded card should spend
+        // a second line on chrome.
+        VStack(alignment: .leading, spacing: 4) {
+            if series.count > Self.inlineLegendLimit {
+                titleText
+                legend
+            } else {
+                HStack(alignment: .top, spacing: 8) {
+                    titleText
+                    Spacer(minLength: 0)
+                    legend
+                }
+            }
+        }
+    }
+
+    private var titleText: some View {
+        Text(title)
+            .font(.system(
+                size: Theme.Layout.cardTitle,
+                weight: .semibold,
+                design: .rounded
+            ))
+            .foregroundStyle(Theme.readout)
+            .lineLimit(1)
+            .fixedSize()
+    }
+
+    /// Current values in the header rather than in a legend below the chart:
+    /// the number and its colour swatch belong together, and it saves a row of
+    /// chrome per card.
+    ///
+    /// Wrapped rather than laid out in one line. An `HStack` given less width
+    /// than its children want compresses them, and compressed legend entries
+    /// truncate to nothing readable; `FlowLayout` spends card height instead,
+    /// which is the cheaper of the two.
+    private var legend: some View {
+        FlowLayout(horizontalSpacing: 10, verticalSpacing: 3) {
             ForEach(Array(series.enumerated()), id: \.offset) { index, entry in
                 if let latest = entry.points.last {
                     legendEntry(entry.descriptor, index: index, latest: latest)
                 }
             }
         }
+        .fixedSize(horizontal: false, vertical: true)
     }
 
     /// One legend entry: colour swatch, series name, current value.

--- a/Sources/MonitorUI/DashboardView.swift
+++ b/Sources/MonitorUI/DashboardView.swift
@@ -37,7 +37,16 @@ public struct DashboardView: View {
             VStack(alignment: .leading, spacing: Theme.Layout.gridSpacing) {
                 gaugeWall
                 resizeHandle
-                charts
+                charts(Self.performanceGroupOrder)
+                // Sensors are a different question from performance. What the
+                // machine is doing and how hot it is getting are read at
+                // different moments and for different reasons, and mixing them
+                // into one grid means hunting for the temperature card among
+                // the throughput ones.
+                if !groups(in: Self.sensorGroupOrder).isEmpty {
+                    sectionRule
+                    charts(Self.sensorGroupOrder)
+                }
             }
             .padding(Theme.Layout.pagePadding)
         }
@@ -204,29 +213,44 @@ public struct DashboardView: View {
     /// needle cannot tell you a transfer has been running for a minute; and
     /// that "Disk Ops", "Network Packets" and "Memory Paging" are diagnostic
     /// detail that belongs in `monitorctl`, not on a dashboard you glance at.
-    private static let chartGroupOrder = [
+    private static let performanceGroupOrder = [
         "CPU", "CPU Cores", "Memory", "Disk", "Network", "GPU", "Disk Latency",
     ]
 
-    private var chartGroups: [(name: String, metrics: [MetricID])] {
+    /// What the machine is doing to itself: heat, fans, watts. Every one of
+    /// these is missing on some Mac — a fanless laptop has no fans, a desktop
+    /// has no battery — so the section draws only what this machine reports and
+    /// disappears entirely on a machine that reports none of it.
+    private static let sensorGroupOrder = ["Temperature", "Fans", "Power"]
+
+    private func groups(in order: [String]) -> [(name: String, metrics: [MetricID])] {
         let available = Dictionary(
             model.groups().map { ($0.name, $0.metrics) },
             uniquingKeysWith: { first, _ in first }
         )
-        return Self.chartGroupOrder.compactMap { name in
+        return order.compactMap { name in
             guard let metrics = available[name], !metrics.isEmpty else { return nil }
             return (name: name, metrics: metrics)
         }
     }
 
-    private var charts: some View {
+    /// The line between the two sections. Deliberately the same rule as the one
+    /// under the gauges, minus the drag: one kind of divider on the panel.
+    private var sectionRule: some View {
+        Rectangle()
+            .fill(Theme.panelEdge)
+            .frame(height: 1)
+            .padding(.vertical, 2)
+    }
+
+    private func charts(_ order: [String]) -> some View {
         LazyVGrid(
             columns: [GridItem(
                 .adaptive(minimum: Theme.Layout.chartMinimum), spacing: Theme.Layout.gridSpacing
             )],
             spacing: Theme.Layout.gridSpacing
         ) {
-            ForEach(chartGroups, id: \.name) { group in
+            ForEach(groups(in: order), id: \.name) { group in
                 ChartCard(
                     title: group.name,
                     series: group.metrics.compactMap { metric in

--- a/Sources/MonitorUI/FlowLayout.swift
+++ b/Sources/MonitorUI/FlowLayout.swift
@@ -22,10 +22,10 @@ struct FlowLayout: Layout {
     func sizeThatFits(
         proposal: ProposedViewSize, subviews: Subviews, cache _: inout ()
     ) -> CGSize {
-        let rows = self.rows(within: proposal.width ?? .infinity, subviews: subviews)
-        let width = rows.map(\.width).max() ?? 0
-        let height = rows.map(\.height).reduce(0, +)
-            + verticalSpacing * CGFloat(max(0, rows.count - 1))
+        let packed = rows(within: proposal.width ?? .infinity, subviews: subviews)
+        let width = packed.map(\.width).max() ?? 0
+        let height = packed.map(\.height).reduce(0, +)
+            + verticalSpacing * CGFloat(max(0, packed.count - 1))
         return CGSize(width: width, height: height)
     }
 

--- a/Sources/MonitorUI/FlowLayout.swift
+++ b/Sources/MonitorUI/FlowLayout.swift
@@ -1,0 +1,83 @@
+import SwiftUI
+
+/// Lays subviews out left to right, wrapping to a new row when the next one
+/// would not fit.
+///
+/// Exists for the legend in a `ChartCard` header. An `HStack` cannot wrap: given
+/// less width than its children want it compresses them instead, and a row of
+/// legend entries under compression turns into a row of ellipses — which is
+/// exactly what the Memory card became, with seven series in a four-column
+/// grid. Wrapping trades a few points of card height for entries that are
+/// either legible or not drawn at all, and height is the cheaper of the two.
+///
+/// Rows are packed greedily and the last row is not stretched: the entries are
+/// read left to right, so ragged right is correct and justification would put
+/// arbitrary gaps between a swatch and the series it belongs to.
+struct FlowLayout: Layout {
+    /// Horizontal gap between entries in a row.
+    var horizontalSpacing: CGFloat = 10
+    /// Vertical gap between rows.
+    var verticalSpacing: CGFloat = 3
+
+    func sizeThatFits(
+        proposal: ProposedViewSize, subviews: Subviews, cache _: inout ()
+    ) -> CGSize {
+        let rows = self.rows(within: proposal.width ?? .infinity, subviews: subviews)
+        let width = rows.map(\.width).max() ?? 0
+        let height = rows.map(\.height).reduce(0, +)
+            + verticalSpacing * CGFloat(max(0, rows.count - 1))
+        return CGSize(width: width, height: height)
+    }
+
+    func placeSubviews(
+        in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache _: inout ()
+    ) {
+        var y = bounds.minY
+        for row in rows(within: proposal.width ?? bounds.width, subviews: subviews) {
+            var x = bounds.minX
+            for index in row.indices {
+                let size = subviews[index].sizeThatFits(.unspecified)
+                subviews[index].place(
+                    // Baselines within a row line up when the entries are all
+                    // the same type size, which they are; centring keeps a
+                    // taller entry from dragging the row's text off the line.
+                    at: CGPoint(x: x, y: y + (row.height - size.height) / 2),
+                    proposal: ProposedViewSize(size)
+                )
+                x += size.width + horizontalSpacing
+            }
+            y += row.height + verticalSpacing
+        }
+    }
+
+    private struct Row {
+        var indices: [Int] = []
+        var width: CGFloat = 0
+        var height: CGFloat = 0
+    }
+
+    /// Greedy packing. An entry wider than the whole line still gets a row of
+    /// its own rather than being dropped — overflowing is more useful than
+    /// vanishing.
+    private func rows(within width: CGFloat, subviews: Subviews) -> [Row] {
+        var rows: [Row] = []
+        var row = Row()
+        for index in subviews.indices {
+            let size = subviews[index].sizeThatFits(.unspecified)
+            let advance = row.indices.isEmpty ? size.width : size.width + horizontalSpacing
+            if !row.indices.isEmpty, row.width + advance > width {
+                rows.append(row)
+                row = Row()
+                row.indices = [index]
+                row.width = size.width
+                row.height = size.height
+            } else {
+                row.indices.append(index)
+                row.width += advance
+                row.height = max(row.height, size.height)
+            }
+        }
+        if !row.indices.isEmpty { rows.append(row) }
+        return rows
+    }
+}

--- a/Sources/MonitorUI/Theme.swift
+++ b/Sources/MonitorUI/Theme.swift
@@ -50,11 +50,12 @@ public enum Theme {
         public static let chartMinimum = 260.0
         /// The plot area alone, not counting the card's header and padding.
         ///
-        /// Sized so that two rows of cards plus the gauge wall fill a 1180×900
-        /// window rather than leaving the bottom third empty. It is a *minimum*,
-        /// so a shorter window scrolls — which is the right way round: the
-        /// charts stay readable and the window decides how many you see at once.
-        public static let chartMinHeight = 250.0
+        /// Half what it was, because the panel now has two sections rather than
+        /// one: performance above the rule and sensors below it. At the old
+        /// height the sensor cards were always below the fold, and a chart you
+        /// have to scroll to reach is a chart you stop looking at. It is still a
+        /// *minimum*, so a shorter window scrolls rather than squeezing.
+        public static let chartMinHeight = 125.0
 
         public static let gridSpacing = 12.0
         public static let pagePadding = 14.0

--- a/Tests/MonitorCoreTests/GaugeScaleTests.swift
+++ b/Tests/MonitorCoreTests/GaugeScaleTests.swift
@@ -275,6 +275,19 @@ struct FormatTests {
         #expect(Format.unitLabel(value, unit: .bytesPerSecond) == "MB/s")
     }
 
+    /// Sensor units carry their unit in the text, because a temperature and a
+    /// fan speed sharing an axis is exactly how "88" gets read as rpm.
+    @Test("sensor readings name their unit")
+    func sensorUnits() {
+        #expect(Format.value(88.4, unit: .celsius) == "88 °C")
+        #expect(Format.value(18.42, unit: .watts) == "18.4 W")
+        #expect(Format.value(2480.6, unit: .rpm) == "2481 rpm")
+        #expect(Format.unitLabel(2480, unit: .rpm) == "rpm")
+        // The reserved slot has to be at least as wide as the reading, or a
+        // legend entry grows as its value does and shoves the rest sideways.
+        #expect(Format.widestValue(unit: .rpm).count >= Format.value(9999, unit: .rpm).count)
+    }
+
     @Test("scales durations to readable units")
     func durations() {
         #expect(Format.duration(0.04) == "40.0 ms")

--- a/Tests/MonitorSourcesTests/SourceTests.swift
+++ b/Tests/MonitorSourcesTests/SourceTests.swift
@@ -234,6 +234,52 @@ struct SourceTests {
         }
     }
 
+    /// Sensors are the one source whose metric list differs per machine — a
+    /// fanless laptop has no fans, a Mac mini has no battery — so what is
+    /// asserted is that whatever it *does* declare, it can read, in range.
+    @Test("every sensor a machine declares reads a plausible value")
+    func sensors() throws {
+        let source = SMCSource()
+        guard !source.descriptors.isEmpty else { return } // no SMC on this machine
+        #expect(source.descriptors.allSatisfy {
+            ["Temperature", "Power", "Fans"].contains($0.group)
+        })
+
+        let batch = try source.read(at: 0)
+        let declared = Set(source.descriptors.map(\.id))
+        #expect(batch.samples.allSatisfy { declared.contains($0.metric) },
+                "a sample arrived for a metric that was never declared")
+
+        let units = Dictionary(
+            source.descriptors.map { ($0.id, $0.unit) }, uniquingKeysWith: { first, _ in first }
+        )
+        for sample in batch.samples {
+            switch units[sample.metric] {
+            // Nothing in a room is at absolute zero, and silicon that reached
+            // 150 °C would have shut the machine down.
+            case .celsius: #expect(sample.value > 0 && sample.value < 150,
+                                   "\(sample.metric) = \(sample.value) °C")
+            // Zero watts is real on a laptop running from its battery.
+            case .watts: #expect(sample.value >= 0 && sample.value < 1000,
+                                 "\(sample.metric) = \(sample.value) W")
+            case .rpm: #expect(sample.value >= 0 && sample.value < 20000,
+                               "\(sample.metric) = \(sample.value) rpm")
+            default: Issue.record("sensor \(sample.metric) has an unexpected unit")
+            }
+        }
+    }
+
+    /// The key name is the whole addressing scheme, so a code that does not
+    /// survive the round trip reads a different sensor than the one asked for.
+    @Test("SMC keys round-trip through their four-character code")
+    func smcKeyCodes() {
+        for name in ["Tp00", "TC0P", "F0Ac", "PDTR", "#KEY"] {
+            #expect(SMC.name(SMC.code(name)) == name)
+        }
+        // Type codes are space-padded on the wire and named without it.
+        #expect(SMC.name(SMC.code("flt ")) == "flt")
+    }
+
     @Test("one failing source does not stop the others")
     func samplerIsolatesFailures() async {
         struct Broken: MetricSource {

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ The index. Each file below is the reference for one part of the app.
 | [architecture.md](architecture.md) | The four libraries, what depends on what, and why the boundaries are where they are |
 | [metrics.md](metrics.md) | Every metric, its unit and kind, and where the number comes from |
 | [sources.md](sources.md) | Writing a new `MetricSource`, and the system APIs each existing one uses |
+| [sensors.md](sensors.md) | What a Mac exposes about heat, fans and power, what it costs to read, and what needs root |
 | [ui.md](ui.md) | Gauges vs charts, the auto-ranging dial, and the rules that keep a chart honest |
 | [storage.md](storage.md) | Why v1 writes nothing to disk, and the SSD-endurance arithmetic for when it does |
 | [roadmap.md](roadmap.md) | What is deliberately not in v1, in the order it is likely to arrive |

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -169,6 +169,33 @@ list of known spellings and a miss reports the source as unavailable rather than
 guessing. Utilization takes the maximum across accelerators, not the mean: with
 two GPUs, one pinned and one idle is not "half loaded".
 
+## Sensors — `SMCSource`
+
+The SMC, read unprivileged. Which metrics exist depends on the machine: a
+fanless laptop declares no fans, a desktop no battery temperature. Group
+`Temperature`, `Power` and `Fans` sit in their own section of the window, below
+the rule.
+
+| id | Meaning |
+|----|---------|
+| `sensor.temperature.cpu` | hottest CPU die sensor (`Tp…`/`Te…`, Intel `TC0P`) |
+| `sensor.temperature.gpu` | hottest GPU die sensor (`Tg…`, Intel `TG0P`) |
+| `sensor.temperature.storage` | internal SSD (`TH0…`) |
+| `sensor.temperature.battery` | battery pack (`TB…T`) |
+| `sensor.temperature.enclosure` | the case (`Ts…P`) |
+| `sensor.temperature.ambient` | intake air (`TA…P`), Intel Macs mostly |
+| `sensor.power.input` | DC input power (`PDTR`) |
+| `sensor.power.soc` | SoC package power (`PHPS`) |
+| `sensor.fan.N.speed` | fan N's actual speed (`FNAc`), full scale from `FNMx` |
+
+Temperatures report the **hottest** sensor in the group rather than the mean,
+because the hot spot is what throttles the machine. A key reading exactly 0 is
+treated as a sensor the model does not populate, not as a cold one.
+
+Only two of the SMC's fifty-five power keys are named, because only two could
+be checked against an independent measurement — `docs/sensors.md` records how,
+and what else a Mac exposes that this does not read.
+
 ## Units
 
 | Unit | Axis behaviour |
@@ -179,7 +206,8 @@ two GPUs, one pinned and one idle is not "half loaded".
 | `bitsPerSecond` | decimal units, **always Mbit/s** — never rescaled |
 | `operationsPerSecond`, `count`, `hertz` | scaled to the data |
 | `seconds` | µs / ms / s by magnitude |
-| `celsius`, `watts` | declared, not yet produced by any source |
+| `celsius` | pinned to 0–110 °C, the point where Apple silicon throttles |
+| `watts`, `rpm` | scaled to the data; a fan to its own maximum when the SMC reports one |
 
 Throughput is pinned to mega-units at every magnitude, including `0.02 MB/s`
 and `5000 MB/s`. Auto-scaling suits an axis and not an instrument: the unit

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -40,9 +40,16 @@ a table, not a gauge.
 
 ## More sources
 
-- **Temperature and power.** Wanted, and the honest answer is that both need
-  either root (`powermetrics`) or private API (IOReport). Worth revisiting; see
-  the discussion in `GPUSource.swift` for the same trade.
+- ~~**Temperature and power.**~~ Done, and the assumption recorded here — that
+  both need root or private API — turned out to be wrong. The SMC gives
+  temperatures, fan speeds and two verified power rails to an ordinary user;
+  `powermetrics` and IOReport are only needed for what the SMC does not carry
+  (per-component watts, clock frequency). `docs/sensors.md` has the survey.
+- **Per-component power and clock frequency.** What is genuinely left behind
+  the private-API line: IOReport's Energy Model has per-core, GPU, ANE and DRAM
+  energy, and its P-state residencies are how an average clock is derived.
+  Same trade as `GPUSource.swift` discusses — an App Store build could not ship
+  it.
 - **Per-volume disk breakout.** Today all block devices are summed. The registry
   walk already visits each device separately, so this is mostly a UI question.
 - **Per-interface network breakout.** Same shape as above.

--- a/docs/sensors.md
+++ b/docs/sensors.md
@@ -1,0 +1,130 @@
+# Sensors
+
+What a Mac will tell you about its own heat, fans and power, what each route
+costs, and which of them need privileges.
+
+Surveyed on a MacBook Air (13-inch, M5) — `Mac17,3`, macOS 26.6 — running as an
+ordinary user with no helper tool and no `sudo`. Counts are from that machine;
+the *routes* are the same on any Mac.
+
+## The short answer
+
+**Temperature, power and fan speed are all readable unprivileged.** Nothing in
+the sensor section needs root, an installer, or a privileged helper.
+
+Root is needed for exactly two things, and the app does neither:
+
+| Wants root | Why we do not need it |
+|-----------|-----------------------|
+| `powermetrics` | It reads the same SMC and IOReport data the app reads directly |
+| *Writing* SMC keys — setting a fan speed | This is a monitor. `SMC` has no write path |
+
+## The four routes
+
+### 1. SMC — what the app uses
+
+`IOServiceOpen` on `AppleSMC`, then one struct-method selector. Undocumented,
+unprivileged, and present on every Mac including Intel.
+
+- **2294 keys** on this machine: 148 temperatures (`T…`), 55 power (`P…`), 44
+  current (`I…`), 40 voltage (`V…`), 254 battery (`B…`), **0 fans** — this model
+  is fanless, and the fan keys are simply absent rather than reading zero.
+- **Cost**: ~350 µs per key for a cold read (one call for the key's type and
+  size, one for the bytes), ~175 µs once the type is cached. Reading all 148
+  temperatures every tick would cost 26 ms — which is why `SMCSource` caps each
+  metric at six sensors and reads about twenty keys in total, ~4 ms per tick.
+- **Enumerating** every key name takes 314 ms, far too long to spend at launch.
+  The key table is sorted, so `SMC.keys(withPrefix:)` binary-searches to the
+  start of the `T` range and walks it: ~30 ms, once, at startup.
+- **Types** are a fixed-point zoo: `flt` (little-endian float, Apple silicon),
+  `sp78` and `fp88` (Intel temperatures), `fpe2` (Intel fan rpm), `ui8`…`ui32`.
+  Decoding one as another produces a number that looks like a temperature.
+
+### 2. IORegistry — `AppleSmartBattery`
+
+Public IOKit, no privileges. Charge, cycle count, design capacity, pack voltage
+and amperage, adapter details, pack temperature, and a `PowerTelemetryData`
+dictionary with `SystemPowerIn` in mW.
+
+Not used for live power: the telemetry values are accumulator-backed and were
+observed unchanged (5332 mW) across a 30× swing in real load. It is the right
+source for *battery state*, which is a candidate for a later card, not for
+watts now.
+
+### 3. IOReport — surveyed, deliberately unused
+
+`/usr/lib/libIOReport.dylib`, resolved by `dlsym`. **8653 channels** are
+visible, subscribable and delta-able as an ordinary user — no entitlement was
+needed for any of it:
+
+- `Energy Model` — 167 channels of energy in mJ: per-core (`ECPU0…5`,
+  `PCPU0…3`), per-cluster, `GPU`, `ANE`, `DRAM`, `DISP`, `ISP`, `PCIe`. This is
+  where a true per-component watt figure lives.
+- `CPU Stats / CPU Complex Performance States` — P-state residencies, which is
+  how you get an average clock frequency.
+- `GPU Stats`, `AMC Stats / Perf Counters` — GPU residency and memory bandwidth.
+
+It is not used for the same reason `GPUSource` gives: it is a private framework,
+and depending on it would rule out ever shipping through the App Store. Its
+value here was as an *oracle* — an independent measurement to check the SMC key
+names against (below).
+
+### 4. Public API — free, already available
+
+`ProcessInfo.thermalState` (nominal / fair / serious / critical) and
+`isLowPowerModeEnabled`. Neither is a sensor reading, but both explain one: a
+machine at `serious` is being throttled, which is the reason a chart flattened.
+
+## What the app reports
+
+`SMCSource` declares a metric only if this machine publishes sensors for it, so
+a fanless laptop shows no Fans card at all and an Intel Mac's `TC0P` feeds the
+same CPU metric as Apple silicon's `Tp01`.
+
+| Metric | Keys | Notes |
+|--------|------|-------|
+| `sensor.temperature.cpu` | `Tp…`, `Te…`; Intel `TC0P`/`TC0D`/`TCXC` | hottest of up to six die sensors |
+| `sensor.temperature.gpu` | `Tg…`; Intel `TG0P`/`TG0D` | |
+| `sensor.temperature.storage` | `TH0…` | internal SSD |
+| `sensor.temperature.battery` | `TB…T` | |
+| `sensor.temperature.enclosure` | `Ts…P` | the case, i.e. what your hands feel |
+| `sensor.temperature.ambient` | `TA…P` | absent on this machine |
+| `sensor.power.input` | `PDTR` | DC in |
+| `sensor.power.soc` | `PHPS` | package: CPU + GPU + memory |
+| `sensor.fan.N.speed` | `FNAc`, scaled by `FNMx` | absent on this machine |
+
+Temperatures take the **hottest** of their sensors rather than the mean: the
+hot spot is what throttles the machine, and averaging fourteen die sensors
+hides the one that is about to.
+
+Charts are pinned to 0–110 °C rather than auto-scaled, for the same reason CPU
+load is pinned to 0–100%: a chart scaled to 2 °C of drift makes a cool machine
+look like a fire.
+
+## Why those two power keys, and not the other fifty-three
+
+A plausible wrong watt figure is worse than no watt figure, so a `P…` key is
+only named if its meaning was checked against something independent. Two were:
+
+- **`PDTR` = DC input power.** It equals `VD0R × ID0R`, the input rail's own
+  voltage and current keys, to three decimal places at both idle (19.947 V ×
+  0.291 A = 5.81 W) and load (19.679 × 1.790 = 35.23 W).
+- **`PHPS` = SoC package power.** Under an eight-thread load it read 18.1 W
+  while IOReport's Energy Model independently reported 17.34 W of CPU energy
+  plus 0.17 W DRAM, 0.14 W DCS, 0.09 W display and 0.03 W GPU — 17.8 W, within
+  2%. At idle both fall below 1 W together.
+
+One trap worth recording: **`PSTR` is `PDTR` one sample late.** Read them in the
+same tick and `PSTR(t)` is exactly, bit for bit, `PDTR(t−1)`. Charting both
+would draw the same series twice and make a lag look like a second measurement.
+
+## What is deliberately not read
+
+- The other ~2270 SMC keys. Most are configuration, limits, or rails whose
+  meaning cannot be checked, and `TPDD`, `Tz11` and friends read a flat 0 —
+  the key exists, the hardware behind it does not. A zero temperature is
+  therefore treated as a missing sensor, not a cold one.
+- Per-component watts (CPU vs GPU vs ANE) — that needs IOReport.
+- CPU clock frequency — same.
+- Battery charge, health and time remaining — `AppleSmartBattery` has all of it,
+  and it belongs on a battery card rather than in a sensor sweep.

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -146,6 +146,36 @@ since chart width is what the time axis needs. `chartMinHeight` is a *minimum*,
 so a shorter window scrolls rather than squashing the charts — the right way
 round: the charts stay readable and the window decides how many you see at once.
 
+`chartMinHeight` later halved to 125pt, when the panel gained a second section.
+Sensors sit below performance, and at the old height every sensor card was below
+the fold — a chart you have to scroll to reach is one you stop looking at.
+
+## Two sections, one rule between them
+
+Performance above, sensors below, separated by the same 1pt rule that sits under
+the gauges. What the machine is doing and how hot it is getting are read at
+different moments and for different reasons, and in one grid the temperature
+card is something you hunt for among the throughput cards.
+
+The sensor section draws only what the machine reports and disappears entirely
+on a machine that reports none of it, which is why it is `if !groups(in:).
+isEmpty` rather than a fixed row: a fanless MacBook Air has no fans, and an
+empty card under a rule is worse than no rule.
+
+## Legends wrap; they do not shrink
+
+A card's legend is the series' colour, name and current value, laid out with
+`FlowLayout` — a `Layout` that packs entries left to right and wraps. An
+`HStack` given less width than its children want compresses them instead, and a
+compressed legend entry truncates: Memory's seven series in a four-column grid
+became a row of coloured dots followed by ellipses, which is what prompted this.
+
+Cards with more than three series put the legend on its own line so it gets the
+card's full width rather than what is left beside the title. Two- and
+three-series cards keep the compact single line, because spending a second line
+of chrome on a Disk card that reads `Read 0.36 MB/s  Write 0.00 MB/s` buys
+nothing.
+
 ## The gauge wall is resizable
 
 The rule between the dials and the charts is a drag handle. Pull it down and the


### PR DESCRIPTION
Four changes that arrived together because the last one needed the first three.

## Legends wrap instead of truncating

An `HStack` given less width than its children want compresses them, so Memory's seven series in a four-column grid rendered as coloured dots followed by ellipses. `FlowLayout` packs entries left to right and wraps. Cards with more than three series put the legend on its own line so it gets the card's full width rather than what is left beside the title; two- and three-series cards keep the compact single line.

## Charts are half as tall

`chartMinHeight` 250 → 125. The panel now has two sections, and at the old height every sensor card was below the fold.

## Sensors are their own section

Performance above, sensors below, separated by the same 1pt rule that sits under the gauges. The section disappears entirely on a machine that reports no sensors.

## `SMCSource` — temperature, fans and power, unprivileged

This contradicts what `docs/roadmap.md` assumed, that both needed root or private API. They do not: the SMC gives all of it to an ordinary user. Root is needed only for `powermetrics` and to *write* a key (setting a fan speed), which this cannot do.

Metrics are found rather than assumed. The key table is scanned at launch — binary-searched, since reading all 2294 key names costs 314 ms — and a metric exists only if this machine publishes sensors for it. A fanless Mac shows no Fans card rather than one reading zero, and an Intel `TC0P` feeds the same CPU metric as Apple silicon's `Tp01`.

Only two of the SMC's fifty-five power keys are named, because only two could be checked against an independent measurement:

- `PDTR` = `VD0R × ID0R`, the input rail's own volts and amps, to three decimals at idle and under load.
- `PHPS` = 18.1 W under an eight-thread load, against IOReport's Energy Model reporting 17.8 W for CPU + GPU + DRAM + display.

One trap recorded: `PSTR(t)` is bit-for-bit `PDTR(t−1)`. Charting both would have drawn one series twice and made a lag look like a second measurement.

`docs/sensors.md` is the full survey — the four routes (SMC, `AppleSmartBattery`, IOReport, public API), what each costs, and why IOReport stays unused despite being subscribable without privileges.

## Verification

`swift build`, `swift test` (75 tests), the release build and `swiftformat --lint` all pass. Checked in the app and via `monitorctl read`: CPU 88 °C, GPU 75 °C, SSD 52 °C, Battery 34 °C, Enclosure 31 °C, Input 18.4 W, SoC 9.5 W. Sensor reads cost ~20 keys / ~4 ms per tick.