### PR TITLE
Give the app an icon and a real About panel, and publish it on release

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,86 @@
+name: Package
+
+# Builds monitor.app, zips it, and — when it is given a release tag — attaches
+# the zip to that release.
+#
+# It is a reusable workflow rather than a step in the release workflow because
+# a release can begin two ways: a merge to main that bumps the version, or a
+# release published by hand from the GitHub UI. Both end here, so the artifact
+# is built exactly one way.
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: Release tag to attach the zip to. Omit to only build it.
+        required: false
+        type: string
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  package:
+    name: Build and zip monitor.app
+    # A self-hosted runner — a Mac on a desk. Only a merge to main, a published
+    # release or a manual run reaches this workflow, and all three need write
+    # access to the repository, so there is no fork path to guard against.
+    runs-on: [self-hosted, macOS, ARM64]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # A release built from a tag must be built from that tag's code. The
+          # default checkout of a `release` event is the tag already, but being
+          # explicit means a hand-made release on an old commit still ships
+          # that commit rather than the tip of main.
+          ref: ${{ inputs.tag || github.ref }}
+
+      - name: Swift version
+        run: swift --version
+
+      # A published zip must not contain code that fails its own gates, and a
+      # tag can point anywhere — including at a commit that never ran CI.
+      - name: Test
+        run: swift test
+
+      - name: Build monitor.app
+        run: Scripts/make-app.sh
+
+      # ditto, not zip: a bundle holds symlinks and extended attributes, and
+      # zip flattens them. This is the command Apple's own notarization
+      # instructions use.
+      - name: Package
+        id: package
+        run: |
+          version="$(sed -n 's/.*static let string = "\(.*\)".*/\1/p' \
+              Sources/MonitorCore/Version.swift)"
+          name="monitor-${version}.zip"
+          ditto -c -k --keepParent .build/monitor.app "$name"
+          echo "name=$name" >> "$GITHUB_OUTPUT"
+          echo "sha=$(shasum -a 256 "$name" | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+          ls -lh "$name"
+
+      # Uploaded on every run, released or not, so a manual run is a way to get
+      # a build without publishing anything.
+      - uses: actions/upload-artifact@v4
+        with:
+          name: monitor-app
+          path: ${{ steps.package.outputs.name }}
+          if-no-files-found: error
+
+      - name: Attach to release
+        if: inputs.tag != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ inputs.tag }}
+          ZIP: ${{ steps.package.outputs.name }}
+          SHA: ${{ steps.package.outputs.sha }}
+        run: |
+          if ! command -v gh >/dev/null 2>&1; then brew install gh; fi
+          # The checksum rides along as a file rather than a line in the notes:
+          # re-running a failed publish then replaces it instead of appending a
+          # second copy.
+          echo "$SHA  $ZIP" > "$ZIP.sha256"
+          # --clobber so a re-run replaces the assets rather than failing on a
+          # name that already exists.
+          gh release upload "$TAG" "$ZIP" "$ZIP.sha256" --clobber

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,113 @@
+name: Release
+
+# Two ways a release begins, and both end in the Package workflow:
+#
+#   1. A pull request lands on main that bumps `MonitorVersion.string`. This
+#      workflow tags that commit and publishes the release.
+#   2. Somebody publishes a release by hand from the GitHub UI.
+#
+# So shipping is a line in a diff, reviewed like any other change. A merge that
+# does not touch the version publishes nothing — most merges should not ship a
+# release, and a docs typo is not a new version.
+#
+# A release created here by `gh` does *not* fire the `release: published`
+# event, because GitHub deliberately refuses to let the default token trigger
+# further workflows. That is why the packaging lives in a reusable workflow
+# this one calls directly rather than in a listener.
+on:
+  push:
+    branches: [main]
+  release:
+    types: [published]
+  workflow_dispatch:
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  # Decides whether this merge is a release, and creates it if it is.
+  tag:
+    name: Tag a new version
+    if: github.event_name == 'push'
+    # git and gh only — no build — so this stays off the Mac runner, which the
+    # packaging job needs to itself.
+    runs-on: [self-hosted, Linux, X64]
+    outputs:
+      tag: ${{ steps.check.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # gh needs the tags to answer "does this one exist yet".
+          fetch-depth: 0
+
+      - name: Version
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          version="$(sed -n 's/.*static let string = "\(.*\)".*/\1/p' \
+              Sources/MonitorCore/Version.swift)"
+          [ -n "$version" ] || { echo "no version in Version.swift" >&2; exit 1; }
+          tag="v$version"
+
+          if git rev-parse -q --verify "refs/tags/$tag" >/dev/null; then
+            echo "$tag exists — this merge is not a release." >> "$GITHUB_STEP_SUMMARY"
+            echo "Bump MonitorVersion.string to ship one." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "Releasing $tag" >> "$GITHUB_STEP_SUMMARY"
+
+      # The app is signed ad-hoc, not with a Developer ID, and it is not
+      # notarized. macOS quarantines anything a browser downloads, so without
+      # these two sentences a first launch is a dialog saying the app is
+      # damaged. The honest explanation belongs on the download page, not in an
+      # issue somebody files a week later.
+      - name: Create release
+        if: steps.check.outputs.tag != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.check.outputs.tag }}
+        run: |
+          command -v gh >/dev/null 2>&1 \
+              || { echo "gh is not installed on this runner" >&2; exit 1; }
+          cat > notes.md <<'NOTES'
+          Download the zip below, unzip it, and drag `monitor.app` to
+          Applications. macOS 14 or later, Apple silicon or Intel.
+
+          **First launch:** the app is not signed with a Developer ID and not
+          notarized, so macOS blocks it. Right-click the app and choose Open,
+          then Open again in the dialog. Or clear the quarantine flag yourself:
+
+          ```sh
+          xattr -d com.apple.quarantine /Applications/monitor.app
+          ```
+
+          Building it yourself avoids all of that — `Scripts/make-app.sh`.
+          NOTES
+
+          gh release create "$TAG" \
+              --target "$GITHUB_SHA" \
+              --title "monitor ${TAG#v}" \
+              --notes-file notes.md \
+              --generate-notes
+
+  # A merge that bumped the version, or a release published by hand. Either
+  # way the zip is built the same way and attached to the tag.
+  package:
+    name: Package
+    needs: tag
+    # `needs` on a skipped job skips this one too, so the release path spells
+    # out both events. `always()` lets the release event through while a
+    # failed tag job still stops the line.
+    if: |
+      always() && needs.tag.result != 'failure'
+        && (github.event_name == 'release' || needs.tag.outputs.tag != '')
+    uses: ./.github/workflows/package.yml
+    with:
+      tag: ${{ github.event_name == 'release' && github.event.release.tag_name || needs.tag.outputs.tag }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,7 +78,10 @@ Scripts/           make-app.sh, which builds monitor.app, and make-icon.swift,
                    which draws its icon
 Tests/             MonitorCoreTests, MonitorSourcesTests, MonitorStoreTests
 docs/              README.md is the index
-.github/workflows/ci.yml   build, test, release build, CLI smoke test, lint
+.github/workflows/
+  ci.yml           build, test, release build, CLI smoke test, lint
+  release.yml      tags a version bump merged to main, publishes the release
+  package.yml      reusable: builds monitor.app, zips it, attaches it to a tag
 ```
 
 One SwiftPM package: one build and one test command cover all of it, so there
@@ -129,6 +132,12 @@ are no component-level AGENTS.md files.
   `docs/sensors.md` is the survey of what a Mac exposes and what it costs.
 - **The panel has two sections.** Performance above the rule, sensors below.
   The sensor section vanishes on a machine that reports none of it.
+- **Releasing is a version bump, nothing else.** Merge a pull request that
+  changes `MonitorVersion.string` and `release.yml` tags that commit, publishes
+  a release, and attaches `monitor-<version>.zip` built by `package.yml`. A
+  merge that leaves the version alone publishes nothing, which is what most
+  merges should do. A release published by hand from the GitHub UI gets its zip
+  the same way.
 - **The version lives in `MonitorCore/Version.swift`.** The About panel reads
   it at runtime and `make-app.sh` greps that file when it writes `Info.plist`,
   so a bundled build and `swift run monitor` cannot claim different versions.
@@ -218,6 +227,11 @@ are no component-level AGENTS.md files.
 - `.github/workflows/ci.yml` — the jobs run on a Mac on a desk, so both are
   guarded to skip pull requests from forks. Keep that condition on any job
   added.
+- `.github/workflows/release.yml` — `package.yml` is called as a reusable
+  workflow rather than listening for `release: published`, because a release
+  created with the default `GITHUB_TOKEN` does not fire that event. Splitting
+  them into two independent workflows would publish releases with no zip
+  attached.
 
 ## Troubleshooting
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,7 @@ swift run monitorctl watch --source disk --interval 0.5
 swift run monitorctl watch --json --count 5        # machine-readable, bounded
 swiftformat Sources Tests --lint --cache ignore    # CI lint gate
 Scripts/make-app.sh [dest]       # wrap the release binary in monitor.app
+Scripts/make-icon.swift out.icns # draw the app icon (make-app.sh calls this)
 ```
 
 `monitorctl` exists because sampling is the part most likely to be wrong and the
@@ -73,7 +74,8 @@ Sources/
                    linked into the app — see "Guardrails" below.
   monitor/         the app target (@main SwiftUI App) and its AppDelegate
   monitorctl/      headless CLI harness
-Scripts/           make-app.sh, which builds monitor.app
+Scripts/           make-app.sh, which builds monitor.app, and make-icon.swift,
+                   which draws its icon
 Tests/             MonitorCoreTests, MonitorSourcesTests, MonitorStoreTests
 docs/              README.md is the index
 .github/workflows/ci.yml   build, test, release build, CLI smoke test, lint
@@ -127,6 +129,13 @@ are no component-level AGENTS.md files.
   `docs/sensors.md` is the survey of what a Mac exposes and what it costs.
 - **The panel has two sections.** Performance above the rule, sensors below.
   The sensor section vanishes on a machine that reports none of it.
+- **The version lives in `MonitorCore/Version.swift`.** The About panel reads
+  it at runtime and `make-app.sh` greps that file when it writes `Info.plist`,
+  so a bundled build and `swift run monitor` cannot claim different versions.
+- **The icon is drawn, not stored.** `Scripts/make-icon.swift` renders it from
+  the same palette as `Theme.swift` and pipes the set through `iconutil`, so
+  `.build/AppIcon.icns` is a build product and no binary blob is in the
+  repository.
 - **A missing sample means unavailable.** `AppModel` marks any descriptor that
   produced no sample this tick, minus the first-tick warm-up for rate metrics.
   That is how a card gets greyed out instead of drawing a flat zero line.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ To install it somewhere you can launch it from, build a real bundle:
 Scripts/make-app.sh ~/Applications
 ```
 
-That produces `monitor.app` — Info.plist, bundle id and an ad-hoc signature.
+That produces `monitor.app` — Info.plist, icon, bundle id and an ad-hoc
+signature.
 It is not signed with a Developer ID or notarized, so it is for this Mac.
 
 There is also a headless CLI, which is how the sampling code gets developed and

--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # monitor
 
+[![CI](https://github.com/evanwtf/monitor/actions/workflows/ci.yml/badge.svg)](https://github.com/evanwtf/monitor/actions/workflows/ci.yml)
+[![Release](https://img.shields.io/github/v/release/evanwtf/monitor?label=release)](https://github.com/evanwtf/monitor/releases/latest)
+[![Downloads](https://img.shields.io/github/downloads/evanwtf/monitor/total?label=downloads)](https://github.com/evanwtf/monitor/releases)
+[![Platform](https://img.shields.io/badge/platform-macOS%2014%2B-lightgrey)](https://github.com/evanwtf/monitor/releases/latest)
+[![Swift](https://img.shields.io/badge/swift-6.0-orange)](https://swift.org)
+[![License](https://img.shields.io/github/license/evanwtf/monitor)](LICENSE)
+
 A standalone macOS system monitor. CPU, GPU, memory, disk and network, in a
 window, with charts big enough to actually read.
 
@@ -20,6 +27,23 @@ Rates get analog gauges. Levels get charts. History is a ten-minute ring buffer
 that dies with the process — persistence and a background sampler are the next
 step, not this one. See `docs/roadmap.md`.
 
+## Download
+
+Grab the latest `monitor-*.zip` from
+[Releases](https://github.com/evanwtf/monitor/releases/latest), unzip it, and
+drag `monitor.app` to Applications.
+
+The app is signed ad-hoc rather than with a Developer ID, and it is not
+notarized, so macOS quarantines it on first launch and says it is damaged.
+Right-click the app and choose Open, then Open again in the dialog. Or clear
+the flag yourself:
+
+```sh
+xattr -d com.apple.quarantine /Applications/monitor.app
+```
+
+Building it yourself avoids all of that.
+
 ## Running it
 
 ```sh
@@ -37,8 +61,8 @@ Scripts/make-app.sh ~/Applications
 ```
 
 That produces `monitor.app` — Info.plist, icon, bundle id and an ad-hoc
-signature.
-It is not signed with a Developer ID or notarized, so it is for this Mac.
+signature. It is not signed with a Developer ID or notarized, so it is for this
+Mac.
 
 There is also a headless CLI, which is how the sampling code gets developed and
 verified without a GUI in the way:

--- a/Scripts/make-app.sh
+++ b/Scripts/make-app.sh
@@ -19,13 +19,27 @@
 set -euo pipefail
 
 readonly BUNDLE_ID="wtf.evan.monitor"
-readonly VERSION="1.0"
 
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$root"
 
+# One version, and it lives in the source so the About panel and the bundle
+# cannot disagree.
+VERSION="$(sed -n 's/.*static let string = "\(.*\)".*/\1/p' \
+    Sources/MonitorCore/Version.swift)"
+[ -n "$VERSION" ] || { echo "no version in Sources/MonitorCore/Version.swift" >&2; exit 1; }
+readonly VERSION
+
 destination="${1:-}"
 app=".build/monitor.app"
+
+# The icon is drawn by a script rather than checked in, so the palette has one
+# home. Rebuilt only when the drawing changes — it costs a few seconds.
+icon=".build/AppIcon.icns"
+if [ ! -f "$icon" ] || [ Scripts/make-icon.swift -nt "$icon" ]; then
+    echo "Drawing icon…"
+    swift Scripts/make-icon.swift "$icon"
+fi
 
 echo "Building release…"
 swift build -c release --product monitor
@@ -37,6 +51,7 @@ echo "Assembling ${app}…"
 rm -rf "$app"
 mkdir -p "$app/Contents/MacOS" "$app/Contents/Resources"
 cp "$binary" "$app/Contents/MacOS/monitor"
+cp "$icon" "$app/Contents/Resources/AppIcon.icns"
 
 cat > "$app/Contents/Info.plist" <<PLIST
 <?xml version="1.0" encoding="UTF-8"?>
@@ -51,6 +66,10 @@ cat > "$app/Contents/Info.plist" <<PLIST
     <string>monitor</string>
     <key>CFBundleIdentifier</key>
     <string>$BUNDLE_ID</string>
+    <key>CFBundleIconFile</key>
+    <string>AppIcon</string>
+    <key>CFBundleIconName</key>
+    <string>AppIcon</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>
@@ -59,6 +78,8 @@ cat > "$app/Contents/Info.plist" <<PLIST
     <string>$VERSION</string>
     <key>LSMinimumSystemVersion</key>
     <string>14.0</string>
+    <key>NSHumanReadableCopyright</key>
+    <string>MIT licensed. Copyright © 2026 Evan Hoffman.</string>
     <key>NSHighResolutionCapable</key>
     <true/>
     <!-- The window is designed against a dark ground; see Theme. -->

--- a/Scripts/make-icon.swift
+++ b/Scripts/make-icon.swift
@@ -1,0 +1,287 @@
+#!/usr/bin/env swift
+//
+// Draw the app icon, then build AppIcon.icns from it.
+//
+// Usage:
+//   swift Scripts/make-icon.swift <output.icns>
+//
+// The icon is drawn rather than stored, for the same reason the rest of the
+// panel is: every colour in it comes from the same palette the app uses, so a
+// change to the theme cannot leave the icon behind. It also keeps a binary
+// blob out of the repository — the source is the drawing.
+//
+// The subject is one dial. Not a chart, not a stack of them: at 32 points a
+// chart is grey fuzz, while a needle at an angle survives all the way down to
+// the 16-point menu size, which is the size that decides whether an icon
+// works.
+
+import AppKit
+import CoreGraphics
+import Foundation
+import ImageIO
+import UniformTypeIdentifiers
+
+// MARK: - Palette
+//
+// Theme.swift is the original. These are the same values; the script cannot
+// import MonitorUI because it runs before anything is built.
+
+let background = (top: (0.16, 0.16, 0.19), bottom: (0.055, 0.055, 0.07))
+let dialFace = (0.16, 0.16, 0.17)
+let bezelLight = 0.42, bezelDark = 0.16
+let tickColour = (0.72, 0.72, 0.72)
+let needleColour = (0.16, 0.68, 0.96)
+let redline = (0.85, 0.20, 0.16)
+let lcd = (1.00, 0.71, 0.24)
+
+func rgb(_ c: (Double, Double, Double), _ alpha: Double = 1) -> CGColor {
+    CGColor(srgbRed: c.0, green: c.1, blue: c.2, alpha: alpha)
+}
+
+// MARK: - Shape
+
+/// A superellipse, which is what a macOS icon's outline actually is.
+///
+/// `CGPath(roundedRect:)` draws circular corners. Next to any other icon in
+/// the Dock that reads as slightly wrong — the corners bulge where Apple's
+/// taper. Five is the exponent that matches closely enough at icon sizes.
+func squirclePath(in rect: CGRect, exponent: Double = 5) -> CGPath {
+    let path = CGMutablePath()
+    let a = rect.width / 2, b = rect.height / 2
+    let cx = rect.midX, cy = rect.midY
+    let steps = 720
+    for step in 0...steps {
+        let t = Double(step) / Double(steps) * 2 * .pi
+        let cosT = cos(t), sinT = sin(t)
+        let power = 2 / exponent
+        let x = cx + a * copysign(pow(abs(cosT), power), cosT)
+        let y = cy + b * copysign(pow(abs(sinT), power), sinT)
+        step == 0 ? path.move(to: CGPoint(x: x, y: y))
+            : path.addLine(to: CGPoint(x: x, y: y))
+    }
+    path.closeSubpath()
+    return path
+}
+
+// MARK: - Drawing
+
+/// The dial sweeps 270°, from lower left round to lower right, and the needle
+/// sits at 62% of that — high enough to read as "under load" rather than
+/// broken or idle, and clear of both the vertical and the diagonal, where a
+/// needle looks like an accident of alignment.
+let sweepStart = 225.0, sweepEnd = -45.0
+let needleFraction = 0.62
+
+func angle(_ fraction: Double) -> Double {
+    (sweepStart + (sweepEnd - sweepStart) * fraction) * .pi / 180
+}
+
+func draw(size: Double, into context: CGContext) {
+    let full = CGRect(x: 0, y: 0, width: size, height: size)
+    context.setFillColor(CGColor(gray: 0, alpha: 0))
+    context.fill(full)
+
+    // Apple's icon grid leaves the outer tenth of the canvas empty, so the
+    // shape below is what people actually see as "the icon".
+    let inset = size * 0.09
+    let body = full.insetBy(dx: inset, dy: inset)
+    let shape = squirclePath(in: body)
+
+    context.saveGState()
+    context.addPath(shape)
+    context.clip()
+    let space = CGColorSpaceCreateDeviceRGB()
+    let gradient = CGGradient(
+        colorsSpace: space,
+        colors: [rgb(background.bottom), rgb(background.top)] as CFArray,
+        locations: [0, 1]
+    )!
+    context.drawLinearGradient(
+        gradient,
+        start: CGPoint(x: 0, y: body.minY),
+        end: CGPoint(x: 0, y: body.maxY),
+        options: []
+    )
+    context.restoreGState()
+
+    // A hairline along the top edge: the same trick a physical panel plays,
+    // where the bevel catches the light from above.
+    context.saveGState()
+    context.addPath(shape)
+    context.setStrokeColor(CGColor(gray: 1, alpha: 0.13))
+    context.setLineWidth(max(1, size * 0.006))
+    context.strokePath()
+    context.restoreGState()
+
+    let centre = CGPoint(x: full.midX, y: full.midY - size * 0.02)
+    let radius = size * 0.30
+
+    // Bezel, then face. Two filled circles rather than a stroked ring, so the
+    // gradient runs across the bezel the way `Theme.bezel` does in the app.
+    context.saveGState()
+    let bezelWidth = radius * 0.11
+    let bezelRect = CGRect(
+        x: centre.x - radius - bezelWidth, y: centre.y - radius - bezelWidth,
+        width: (radius + bezelWidth) * 2, height: (radius + bezelWidth) * 2
+    )
+    context.addEllipse(in: bezelRect)
+    context.clip()
+    let bezelGradient = CGGradient(
+        colorsSpace: space,
+        colors: [
+            CGColor(gray: bezelLight, alpha: 1),
+            CGColor(gray: bezelDark, alpha: 1),
+            CGColor(gray: bezelLight * 0.8, alpha: 1),
+        ] as CFArray,
+        locations: [0, 0.55, 1]
+    )!
+    context.drawLinearGradient(
+        bezelGradient,
+        start: CGPoint(x: bezelRect.minX, y: bezelRect.maxY),
+        end: CGPoint(x: bezelRect.maxX, y: bezelRect.minY),
+        options: []
+    )
+    context.restoreGState()
+
+    context.setFillColor(rgb(dialFace))
+    context.fillEllipse(
+        in: CGRect(
+            x: centre.x - radius, y: centre.y - radius,
+            width: radius * 2, height: radius * 2
+        ))
+
+    // The lit arc: how far the needle has travelled, in the amber of the
+    // readout. It is the one warm colour on the panel and the thing that makes
+    // the icon legible when it is 16 points wide and the needle is two pixels.
+    context.saveGState()
+    context.setStrokeColor(rgb(lcd))
+    context.setLineWidth(radius * 0.13)
+    context.setLineCap(.butt)
+    context.addArc(
+        center: centre, radius: radius * 0.86,
+        startAngle: angle(0), endAngle: angle(needleFraction),
+        clockwise: true
+    )
+    context.strokePath()
+    context.restoreGState()
+
+    // Ticks. Nine of them, the last two in redline red. Minor ticks are left
+    // out on purpose: below 128 points they close up into a grey band.
+    context.setLineCap(.butt)
+    for index in 0...8 {
+        let fraction = Double(index) / 8
+        let theta = angle(fraction)
+        let outer = radius * 0.70, inner = radius * 0.57
+        context.setStrokeColor(rgb(fraction > 0.76 ? redline : tickColour))
+        context.setLineWidth(radius * 0.075)
+        context.move(to: CGPoint(
+            x: centre.x + cos(theta) * outer, y: centre.y + sin(theta) * outer))
+        context.addLine(to: CGPoint(
+            x: centre.x + cos(theta) * inner, y: centre.y + sin(theta) * inner))
+        context.strokePath()
+    }
+
+    // The needle: a tapered blade, wide at the hub and pointed at the tip, so
+    // which end is which survives being three pixels long.
+    let theta = angle(needleFraction)
+    let tip = CGPoint(
+        x: centre.x + cos(theta) * radius * 0.49,
+        y: centre.y + sin(theta) * radius * 0.49
+    )
+    let halfWidth = radius * 0.085
+    let side = theta + .pi / 2
+    let tail = radius * 0.16
+    context.setFillColor(rgb(needleColour))
+    context.beginPath()
+    context.move(to: tip)
+    context.addLine(to: CGPoint(
+        x: centre.x + cos(side) * halfWidth - cos(theta) * tail,
+        y: centre.y + sin(side) * halfWidth - sin(theta) * tail
+    ))
+    context.addLine(to: CGPoint(
+        x: centre.x - cos(side) * halfWidth - cos(theta) * tail,
+        y: centre.y - sin(side) * halfWidth - sin(theta) * tail
+    ))
+    context.closePath()
+    context.fillPath()
+
+    // Hub.
+    let hub = radius * 0.13
+    context.setFillColor(CGColor(gray: 0.86, alpha: 1))
+    context.fillEllipse(
+        in: CGRect(x: centre.x - hub, y: centre.y - hub, width: hub * 2, height: hub * 2))
+}
+
+// MARK: - Output
+
+func render(size: Int) -> CGImage {
+    let context = CGContext(
+        data: nil, width: size, height: size,
+        bitsPerComponent: 8, bytesPerRow: 0,
+        space: CGColorSpaceCreateDeviceRGB(),
+        bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+    )!
+    context.setAllowsAntialiasing(true)
+    context.interpolationQuality = .high
+    draw(size: Double(size), into: context)
+    return context.makeImage()!
+}
+
+func writePNG(_ image: CGImage, to url: URL) throws {
+    guard let destination = CGImageDestinationCreateWithURL(
+        url as CFURL, UTType.png.identifier as CFString, 1, nil)
+    else { throw Failure("cannot write \(url.path)") }
+    CGImageDestinationAddImage(destination, image, nil)
+    guard CGImageDestinationFinalize(destination) else {
+        throw Failure("cannot encode \(url.path)")
+    }
+}
+
+struct Failure: Error, CustomStringConvertible {
+    let description: String
+    init(_ description: String) { self.description = description }
+}
+
+let arguments = CommandLine.arguments
+guard arguments.count == 2 else {
+    FileHandle.standardError.write(
+        Data("usage: swift Scripts/make-icon.swift <output.icns>\n".utf8))
+    exit(2)
+}
+let output = URL(fileURLWithPath: arguments[1])
+
+do {
+    let work = URL(fileURLWithPath: NSTemporaryDirectory())
+        .appendingPathComponent("monitor-icon-\(getpid()).iconset")
+    try? FileManager.default.removeItem(at: work)
+    try FileManager.default.createDirectory(at: work, withIntermediateDirectories: true)
+
+    // The names are `iconutil`'s, not a choice: it reads the set by filename.
+    for base in [16, 32, 128, 256, 512] {
+        try writePNG(
+            render(size: base),
+            to: work.appendingPathComponent("icon_\(base)x\(base).png"))
+        try writePNG(
+            render(size: base * 2),
+            to: work.appendingPathComponent("icon_\(base)x\(base)@2x.png"))
+    }
+
+    try? FileManager.default.removeItem(at: output)
+    try FileManager.default.createDirectory(
+        at: output.deletingLastPathComponent(), withIntermediateDirectories: true)
+
+    let iconutil = Process()
+    iconutil.executableURL = URL(fileURLWithPath: "/usr/bin/iconutil")
+    iconutil.arguments = ["-c", "icns", work.path, "-o", output.path]
+    try iconutil.run()
+    iconutil.waitUntilExit()
+    guard iconutil.terminationStatus == 0 else {
+        throw Failure("iconutil failed (\(iconutil.terminationStatus))")
+    }
+
+    try? FileManager.default.removeItem(at: work)
+    print("Wrote \(output.path)")
+} catch {
+    FileHandle.standardError.write(Data("make-icon: \(error)\n".utf8))
+    exit(1)
+}

--- a/Sources/MonitorCore/Version.swift
+++ b/Sources/MonitorCore/Version.swift
@@ -5,5 +5,5 @@
 /// unbundled one cannot claim different versions. Keep the literal on one
 /// line: the script's pattern expects it there.
 public enum MonitorVersion {
-    public static let string = "1.0"
+    public static let string = "1.0.0"
 }

--- a/Sources/MonitorCore/Version.swift
+++ b/Sources/MonitorCore/Version.swift
@@ -1,0 +1,9 @@
+/// The version of the app, in one place.
+///
+/// The About panel reads it at runtime and `Scripts/make-app.sh` greps this
+/// file for it when it writes `Info.plist`, so a bundled build and an
+/// unbundled one cannot claim different versions. Keep the literal on one
+/// line: the script's pattern expects it there.
+public enum MonitorVersion {
+    public static let string = "1.0"
+}

--- a/Sources/MonitorSources/CPUSource.swift
+++ b/Sources/MonitorSources/CPUSource.swift
@@ -96,15 +96,15 @@ public final class CPUSource: MetricSource, @unchecked Sendable {
     /// core count, because a wrong split is worse than no split: it would label
     /// real load as coming from the wrong kind of core.
     static func readClusters() -> [Cluster] {
-        let levels = sysctlInt("hw.nperflevels") ?? 1
+        let levels = Sysctl.int("hw.nperflevels") ?? 1
         guard levels > 1 else { return [] }
 
         var descending: [(level: Int, name: String, count: Int)] = []
         for level in 0..<levels {
-            guard let count = sysctlInt("hw.perflevel\(level).logicalcpu"), count > 0 else {
+            guard let count = Sysctl.int("hw.perflevel\(level).logicalcpu"), count > 0 else {
                 return []
             }
-            let name = sysctlString("hw.perflevel\(level).name") ?? "Level \(level)"
+            let name = Sysctl.string("hw.perflevel\(level).name") ?? "Level \(level)"
             descending.append((level, name, count))
         }
 
@@ -126,22 +126,6 @@ public final class CPUSource: MetricSource, @unchecked Sendable {
         // Fastest cluster first, so it takes the first series colour and reads
         // at the top of the legend.
         return result.sorted { $0.level < $1.level }
-    }
-
-    static func sysctlInt(_ name: String) -> Int? {
-        var value = 0
-        var size = MemoryLayout<Int>.size
-        guard sysctlbyname(name, &value, &size, nil, 0) == 0 else { return nil }
-        return value
-    }
-
-    static func sysctlString(_ name: String) -> String? {
-        var size = 0
-        guard sysctlbyname(name, nil, &size, nil, 0) == 0, size > 0 else { return nil }
-        var buffer = [UInt8](repeating: 0, count: size)
-        guard sysctlbyname(name, &buffer, &size, nil, 0) == 0 else { return nil }
-        // sysctl includes the null terminator in the byte count it reports.
-        return String(decoding: buffer.prefix(while: { $0 != 0 }), as: UTF8.self)
     }
 
     public func read(at timestamp: TimeInterval) throws -> SampleBatch {

--- a/Sources/MonitorSources/MachineInfo.swift
+++ b/Sources/MonitorSources/MachineInfo.swift
@@ -1,0 +1,65 @@
+import Darwin
+import Foundation
+
+/// Thin wrappers over `sysctlbyname`.
+///
+/// Two calls, both of the same shape: ask for the size, then ask for the
+/// value. They live here rather than on one source because the machine
+/// description below reads the same table the CPU source does.
+public enum Sysctl {
+    public static func int(_ name: String) -> Int? {
+        var value = 0
+        var size = MemoryLayout<Int>.size
+        guard sysctlbyname(name, &value, &size, nil, 0) == 0 else { return nil }
+        return value
+    }
+
+    public static func string(_ name: String) -> String? {
+        var size = 0
+        guard sysctlbyname(name, nil, &size, nil, 0) == 0, size > 0 else { return nil }
+        var buffer = [UInt8](repeating: 0, count: size)
+        guard sysctlbyname(name, &buffer, &size, nil, 0) == 0 else { return nil }
+        // sysctl includes the null terminator in the byte count it reports.
+        return String(decoding: buffer.prefix(while: { $0 != 0 }), as: UTF8.self)
+    }
+}
+
+/// What this Mac is.
+///
+/// The About panel says which machine the readings come from. A screenshot of
+/// a dashboard is worth much less when nobody can tell whether it is an M4 or
+/// a 2019 Intel, and the answer costs three sysctl calls.
+///
+/// Every field is optional at the source and falls back rather than throws:
+/// nothing here is a measurement, so a missing key should cost a line of the
+/// panel and nothing more.
+public struct MachineInfo: Sendable {
+    /// Marketing-ish model identifier, for example `Mac16,10`.
+    public let model: String
+    /// The CPU brand string: "Apple M4" on Apple silicon, the full Intel part
+    /// number otherwise.
+    public let chip: String
+    public let cores: Int
+    public let memoryBytes: Int
+    /// For example `14.5.0`.
+    public let systemVersion: String
+
+    public static var current: MachineInfo {
+        let version = ProcessInfo.processInfo.operatingSystemVersion
+        return MachineInfo(
+            model: Sysctl.string("hw.model") ?? "Mac",
+            chip: Sysctl.string("machdep.cpu.brand_string") ?? "unknown CPU",
+            cores: ProcessInfo.processInfo.activeProcessorCount,
+            memoryBytes: Sysctl.int("hw.memsize") ?? 0,
+            systemVersion: "\(version.majorVersion).\(version.minorVersion)"
+                + ".\(version.patchVersion)"
+        )
+    }
+
+    /// One line for the About panel: chip, core count, memory.
+    public var hardwareSummary: String {
+        let gigabytes = Double(memoryBytes) / 1_073_741_824
+        let memory = memoryBytes > 0 ? ", \(Int(gigabytes.rounded())) GB" : ""
+        return "\(chip), \(cores) cores\(memory)"
+    }
+}

--- a/Sources/MonitorUI/AboutPanel.swift
+++ b/Sources/MonitorUI/AboutPanel.swift
@@ -1,0 +1,96 @@
+import AppKit
+import MonitorCore
+import MonitorSources
+import SwiftUI
+
+/// The About panel.
+///
+/// The standard panel with the standard layout, filled in by hand rather than
+/// read from the bundle: `swift run monitor` has no `Info.plist`, so the
+/// stock panel there says "monitor 1.0 (1)" over a generic icon. Passing the
+/// options explicitly makes the bundled build and the development build say
+/// the same thing.
+///
+/// What it says is the machine the readings come from — chip, cores, memory,
+/// macOS version. A dashboard screenshot means much less without it, and a
+/// monitoring tool is the last place to make somebody go looking elsewhere for
+/// what hardware they are on.
+public enum About {
+    public static let name = "Monitor"
+    public static let tagline =
+        "A system monitor for macOS, with charts big enough to read."
+    public static let repository = "https://github.com/evanwtf/monitor"
+    /// The link's text. The scheme adds nothing a reader needs and makes the
+    /// line wrap in a 284-point panel.
+    static let repositoryLabel = "github.com/evanwtf/monitor"
+
+    /// Opens the panel. Safe to call from a menu item on the main thread.
+    @MainActor public static func show() {
+        NSApp.orderFrontStandardAboutPanel(options: options())
+    }
+
+    @MainActor static func options() -> [NSApplication.AboutPanelOptionKey: Any] {
+        var options: [NSApplication.AboutPanelOptionKey: Any] = [
+            .applicationName: name,
+            .applicationVersion: MonitorVersion.string,
+            .credits: credits(),
+        ]
+        // The panel prints this in parentheses after the version. An unbundled
+        // build has no build number to print, and "(1)" invented from nowhere
+        // is worse than nothing.
+        options[.version] = ""
+        return options
+    }
+
+    static func credits() -> NSAttributedString {
+        let machine = MachineInfo.current
+        let body = NSFont.systemFont(ofSize: NSFont.smallSystemFontSize)
+        let centred = NSMutableParagraphStyle()
+        centred.alignment = .center
+        centred.lineSpacing = 2
+
+        let text = NSMutableAttributedString()
+        text.append(NSAttributedString(
+            string: tagline + "\n\n",
+            attributes: [
+                .font: body,
+                .foregroundColor: NSColor.labelColor,
+                .paragraphStyle: centred,
+            ]
+        ))
+        text.append(NSAttributedString(
+            string: machine.hardwareSummary + "\n"
+                + "\(machine.model) · macOS \(machine.systemVersion)\n\n",
+            attributes: [
+                .font: NSFont.monospacedDigitSystemFont(
+                    ofSize: NSFont.smallSystemFontSize,
+                    weight: .regular
+                ),
+                .foregroundColor: NSColor.secondaryLabelColor,
+                .paragraphStyle: centred,
+            ]
+        ))
+        text.append(NSAttributedString(
+            string: repositoryLabel,
+            attributes: [
+                .font: body,
+                .link: URL(string: repository) as Any,
+                .paragraphStyle: centred,
+            ]
+        ))
+        return text
+    }
+}
+
+/// Replaces the stock "About monitor" item with one that opens the panel
+/// above. The menu title keeps the app's display name, not the executable name
+/// the unbundled build would otherwise show.
+public struct AboutCommand: Commands {
+    public init() {}
+
+    public var body: some Commands {
+        CommandGroup(replacing: .appInfo) {
+            Button("About \(About.name)") { About.show() }
+        }
+    }
+}

--- a/Sources/monitor/MonitorApp.swift
+++ b/Sources/monitor/MonitorApp.swift
@@ -21,6 +21,7 @@ struct MonitorApp: App {
         // Dark only for now. The instrument panel is designed against a dark
         // ground and a light mode is a separate palette, not a toggle.
         .defaultSize(width: 1000, height: 760)
+        .commands { AboutCommand() }
     }
 }
 

--- a/Tests/MonitorSourcesTests/SourceTests.swift
+++ b/Tests/MonitorSourcesTests/SourceTests.swift
@@ -293,4 +293,17 @@ struct SourceTests {
         let batch = await sampler.tick(at: 1)
         #expect(!batch.samples.isEmpty, "a broken source suppressed a working one")
     }
+
+    @Test("the machine describes itself for the About panel")
+    func machineInfo() {
+        let machine = MachineInfo.current
+        #expect(!machine.model.isEmpty)
+        #expect(!machine.chip.isEmpty)
+        #expect(machine.cores > 0)
+        #expect(machine.memoryBytes > 0)
+        // "Apple M4, 10 cores, 16 GB" — three facts, no empty fields between
+        // the commas even when a sysctl key is missing.
+        #expect(machine.hardwareSummary.contains(machine.chip))
+        #expect(!machine.hardwareSummary.contains(", ,"))
+    }
 }


### PR DESCRIPTION
Three things, in order.

**An icon.** `Scripts/make-icon.swift` draws it — a squircle panel with one
dial: amber sweep arc, ticks going red at the top end, blue needle — from the
same colour values as `Theme.swift`, then pipes the set through `iconutil`. It
is drawn rather than checked in so the icon cannot drift from the panel it
depicts, and no binary blob lands in the repository. `make-app.sh` renders it
into `.build/AppIcon.icns` and copies it into the bundle. Checked at 512, 32
and 16 points; the needle and arc still read at menu size.

**A real About panel.** Filled in by hand rather than read from the bundle,
because `swift run monitor` has no `Info.plist` and the stock panel there says
"monitor 1.0 (1)" over a generic icon. It now names the machine the readings
come from — chip, cores, memory, model, macOS version — which is the thing
missing from every dashboard screenshot anyone posts. `MachineInfo` carries
that description, and the two sysctl wrappers move off `CPUSource` into
`Sysctl` so both callers share them.

**Releases.** `release.yml` watches main: a merged pull request that changes
`MonitorVersion.string` to a version with no tag gets that commit tagged and a
release published, with install and Gatekeeper instructions. A merge that
leaves the version alone publishes nothing. `package.yml` builds the app, zips
it with `ditto` and attaches it to the tag; it is a reusable workflow called
directly rather than a listener on `release: published`, because a release
created with the default token does not fire that event. Publishing a release
by hand from the UI lands in the same place.

The version moves to `MonitorCore/Version.swift`, set to `1.0.0` to match the
shape of the existing `v0.1.0` tag. The About panel reads it and `make-app.sh`
greps it, so the bundle and the development build cannot disagree.

README gets the usual badges and a Download section.

**Merging this ships v1.0.0.** No `v1.0.0` tag exists, so the merge commit
gets tagged and the first zip is published. That is the intended behaviour —
worth knowing before hitting the button.

`swift test` (76 tests), swiftformat and actionlint all pass locally.

https://claude.ai/code/session_01MokwUgevNdiqWEFR3uJqVb