### PR TITLE
Choose which metrics get a gauge and which get a chart

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,8 +123,9 @@ are no component-level AGENTS.md files.
   encodes the split — but as an opening position, not a rule.
 - **The layout is chosen per metric, in preferences.** Cmd-, opens a tabbed
   window whose one tab, Layout, lists every metric with a Gauge checkbox and a
-  Chart checkbox. The two are not symmetrical: **a gauge is per metric, a chart
-  is per group.** Ticking Network In and Network Out gives two dials and *one*
+  Chart checkbox, grouped into collapsible sections whose headings carry the
+  same two checkboxes for the whole group. The two columns are not symmetrical:
+  **a gauge is per metric, a chart is per group.** Ticking Network In and Network Out gives two dials and *one*
   Network card with two lines, because in and out are only readable against each
   other. `LayoutPreferences` (in `MonitorCore`, so the merge rules are testable)
   tracks which metrics it has an opinion about as well as which are on —

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,14 +62,15 @@ look at it in the app.
 ```
 Sources/
   MonitorCore/     metric model, ring buffer, downsampling, gauge auto-ranging,
-                   seven-segment digit mapping, formatting, the sampling clock.
-                   No macOS APIs — so all of it is testable without a machine
-                   to read.
+                   seven-segment digit mapping, formatting, the sampling clock,
+                   the layout preferences model. No macOS APIs — so all of it is
+                   testable without a machine to read.
   MonitorSources/  the readers: CPU, memory, disk, network, GPU, SMC sensors
                    (temperature, fans, power), and the registry that lists them.
                    One file per source, plus SMC.swift for the SMC transport.
   MonitorUI/       Theme (palette + Layout density), GaugeView, SevenSegmentText,
-                   ChartCard, FlowLayout, DashboardView, AppModel
+                   ChartCard, FlowLayout, DashboardView, PreferencesView,
+                   AppModel, LayoutPreferencesStore
   MonitorStore/    SQLite history and retention. Designed and tested but NOT
                    linked into the app — see "Guardrails" below.
   monitor/         the app target (@main SwiftUI App) and its AppDelegate
@@ -118,8 +119,17 @@ are no component-level AGENTS.md files.
   perflevel order — slowest cluster first.
 - **Gauges are for rates, charts are for levels.** A dial answers "how hard is
   this working right now against what it can do" (disk, network throughput). A
-  chart answers "what has been happening" (CPU, memory). `AppModel.isGauge`
-  encodes the split, by unit: the per-second units get a dial.
+  chart answers "what has been happening" (CPU, memory). `LayoutDefaults`
+  encodes the split — but as an opening position, not a rule.
+- **The layout is chosen per metric, in preferences.** Cmd-, opens a tabbed
+  window whose one tab, Layout, lists every metric with a Gauge checkbox and a
+  Chart checkbox. The two are not symmetrical: **a gauge is per metric, a chart
+  is per group.** Ticking Network In and Network Out gives two dials and *one*
+  Network card with two lines, because in and out are only readable against each
+  other. `LayoutPreferences` (in `MonitorCore`, so the merge rules are testable)
+  tracks which metrics it has an opinion about as well as which are on —
+  otherwise a metric added by a later version is indistinguishable from one
+  somebody switched off, and stays silently missing.
 - **One clock.** `Sampler.tick(at:)` reads every source at one timestamp so a
   batch lines up on the x-axis. A source that throws is logged and skipped for
   that tick only. `AppModel` samples at 0.5 s into a 1200-point ring buffer —
@@ -201,7 +211,9 @@ are no component-level AGENTS.md files.
   the filesystem. This is about SSD endurance: a monitor runs all day, every
   day. Adding that dependency is a deliberate product decision with an
   arithmetic argument behind it (`docs/storage.md`), never a convenience during
-  a refactor.
+  a refactor. Preferences are the exception that proves the rule: layout
+  choices go to `UserDefaults` under `wtf.evan.monitor`, which is a write when
+  somebody ticks a checkbox, not a write every half second forever.
 - Never report a fabricated value when a source fails. Throw
   `MetricSourceError` and let the UI say "not available". A plausible wrong
   number in a monitoring tool is worse than a gap, because nobody checks it.

--- a/README.md
+++ b/README.md
@@ -92,11 +92,21 @@ the two is a number about nothing.
 
 A few decisions that are load-bearing rather than incidental:
 
-- **Nothing is written to disk.** A monitor runs all day, every day. Writing a
-  sample a second forever costs real SSD endurance for data nobody reads, so v1
-  simply does not. This is enforced by the dependency graph — the app does not
-  link the storage library at all — not by anyone remembering. `docs/storage.md`
-  works through the arithmetic for when persistence does arrive.
+- **No history is written to disk.** A monitor runs all day, every day. Writing
+  a sample a second forever costs real SSD endurance for data nobody reads, so
+  v1 simply does not. This is enforced by the dependency graph — the app does
+  not link the storage library at all — not by anyone remembering. Preferences
+  are the one thing that persists, which is a write per checkbox rather than a
+  write per sample. `docs/storage.md` works through the arithmetic for when
+  history does arrive.
+- **A gauge is per metric; a chart is per group.** Cmd-, opens Preferences, and
+  its Layout tab lists every metric with a Gauge checkbox and a Chart checkbox.
+  Ticking the chart column for Network In and Network Out gives one Network card
+  with both lines on it, because in and out are only readable against each
+  other; ticking the gauge column gives two dials, because a dial shows one
+  number. The panel opens with a considered layout — dials for disk and network
+  throughput, charts for everything worth glancing at — and this is where you
+  disagree with it.
 - **A failed reading is shown as a gap, never as zero.** An idle machine and a
   broken sensor must not look identical. Sources throw; the UI greys the card
   out and says so.

--- a/README.md
+++ b/README.md
@@ -104,7 +104,9 @@ A few decisions that are load-bearing rather than incidental:
   Ticking the chart column for Network In and Network Out gives one Network card
   with both lines on it, because in and out are only readable against each
   other; ticking the gauge column gives two dials, because a dial shows one
-  number. The panel opens with a considered layout — dials for disk and network
+  number. Sections collapse, and a section heading's checkbox sets the whole
+  group at once — it shows a dash when the rows disagree, so a folded section
+  still tells you what state it is in. The panel opens with a considered layout — dials for disk and network
   throughput, charts for everything worth glancing at — and this is where you
   disagree with it.
 - **A failed reading is shown as a gap, never as zero.** An idle machine and a

--- a/Sources/MonitorCore/LayoutPreferences.swift
+++ b/Sources/MonitorCore/LayoutPreferences.swift
@@ -1,0 +1,116 @@
+import Foundation
+
+/// What the panel draws when nobody has said otherwise.
+///
+/// These lists were hard-coded in the dashboard before the layout could be
+/// chosen. They live here now because they are two different things at once:
+/// the starting state of a fresh preference set, and the order things appear
+/// in. Order matters as much as membership — a dial or a card that moves
+/// between launches is one you have to hunt for, so enabling a metric adds it
+/// to a fixed position rather than wherever the registry happened to yield it.
+public enum LayoutDefaults {
+    /// The dials on the wall, left to right.
+    ///
+    /// Rates only. A gauge answers "how hard is this working right now against
+    /// what it can do", which is the question for disk and network throughput
+    /// and not the question for memory.
+    public static let gaugeOrder: [MetricID] = [
+        MetricID("disk.bytes.read"),
+        MetricID("disk.bytes.written"),
+        MetricID("net.bits.in"),
+        MetricID("net.bits.out"),
+    ]
+
+    /// Chart cards above the section rule, in the order they appear.
+    ///
+    /// Disk and network are here as well as on the gauge wall on purpose: a
+    /// needle cannot tell you a transfer has been running for a minute.
+    public static let performanceGroupOrder = [
+        "CPU", "CPU Cores", "Memory", "Disk", "Network", "GPU", "Disk Latency",
+    ]
+
+    /// Chart cards below the rule: what the machine is doing to itself — heat,
+    /// fans, watts. Every one of these is missing on some Mac, so the section
+    /// draws only what this machine reports.
+    public static let sensorGroupOrder = ["Temperature", "Fans", "Power"]
+
+    /// Groups left off both lists by default: "Disk Ops", "Network Packets"
+    /// and "Memory Paging" are diagnostic detail rather than something to
+    /// glance at. They are one checkbox away rather than gone.
+    public static func showsChart(_ descriptor: MetricDescriptor) -> Bool {
+        performanceGroupOrder.contains(descriptor.group)
+            || sensorGroupOrder.contains(descriptor.group)
+    }
+
+    public static func showsGauge(_ descriptor: MetricDescriptor) -> Bool {
+        gaugeOrder.contains(descriptor.id)
+    }
+}
+
+/// Which metrics get a dial, and which get a line on a chart.
+///
+/// The two are independent, and both are per metric. A dial is per metric
+/// because it shows one number. A chart is per metric but drawn per *group*:
+/// every charted metric in a group shares that group's card, so ticking
+/// Network In and Network Out gives one Network chart with two lines, not two
+/// charts. That is the point of the group — in and out are only readable
+/// against each other.
+///
+/// A value type in `MonitorCore` rather than a view model, so the merge rules
+/// below are testable without a window.
+public struct LayoutPreferences: Codable, Equatable, Sendable {
+    /// Raw metric ids rather than `MetricID`, because this is what gets
+    /// written to preferences and a bare list of strings is the shape that
+    /// survives a change to the type.
+    private var gauges: Set<String>
+    private var charts: Set<String>
+    /// Every metric this set has already decided about.
+    ///
+    /// Without it a metric added by a later version — or by a machine that
+    /// starts reporting a sensor it did not before — would be silently off,
+    /// because "not in `charts`" and "never heard of" look the same. Tracking
+    /// what is known separates them, so a new metric gets its default and
+    /// everything else keeps whatever was chosen.
+    private var known: Set<String>
+
+    public init(
+        gauges: Set<MetricID> = [], charts: Set<MetricID> = [], known: Set<MetricID> = []
+    ) {
+        self.gauges = Set(gauges.map(\.rawValue))
+        self.charts = Set(charts.map(\.rawValue))
+        self.known = Set(known.map(\.rawValue)).union(self.gauges).union(self.charts)
+    }
+
+    public func showsGauge(_ metric: MetricID) -> Bool { gauges.contains(metric.rawValue) }
+    public func showsChart(_ metric: MetricID) -> Bool { charts.contains(metric.rawValue) }
+
+    public mutating func setGauge(_ shown: Bool, for metric: MetricID) {
+        known.insert(metric.rawValue)
+        if shown { gauges.insert(metric.rawValue) } else { gauges.remove(metric.rawValue) }
+    }
+
+    public mutating func setChart(_ shown: Bool, for metric: MetricID) {
+        known.insert(metric.rawValue)
+        if shown { charts.insert(metric.rawValue) } else { charts.remove(metric.rawValue) }
+    }
+
+    /// The panel as it shipped: `LayoutDefaults` applied to every descriptor.
+    public static func defaults(for descriptors: [MetricDescriptor]) -> LayoutPreferences {
+        LayoutPreferences(
+            gauges: Set(descriptors.filter(LayoutDefaults.showsGauge).map(\.id)),
+            charts: Set(descriptors.filter(LayoutDefaults.showsChart).map(\.id)),
+            known: Set(descriptors.map(\.id))
+        )
+    }
+
+    /// Gives any metric this set has not seen before its default state, and
+    /// leaves every choice already made alone.
+    public func adoptingDefaults(for descriptors: [MetricDescriptor]) -> LayoutPreferences {
+        var merged = self
+        for descriptor in descriptors where !known.contains(descriptor.id.rawValue) {
+            merged.setGauge(LayoutDefaults.showsGauge(descriptor), for: descriptor.id)
+            merged.setChart(LayoutDefaults.showsChart(descriptor), for: descriptor.id)
+        }
+        return merged
+    }
+}

--- a/Sources/MonitorUI/AppModel.swift
+++ b/Sources/MonitorUI/AppModel.swift
@@ -199,6 +199,31 @@ public final class AppModel {
         }
     }
 
+    /// The two things preferences can turn on for a metric.
+    public enum LayoutColumn: String, CaseIterable, Sendable {
+        case gauge, chart
+    }
+
+    /// A checkbox's worth of the layout, as a binding.
+    ///
+    /// Vended by the model rather than built in the view because a metric's row
+    /// and its section heading both write the same state, and a single
+    /// definition is what keeps them from drifting.
+    public func binding(_ column: LayoutColumn, for metric: MetricID) -> Binding<Bool> {
+        switch column {
+        case .gauge:
+            Binding(
+                get: { self.layout.showsGauge(metric) },
+                set: { self.layout.setGauge($0, for: metric) }
+            )
+        case .chart:
+            Binding(
+                get: { self.layout.showsChart(metric) },
+                set: { self.layout.setChart($0, for: metric) }
+            )
+        }
+    }
+
     /// Puts every metric back to the layout the app ships with.
     public func restoreDefaultLayout() {
         layout = LayoutPreferences.defaults(for: Array(descriptors.values))

--- a/Sources/MonitorUI/AppModel.swift
+++ b/Sources/MonitorUI/AppModel.swift
@@ -20,6 +20,16 @@ public final class AppModel {
     /// instead of drawing a flat line that looks like an idle machine.
     public private(set) var unavailable: Set<MetricID> = []
 
+    /// Which metrics get a dial and which get a line, as chosen in the
+    /// preferences window. Written back on every change: a preferences pane
+    /// that forgets is not a preferences pane.
+    public var layout: LayoutPreferences {
+        didSet {
+            guard layout != oldValue else { return }
+            LayoutPreferencesStore.save(layout)
+        }
+    }
+
     /// Half a second by default rather than one. Reading every source costs
     /// well under a millisecond, and at 1 Hz the gauges visibly step: the
     /// needle animation can smooth the gap, but it cannot invent detail that
@@ -42,8 +52,14 @@ public final class AppModel {
             uniquingKeysWith: { first, _ in first }
         )
         sampler = Sampler(sources: sources, sinks: [], interval: 0.5)
+        layout = LayoutPreferencesStore.load(for: all)
 
-        for descriptor in all where Self.isGauge(descriptor) {
+        // A scale for every metric, not only the ones a dial shows today. Any
+        // metric can be given a dial in preferences, and auto-ranging needs
+        // history: a scale built the moment its checkbox is ticked would start
+        // from the floor and climb, so the first reading on a new dial would
+        // be pinned at full deflection.
+        for descriptor in all {
             scales[descriptor.id] = Self.makeScale(descriptor)
         }
     }
@@ -110,20 +126,85 @@ public final class AppModel {
         return order.map { (name: $0, metrics: byGroup[$0] ?? []) }
     }
 
-    // MARK: - Gauge policy
+    // MARK: - What the panel draws
 
-    /// Rates get a dial; levels get a chart.
+    /// The dials on the wall, left to right.
     ///
-    /// A gauge shows "how fast, right now, against what this machine can do".
-    /// That is the question for disk and network throughput. It is not the
-    /// question for memory, where what matters is the trend over an hour, and a
-    /// needle would just wobble.
-    static func isGauge(_ descriptor: MetricDescriptor) -> Bool {
-        switch descriptor.unit {
-        case .bytesPerSecond, .bitsPerSecond, .operationsPerSecond: true
-        default: false
+    /// `LayoutDefaults.gaugeOrder` first, so the four the app opens with never
+    /// move, then anything else that has been ticked, by metric id. Both halves
+    /// are fixed orders rather than registry order for the same reason: a dial
+    /// that moves between launches is a dial you stop glancing at.
+    public var gaugeMetrics: [MetricID] {
+        let ordered = LayoutDefaults.gaugeOrder.filter {
+            descriptors[$0] != nil && layout.showsGauge($0)
+        }
+        let rest = descriptors.keys
+            .filter { layout.showsGauge($0) && !LayoutDefaults.gaugeOrder.contains($0) }
+            .sorted { $0.rawValue < $1.rawValue }
+        return ordered + rest
+    }
+
+    /// Every group this machine reports, in the order the panel lays its cards
+    /// out — which is the order the preferences list has to use as well, or the
+    /// list and the window it configures disagree about where things are.
+    public var groupOrder: [(name: String, metrics: [MetricID])] {
+        let byName = Dictionary(
+            groups().map { ($0.name, $0.metrics) }, uniquingKeysWith: { first, _ in first }
+        )
+        let order = LayoutDefaults.performanceGroupOrder + extraGroupNames
+            + LayoutDefaults.sensorGroupOrder
+        return order.compactMap { name in
+            byName[name].map { (name: name, metrics: $0) }
         }
     }
+
+    /// Groups nothing draws by default — "Disk Ops", "Network Packets",
+    /// "Memory Paging". They have to land somewhere once they are ticked, and
+    /// performance is what they are, so they go after the named performance
+    /// cards and before the section rule.
+    private var extraGroupNames: [String] {
+        let named = Set(
+            LayoutDefaults.performanceGroupOrder + LayoutDefaults.sensorGroupOrder
+        )
+        return groups().map(\.name).filter { !named.contains($0) }
+    }
+
+    /// Chart cards above the section rule.
+    public var performanceGroups: [(name: String, metrics: [MetricID])] {
+        chartGroups(in: LayoutDefaults.performanceGroupOrder + extraGroupNames)
+    }
+
+    /// Chart cards below the rule: temperature, fans, power.
+    public var sensorGroups: [(name: String, metrics: [MetricID])] {
+        chartGroups(in: LayoutDefaults.sensorGroupOrder)
+    }
+
+    /// Groups with at least one charted metric, in registry order. A group
+    /// whose metrics are all unticked has no card at all rather than an empty
+    /// one.
+    private var chartGroups: [(name: String, metrics: [MetricID])] {
+        groups().compactMap { group in
+            let metrics = group.metrics.filter(layout.showsChart)
+            return metrics.isEmpty ? nil : (name: group.name, metrics: metrics)
+        }
+    }
+
+    private func chartGroups(in order: [String]) -> [(name: String, metrics: [MetricID])] {
+        let available = Dictionary(
+            chartGroups.map { ($0.name, $0.metrics) }, uniquingKeysWith: { first, _ in first }
+        )
+        return order.compactMap { name in
+            guard let metrics = available[name] else { return nil }
+            return (name: name, metrics: metrics)
+        }
+    }
+
+    /// Puts every metric back to the layout the app ships with.
+    public func restoreDefaultLayout() {
+        layout = LayoutPreferences.defaults(for: Array(descriptors.values))
+    }
+
+    // MARK: - Gauge policy
 
     /// A sensible smallest full scale per unit, so an idle gauge does not sit
     /// pinned at the top of a dial reading 200 bytes a second.

--- a/Sources/MonitorUI/DashboardView.swift
+++ b/Sources/MonitorUI/DashboardView.swift
@@ -35,17 +35,22 @@ public struct DashboardView: View {
     public var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: Theme.Layout.gridSpacing) {
-                gaugeWall
-                resizeHandle
-                charts(Self.performanceGroupOrder)
+                // Both halves are optional now that the layout is chosen in
+                // preferences. A wall with no dials on it would otherwise leave
+                // a drag handle with nothing to drag.
+                if !gaugeMetrics.isEmpty {
+                    gaugeWall
+                    resizeHandle
+                }
+                charts(model.performanceGroups)
                 // Sensors are a different question from performance. What the
                 // machine is doing and how hot it is getting are read at
                 // different moments and for different reasons, and mixing them
                 // into one grid means hunting for the temperature card among
                 // the throughput ones.
-                if !groups(in: Self.sensorGroupOrder).isEmpty {
+                if !model.sensorGroups.isEmpty {
                     sectionRule
-                    charts(Self.sensorGroupOrder)
+                    charts(model.sensorGroups)
                 }
             }
             .padding(Theme.Layout.pagePadding)
@@ -58,17 +63,9 @@ public struct DashboardView: View {
 
     // MARK: - Gauges
 
-    private var gaugeMetrics: [MetricID] {
-        // Fixed order rather than whatever the registry yields, so the dials do
-        // not move around between launches. A gauge you have to hunt for is a
-        // gauge you stop glancing at.
-        [
-            MetricID("disk.bytes.read"),
-            MetricID("disk.bytes.written"),
-            MetricID("net.bits.in"),
-            MetricID("net.bits.out"),
-        ].filter { model.descriptor($0) != nil }
-    }
+    /// Whichever dials preferences say to draw, in a fixed order — see
+    /// `AppModel.gaugeMetrics`.
+    private var gaugeMetrics: [MetricID] { model.gaugeMetrics }
 
     /// The largest dial that still fits the whole row in the window.
     ///
@@ -204,36 +201,6 @@ public struct DashboardView: View {
 
     // MARK: - Charts
 
-    /// Which groups get a chart card, in the order they appear.
-    ///
-    /// Named explicitly rather than derived, for the same reason as the gauge
-    /// list: cards that move between launches are cards you have to hunt for.
-    /// Deriving it also cannot express the two decisions encoded here — that
-    /// disk and network throughput deserve a chart *as well as* a dial, since a
-    /// needle cannot tell you a transfer has been running for a minute; and
-    /// that "Disk Ops", "Network Packets" and "Memory Paging" are diagnostic
-    /// detail that belongs in `monitorctl`, not on a dashboard you glance at.
-    private static let performanceGroupOrder = [
-        "CPU", "CPU Cores", "Memory", "Disk", "Network", "GPU", "Disk Latency",
-    ]
-
-    /// What the machine is doing to itself: heat, fans, watts. Every one of
-    /// these is missing on some Mac — a fanless laptop has no fans, a desktop
-    /// has no battery — so the section draws only what this machine reports and
-    /// disappears entirely on a machine that reports none of it.
-    private static let sensorGroupOrder = ["Temperature", "Fans", "Power"]
-
-    private func groups(in order: [String]) -> [(name: String, metrics: [MetricID])] {
-        let available = Dictionary(
-            model.groups().map { ($0.name, $0.metrics) },
-            uniquingKeysWith: { first, _ in first }
-        )
-        return order.compactMap { name in
-            guard let metrics = available[name], !metrics.isEmpty else { return nil }
-            return (name: name, metrics: metrics)
-        }
-    }
-
     /// The line between the two sections. Deliberately the same rule as the one
     /// under the gauges, minus the drag: one kind of divider on the panel.
     private var sectionRule: some View {
@@ -243,14 +210,14 @@ public struct DashboardView: View {
             .padding(.vertical, 2)
     }
 
-    private func charts(_ order: [String]) -> some View {
+    private func charts(_ groups: [(name: String, metrics: [MetricID])]) -> some View {
         LazyVGrid(
             columns: [GridItem(
                 .adaptive(minimum: Theme.Layout.chartMinimum), spacing: Theme.Layout.gridSpacing
             )],
             spacing: Theme.Layout.gridSpacing
         ) {
-            ForEach(groups(in: order), id: \.name) { group in
+            ForEach(groups, id: \.name) { group in
                 ChartCard(
                     title: group.name,
                     series: group.metrics.compactMap { metric in

--- a/Sources/MonitorUI/LayoutPreferencesStore.swift
+++ b/Sources/MonitorUI/LayoutPreferencesStore.swift
@@ -1,0 +1,50 @@
+import Foundation
+import MonitorCore
+
+/// Where the layout choices are kept between launches.
+///
+/// `UserDefaults`, which is the one place a Mac app is expected to write. Note
+/// what this is not: the app still writes no *history* to disk, and still does
+/// not link `MonitorStore`. The argument against storing samples is about SSD
+/// endurance — a monitor runs all day, and a sample every half second forever
+/// costs real writes. A checkbox written when somebody ticks it costs nothing,
+/// and the alternative is a preferences pane that forgets.
+enum LayoutPreferencesStore {
+    static let key = "layout.preferences"
+
+    /// Named explicitly rather than taken from `.standard`.
+    ///
+    /// `.standard` keys off the bundle identifier, and `swift run monitor` has
+    /// no bundle: the development build would write to a domain called
+    /// `monitor` and `monitor.app` to `wtf.evan.monitor`, so a layout chosen in
+    /// one would be invisible in the other. Same reasoning as the version
+    /// string — the two builds are the same program and must not disagree.
+    /// Computed rather than stored because a `static let` holding a
+    /// non-`Sendable` class is a concurrency error under Swift 6, and
+    /// `UserDefaults` is cheap to ask for and shared behind the scenes anyway.
+    static var suite: UserDefaults { UserDefaults(suiteName: domain) ?? .standard }
+
+    static let domain = "wtf.evan.monitor"
+
+    /// Reads the stored layout and gives any metric it has not seen its
+    /// default. A first launch, a corrupt value and a missing key all end up
+    /// in the same place: the defaults for whatever this machine reports.
+    static func load(
+        for descriptors: [MetricDescriptor], from defaults: UserDefaults = suite
+    ) -> LayoutPreferences {
+        guard let data = defaults.data(forKey: key),
+              let stored = try? JSONDecoder().decode(LayoutPreferences.self, from: data)
+        else {
+            return LayoutPreferences.defaults(for: descriptors)
+        }
+        return stored.adoptingDefaults(for: descriptors)
+    }
+
+    static func save(_ preferences: LayoutPreferences, to defaults: UserDefaults = suite) {
+        guard let data = try? JSONEncoder().encode(preferences) else {
+            log.error("Could not encode layout preferences")
+            return
+        }
+        defaults.set(data, forKey: key)
+    }
+}

--- a/Sources/MonitorUI/PreferencesView.swift
+++ b/Sources/MonitorUI/PreferencesView.swift
@@ -64,25 +64,80 @@ struct LayoutTab: View {
         .padding(.vertical, 12)
     }
 
+    /// Sections the reader has folded away. Empty to start: a list that opens
+    /// half closed hides the thing somebody came here to find.
+    ///
+    /// View state rather than a stored preference. Collapsing is how you get a
+    /// long list out of the way while you work on one group, which is a
+    /// decision for the next thirty seconds, not for the next month.
+    @State private var collapsed: Set<String> = []
+
     private var list: some View {
         ScrollView {
             Grid(alignment: .leading, horizontalSpacing: 14, verticalSpacing: 7) {
                 header
                 ForEach(sections, id: \.name) { section in
-                    GridRow {
-                        Text(section.name)
-                            .font(.headline)
-                            .gridCellColumns(3)
-                    }
-                    .padding(.top, 6)
-                    ForEach(section.metrics, id: \.self) { metric in
-                        if let descriptor = model.descriptor(metric) {
-                            row(descriptor)
+                    sectionHeader(section)
+                    if !collapsed.contains(section.name) {
+                        ForEach(section.metrics, id: \.self) { metric in
+                            if let descriptor = model.descriptor(metric) {
+                                row(descriptor)
+                            }
                         }
                     }
                 }
             }
             .padding(16)
+        }
+    }
+
+    /// A group's heading: a disclosure triangle, the group name, and the two
+    /// checkboxes that set every metric under it.
+    ///
+    /// The section checkbox is the same control as the row checkboxes, one
+    /// level up — tick it and the whole column turns on, untick it and the
+    /// whole column turns off. It draws itself as mixed when the rows disagree,
+    /// which is what makes a collapsed section still readable: a dash rather
+    /// than a tick says "some of these", so folding a group away does not hide
+    /// what state it is in.
+    private func sectionHeader(
+        _ section: (name: String, metrics: [MetricID])
+    ) -> some View {
+        GridRow {
+            Button {
+                toggleCollapsed(section.name)
+            } label: {
+                HStack(spacing: 6) {
+                    Image(systemName: "chevron.down")
+                        .font(.caption2.weight(.bold))
+                        .foregroundStyle(.secondary)
+                        // Rotated rather than swapped for a second symbol, so
+                        // the triangle turns instead of blinking.
+                        .rotationEffect(.degrees(collapsed.contains(section.name) ? -90 : 0))
+                    Text(section.name).font(.headline)
+                    Spacer()
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("\(section.name) metrics")
+            .accessibilityValue(collapsed.contains(section.name) ? "collapsed" : "expanded")
+
+            SectionToggle(model: model, section: section.name,
+                          metrics: section.metrics, column: .gauge)
+                .gridColumnAlignment(.center)
+            SectionToggle(model: model, section: section.name,
+                          metrics: section.metrics, column: .chart)
+                .gridColumnAlignment(.center)
+        }
+        .padding(.top, 6)
+    }
+
+    private func toggleCollapsed(_ section: String) {
+        if collapsed.contains(section) {
+            collapsed.remove(section)
+        } else {
+            collapsed.insert(section)
         }
     }
 
@@ -119,41 +174,48 @@ struct LayoutTab: View {
 }
 
 /// One checkbox in the grid.
-///
-/// Its own view rather than a helper returning `some View` because the binding
-/// has to read and write the model, and a view that owns the model is the
-/// straightforward way to say that.
 private struct LayoutToggle: View {
-    enum Column: String {
-        case gauge, chart
-    }
-
     @Bindable var model: AppModel
     let descriptor: MetricDescriptor
-    let column: Column
+    let column: AppModel.LayoutColumn
 
     var body: some View {
         // The label is hidden but not absent: without it a screen reader reads
         // a column of unnamed checkboxes, and the column heading is rows away.
         Toggle(
-            "\(descriptor.group) \(descriptor.name) \(column.rawValue)", isOn: binding
+            "\(descriptor.group) \(descriptor.name) \(column.rawValue)",
+            isOn: model.binding(column, for: descriptor.id)
         )
         .labelsHidden()
     }
+}
 
-    private var binding: Binding<Bool> {
-        switch column {
-        case .gauge:
-            Binding(
-                get: { model.layout.showsGauge(descriptor.id) },
-                set: { model.layout.setGauge($0, for: descriptor.id) }
-            )
-        case .chart:
-            Binding(
-                get: { model.layout.showsChart(descriptor.id) },
-                set: { model.layout.setChart($0, for: descriptor.id) }
-            )
-        }
+/// The checkbox in a section heading, which sets every metric under it.
+///
+/// `Toggle(_:sources:isOn:)` rather than a `Bool` of our own: given the row
+/// bindings it derives the three states itself — on when all agree, off when
+/// none, mixed when they disagree — and writes to all of them when clicked.
+/// A hand-rolled version would have to keep a separate flag in step with the
+/// rows, which is the bug this API exists to remove.
+private struct SectionToggle: View {
+    /// One row's binding, wrapped because `sources:` takes a collection of
+    /// elements and a key path to the binding inside each.
+    private struct Entry {
+        let binding: Binding<Bool>
+    }
+
+    @Bindable var model: AppModel
+    let section: String
+    let metrics: [MetricID]
+    let column: AppModel.LayoutColumn
+
+    var body: some View {
+        Toggle(
+            "All \(section) \(column.rawValue)s",
+            sources: metrics.map { Entry(binding: model.binding(column, for: $0)) },
+            isOn: \.binding
+        )
+        .labelsHidden()
     }
 }
 

--- a/Sources/MonitorUI/PreferencesView.swift
+++ b/Sources/MonitorUI/PreferencesView.swift
@@ -1,0 +1,162 @@
+import MonitorCore
+import SwiftUI
+
+/// The preferences window, opened with Cmd-, from the app menu.
+///
+/// Tabbed, with one tab in it. That looks like overkill until the second tab
+/// arrives — a `TabView` added later moves every control down by the height of
+/// the tab bar, and a preferences window that changes shape between versions is
+/// one people have to re-learn. The frame is fixed for the same reason: a
+/// settings window is not a document window.
+public struct PreferencesView: View {
+    @Bindable private var model: AppModel
+
+    public init(model: AppModel) {
+        _model = Bindable(model)
+    }
+
+    public var body: some View {
+        TabView {
+            LayoutTab(model: model)
+                .tabItem { Label("Layout", systemImage: "square.grid.2x2") }
+        }
+        .frame(width: 460, height: 520)
+    }
+}
+
+/// Which metrics get a dial and which get a line, one row per metric.
+///
+/// Every metric this machine reports is listed, including the ones nothing
+/// draws by default. That is the point: the panel ships with a considered
+/// layout, and this is where you disagree with it.
+struct LayoutTab: View {
+    @Bindable var model: AppModel
+
+    /// Rows grouped the way the panel groups them, in the order the panel lays
+    /// them out, so the list reads like the window it configures.
+    private var sections: [(name: String, metrics: [MetricID])] {
+        model.groupOrder
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            explanation
+            Divider()
+            list
+            Divider()
+            footer
+        }
+    }
+
+    /// The one thing about this screen that is not obvious from the checkboxes:
+    /// a chart is per group, so two ticks in the same group give one card with
+    /// two lines rather than two cards.
+    private var explanation: some View {
+        Text(
+            "A gauge is one dial per metric. A chart is one card per group, "
+                + "so metrics in the same group share it — tick Network In and "
+                + "Network Out and both lines land on the Network chart."
+        )
+        .font(.callout)
+        .foregroundStyle(.secondary)
+        .fixedSize(horizontal: false, vertical: true)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+    }
+
+    private var list: some View {
+        ScrollView {
+            Grid(alignment: .leading, horizontalSpacing: 14, verticalSpacing: 7) {
+                header
+                ForEach(sections, id: \.name) { section in
+                    GridRow {
+                        Text(section.name)
+                            .font(.headline)
+                            .gridCellColumns(3)
+                    }
+                    .padding(.top, 6)
+                    ForEach(section.metrics, id: \.self) { metric in
+                        if let descriptor = model.descriptor(metric) {
+                            row(descriptor)
+                        }
+                    }
+                }
+            }
+            .padding(16)
+        }
+    }
+
+    private var header: some View {
+        GridRow {
+            // The name column takes the slack, so the two checkbox columns sit
+            // against the right edge of the window instead of huddling in the
+            // middle with the width of the longest metric name.
+            Text("Metric").frame(maxWidth: .infinity, alignment: .leading)
+            Text("Gauge")
+            Text("Chart")
+        }
+        .font(.caption.weight(.semibold))
+        .foregroundStyle(.secondary)
+    }
+
+    private func row(_ descriptor: MetricDescriptor) -> some View {
+        GridRow {
+            Text(descriptor.name).frame(maxWidth: .infinity, alignment: .leading)
+            LayoutToggle(model: model, descriptor: descriptor, column: .gauge)
+                .gridColumnAlignment(.center)
+            LayoutToggle(model: model, descriptor: descriptor, column: .chart)
+                .gridColumnAlignment(.center)
+        }
+    }
+
+    private var footer: some View {
+        HStack {
+            Button("Restore Defaults") { model.restoreDefaultLayout() }
+            Spacer()
+        }
+        .padding(16)
+    }
+}
+
+/// One checkbox in the grid.
+///
+/// Its own view rather than a helper returning `some View` because the binding
+/// has to read and write the model, and a view that owns the model is the
+/// straightforward way to say that.
+private struct LayoutToggle: View {
+    enum Column: String {
+        case gauge, chart
+    }
+
+    @Bindable var model: AppModel
+    let descriptor: MetricDescriptor
+    let column: Column
+
+    var body: some View {
+        // The label is hidden but not absent: without it a screen reader reads
+        // a column of unnamed checkboxes, and the column heading is rows away.
+        Toggle(
+            "\(descriptor.group) \(descriptor.name) \(column.rawValue)", isOn: binding
+        )
+        .labelsHidden()
+    }
+
+    private var binding: Binding<Bool> {
+        switch column {
+        case .gauge:
+            Binding(
+                get: { model.layout.showsGauge(descriptor.id) },
+                set: { model.layout.setGauge($0, for: descriptor.id) }
+            )
+        case .chart:
+            Binding(
+                get: { model.layout.showsChart(descriptor.id) },
+                set: { model.layout.setChart($0, for: descriptor.id) }
+            )
+        }
+    }
+}
+
+#Preview {
+    PreferencesView(model: AppModel())
+}

--- a/Sources/monitor/MonitorApp.swift
+++ b/Sources/monitor/MonitorApp.swift
@@ -13,15 +13,26 @@ import SwiftUI
 struct MonitorApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) private var delegate
 
+    /// One model behind both scenes. The preferences window edits the same
+    /// layout the dashboard draws from, so a checkbox takes effect while you
+    /// are looking at it rather than at the next launch.
+    @State private var model = AppModel()
+
     var body: some Scene {
         Window("Monitor", id: "monitor") {
-            DashboardView()
+            DashboardView(model: model)
                 .frame(minWidth: 720, minHeight: 560)
         }
         // Dark only for now. The instrument panel is designed against a dark
         // ground and a light mode is a separate palette, not a toggle.
         .defaultSize(width: 1000, height: 760)
         .commands { AboutCommand() }
+
+        // A `Settings` scene rather than a window of our own: it is what puts
+        // "Settings…" in the app menu under Cmd-, where people look for it.
+        Settings {
+            PreferencesView(model: model)
+        }
     }
 }
 

--- a/Tests/MonitorCoreTests/LayoutPreferencesTests.swift
+++ b/Tests/MonitorCoreTests/LayoutPreferencesTests.swift
@@ -1,0 +1,100 @@
+import Foundation
+@testable import MonitorCore
+import Testing
+
+@Suite("LayoutPreferences")
+struct LayoutPreferencesTests {
+    /// A stand-in registry: one metric from each of the three cases the
+    /// defaults distinguish — a dial, a chart-only group, and a group nothing
+    /// draws until somebody asks for it.
+    static let descriptors = [
+        MetricDescriptor(
+            id: MetricID("disk.bytes.read"), name: "Read", group: "Disk",
+            unit: .bytesPerSecond, kind: .counter
+        ),
+        MetricDescriptor(
+            id: MetricID("cpu.total"), name: "Total", group: "CPU", unit: .fraction
+        ),
+        MetricDescriptor(
+            id: MetricID("disk.ops.read"), name: "Reads", group: "Disk Ops",
+            unit: .operationsPerSecond, kind: .counter
+        ),
+    ]
+
+    @Test("Defaults draw the panel the app ships with")
+    func defaults() {
+        let layout = LayoutPreferences.defaults(for: Self.descriptors)
+
+        #expect(layout.showsGauge(MetricID("disk.bytes.read")))
+        #expect(layout.showsChart(MetricID("disk.bytes.read")))
+
+        // A level, so a chart and no dial.
+        #expect(!layout.showsGauge(MetricID("cpu.total")))
+        #expect(layout.showsChart(MetricID("cpu.total")))
+
+        // Diagnostic detail: neither, until somebody ticks it.
+        #expect(!layout.showsGauge(MetricID("disk.ops.read")))
+        #expect(!layout.showsChart(MetricID("disk.ops.read")))
+    }
+
+    @Test("Setting one column leaves the other alone")
+    func columnsAreIndependent() {
+        var layout = LayoutPreferences.defaults(for: Self.descriptors)
+
+        layout.setGauge(true, for: MetricID("cpu.total"))
+        #expect(layout.showsGauge(MetricID("cpu.total")))
+        #expect(layout.showsChart(MetricID("cpu.total")))
+
+        layout.setChart(false, for: MetricID("cpu.total"))
+        #expect(layout.showsGauge(MetricID("cpu.total")))
+        #expect(!layout.showsChart(MetricID("cpu.total")))
+    }
+
+    /// The case this exists for: a later version adds a metric, or a machine
+    /// starts reporting a sensor it did not before. The new one gets its
+    /// default; nothing already chosen moves.
+    @Test("A metric the stored layout never saw gets its default")
+    func newMetricAdoptsDefaults() {
+        var stored = LayoutPreferences.defaults(for: [Self.descriptors[0]])
+        stored.setGauge(false, for: MetricID("disk.bytes.read"))
+
+        let merged = stored.adoptingDefaults(for: Self.descriptors)
+
+        // The choice already made survives the merge.
+        #expect(!merged.showsGauge(MetricID("disk.bytes.read")))
+        #expect(merged.showsChart(MetricID("disk.bytes.read")))
+        // The metric it had never seen picks up the shipped layout.
+        #expect(merged.showsChart(MetricID("cpu.total")))
+        #expect(!merged.showsChart(MetricID("disk.ops.read")))
+    }
+
+    /// A metric switched off is not the same as one never seen, so the merge
+    /// must not switch it back on.
+    @Test("Turning everything off survives a merge")
+    func everythingOffSurvives() {
+        var layout = LayoutPreferences()
+        for descriptor in Self.descriptors {
+            layout.setGauge(false, for: descriptor.id)
+            layout.setChart(false, for: descriptor.id)
+        }
+
+        let merged = layout.adoptingDefaults(for: Self.descriptors)
+
+        for descriptor in Self.descriptors {
+            #expect(!merged.showsGauge(descriptor.id))
+            #expect(!merged.showsChart(descriptor.id))
+        }
+    }
+
+    @Test("A layout round-trips through JSON")
+    func roundTrip() throws {
+        var layout = LayoutPreferences.defaults(for: Self.descriptors)
+        layout.setChart(true, for: MetricID("disk.ops.read"))
+
+        let data = try JSONEncoder().encode(layout)
+        let decoded = try JSONDecoder().decode(LayoutPreferences.self, from: data)
+
+        #expect(decoded == layout)
+        #expect(decoded.showsChart(MetricID("disk.ops.read")))
+    }
+}

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -2,14 +2,53 @@
 
 ## Gauges for rates, charts for levels
 
-`AppModel.isGauge` splits them by unit: `bytesPerSecond`, `bitsPerSecond` and
-`operationsPerSecond` get a dial, everything else gets a chart.
+`LayoutDefaults` splits them: disk and network throughput open with a dial,
+everything the panel draws opens with a chart.
 
 The split is not decorative. A dial answers *"how hard is this working right
 now, against what it can do"* — the right question for disk and network
 throughput. A chart answers *"what has been happening"* — the right question for
 CPU and memory, where a needle would just wobble and tell you nothing about the
 last two minutes.
+
+It is a default rather than a rule. Every metric can have either, both or
+neither, chosen per metric in preferences — see below.
+
+## Choosing the layout
+
+Preferences (Cmd-,) is a tabbed window with one tab, Layout: every metric this
+machine reports, one row each, with a Gauge checkbox and a Chart checkbox.
+
+The two columns are not symmetrical, and that is the one thing about the screen
+worth explaining:
+
+- **A gauge is per metric.** Tick Network In and Network Out and you get two
+  dials, because a dial shows one number.
+- **A chart is per group.** Tick both and you get *one* Network card with two
+  lines, because in and out are only readable against each other. A group whose
+  metrics are all unticked has no card at all rather than an empty one.
+
+`LayoutPreferences` holds the two sets and lives in `MonitorCore`, so the merge
+rules are testable without a window. It records which metrics it has an opinion
+about as well as which are on: without that, a metric added by a later version
+looks exactly like one somebody switched off, and would be silently missing.
+`adoptingDefaults(for:)` gives an unseen metric its default and leaves every
+choice already made alone.
+
+Order is fixed, not derived. `LayoutDefaults.gaugeOrder` places the four dials
+the app opens with, and anything else ticked goes after them by metric id;
+`performanceGroupOrder` and `sensorGroupOrder` place the cards, with groups on
+neither list — `Disk Ops`, `Network Packets`, `Memory Paging` — landing after
+the named performance cards. A dial or a card that moves between launches is one
+you have to hunt for.
+
+The choices are written to `UserDefaults` under `wtf.evan.monitor`, named
+explicitly rather than taken from `.standard`: `swift run monitor` has no
+bundle, so `.standard` would give the development build its own domain and a
+layout chosen in one build would be invisible in the other. Note what this is
+not — the app still writes no *history* to disk and still does not link
+`MonitorStore`. The argument in `storage.md` is about a sample every half second
+forever, not about a checkbox written when somebody ticks it.
 
 ## The auto-ranging dial
 
@@ -235,13 +274,14 @@ their labels never change at all.
 
 ## Which cards appear, and what they are bounded by
 
-`DashboardView.chartGroupOrder` names the chart cards explicitly, in order, for
-the same reason the gauge list is explicit: cards that move between launches are
-cards you have to hunt for. It also carries two decisions that deriving the list
-could not express — that disk and network throughput deserve a chart *as well as*
-a dial, because a needle cannot tell you a transfer has been running for a
-minute; and that `Disk Ops`, `Network Packets` and `Memory Paging` are diagnostic
-detail belonging in `monitorctl` rather than on a dashboard you glance at.
+`LayoutDefaults` names the chart cards explicitly, in order, for the same reason
+the gauge list is explicit: cards that move between launches are cards you have
+to hunt for. It also carries two decisions that deriving the list could not
+express — that disk and network throughput deserve a chart *as well as* a dial,
+because a needle cannot tell you a transfer has been running for a minute; and
+that `Disk Ops`, `Network Packets` and `Memory Paging` are diagnostic detail
+belonging in `monitorctl` rather than on a dashboard you glance at. Both are
+opening positions rather than verdicts: the Layout tab is where you disagree.
 
 Two things bound a chart to its card:
 

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -28,6 +28,18 @@ worth explaining:
   lines, because in and out are only readable against each other. A group whose
   metrics are all unticked has no card at all rather than an empty one.
 
+Each group is a collapsible section, and its heading carries the same two
+checkboxes one level up: they set every metric under it. They are built with
+`Toggle(_:sources:isOn:)`, given the row bindings, so the three states come from
+the rows rather than from a flag kept in step with them — on when all agree, off
+when none, **mixed** when they disagree. The mixed dash is what keeps a folded
+section readable: "some of these" is visible without unfolding it.
+
+Collapsing is view state, not a stored preference. It is how you get a long list
+out of the way while working on one group — a decision for the next thirty
+seconds, not the next month — and a preferences window that opens half closed
+hides the thing somebody came to find.
+
 `LayoutPreferences` holds the two sets and lives in `MonitorCore`, so the merge
 rules are testable without a window. It records which metrics it has an opinion
 about as well as which are on: without that, a metric added by a later version


### PR DESCRIPTION
Preferences (Cmd-,) is a tabbed window with one tab, **Layout**: every metric this machine reports, one row each, with a Gauge checkbox and a Chart checkbox. The tab bar is there with one tab on purpose — adding a `TabView` later moves every control down by its height, and a preferences window that changes shape between versions is one people have to re-learn.

## The two columns are deliberately not symmetrical

- **A gauge is per metric**, because a dial shows one number.
- **A chart is per group**, because in and out are only readable against each other: ticking the chart column for Network In and Network Out gives one Network card with two lines, not two cards. A group with nothing ticked draws no card at all rather than an empty one.

## Sections

Each group is a disclosure section whose heading carries the same two checkboxes one level up, setting every metric in that group and column at once. They are built with `Toggle(_:sources:isOn:)` given the row bindings, so the three states are derived rather than tracked — on when the rows agree, off when none is on, **mixed** when they disagree. The mixed dash is what keeps a folded section readable.

Collapsing is view state rather than a stored preference: it is how you get the rest of the list out of the way while working on one group, and a preferences window that opens half closed hides the thing somebody came to find.

## Model

`LayoutPreferences` lives in `MonitorCore` so the merge rules are testable without a window. It records which metrics it has an opinion about as well as which are on — otherwise a metric added by a later version, or a sensor a machine starts reporting, is indistinguishable from one somebody switched off and would stay silently missing. `adoptingDefaults(for:)` gives an unseen metric its default and leaves every choice already made alone.

The lists `DashboardView` hard-coded become `LayoutDefaults`, now two things at once: the starting state of a fresh preference set, and the order things appear in. Order matters as much as membership — a dial or a card that moves between launches is one you have to hunt for — so enabling a metric adds it at a fixed position. `AppModel.isGauge` goes with them; the unit rule it encoded was never what the gauge wall actually used, which was an explicit list of four.

`AppModel` now builds a `GaugeScale` for every metric rather than only the ones with a dial today. Auto-ranging needs history, and a scale created the moment its checkbox is ticked would start at the floor and climb, so the first reading on a new dial would sit pinned at full deflection.

## Persistence

Choices go to `UserDefaults` under `wtf.evan.monitor`, named explicitly rather than taken from `.standard`: `swift run monitor` has no bundle, so `.standard` would give the development build its own domain and a layout chosen in one build would be invisible in the other — the same reasoning as the version string.

**This is not the storage decision v1 defers.** The app still writes no history and still does not link `MonitorStore`. The argument in `docs/storage.md` is about a sample every half second forever, not a checkbox written when somebody ticks it.

## Verified

Looked at in the running app, not only built: defaults render the dashboard unchanged; ticking CPU → Total adds a live 0–100 % dial immediately and it survives a relaunch; a heading checkbox sets all seven Memory gauges in one click; collapsing a section keeps its mixed dash visible.

`swift build`, 81 tests, the release build and the swiftformat lint gate all pass.