### PR TITLE
Version 1.1.0: the preferences screen

### DIFF
--- a/Sources/MonitorCore/Version.swift
+++ b/Sources/MonitorCore/Version.swift
@@ -5,5 +5,5 @@
 /// unbundled one cannot claim different versions. Keep the literal on one
 /// line: the script's pattern expects it there.
 public enum MonitorVersion {
-    public static let string = "1.0.0"
+    public static let string = "1.1.0"
 }


### PR DESCRIPTION
Bumps `MonitorVersion.string` to 1.1.0, which is what tags the release and publishes `monitor-1.1.0.zip`.

A minor bump rather than a patch: #12 added a preferences window with a Layout tab, where every metric gets a Gauge checkbox and a Chart checkbox. Nothing was removed and the default layout is unchanged, so an existing user sees the same panel until they open Cmd-, and disagree with it.