### PR TITLE
Release on every merge, and work out the version number here

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,27 @@
 name: Release
 
-# Two ways a release begins, and both end in the Package workflow:
+# Every merge to main ships a release, and this workflow works out which
+# version it is.
 #
-#   1. A pull request lands on main that bumps `MonitorVersion.string`. This
-#      workflow tags that commit and publishes the release.
-#   2. Somebody publishes a release by hand from the GitHub UI.
+# The default is a patch bump. A `release:minor` or `release:major` label on
+# the pull request says otherwise, so the size of a release is decided during
+# review, on the pull request, rather than remembered at merge time. Labels
+# rather than commit-message prefixes because the commit style here is prose —
+# see AGENTS.md — and `feat:` in front of it would be a tax on every message
+# for the sake of two merges in ten.
 #
-# So shipping is a line in a diff, reviewed like any other change. A merge that
-# does not touch the version publishes nothing — most merges should not ship a
-# release, and a docs typo is not a new version.
+# Two things publish nothing: a `release:skip` label, and a merge that touched
+# only documentation or workflows. A typo in the README is not a new version.
+#
+# Two escape hatches survive from when every release was hand-cut:
+#
+#   1. A pull request that bumps `MonitorVersion.string` itself ships exactly
+#      that version. The automatic path is the default, not the only way.
+#   2. Somebody publishes a release by hand from the GitHub UI, which enters at
+#      the Package job below.
+#
+# The bump is committed back to main as `Version x.y.z [skip ci]`. The marker
+# is what stops this workflow from triggering itself, so do not remove it.
 #
 # A release created here by `gh` does *not* fire the `release: published`
 # event, because GitHub deliberately refuses to let the default token trigger
@@ -29,19 +42,27 @@ permissions:
   contents: write
 
 jobs:
-  # Decides whether this merge is a release, and creates it if it is.
+  # Works out this merge's version, writes it to Version.swift, and creates the
+  # release.
   tag:
     name: Tag a new version
-    if: github.event_name == 'push'
+    # The `[skip ci]` in the bump commit already stops GitHub from starting a
+    # run for it. This is the second lock on the same door: a workflow that can
+    # push to the branch it watches has to be unable to answer itself.
+    if: |
+      github.event_name == 'push'
+        && !contains(github.event.head_commit.message, '[skip ci]')
     # git and gh only — no build — so this stays off the Mac runner, which the
     # packaging job needs to itself.
     runs-on: [self-hosted, Linux, X64]
     outputs:
       tag: ${{ steps.check.outputs.tag }}
+      sha: ${{ steps.check.outputs.sha }}
     steps:
       - uses: actions/checkout@v4
         with:
-          # gh needs the tags to answer "does this one exist yet".
+          # gh needs the tags to answer "does this one exist yet", and the
+          # docs-only test needs the previous commit to diff against.
           fetch-depth: 0
 
       - name: Version
@@ -49,19 +70,83 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          version="$(sed -n 's/.*static let string = "\(.*\)".*/\1/p' \
-              Sources/MonitorCore/Version.swift)"
-          [ -n "$version" ] || { echo "no version in Version.swift" >&2; exit 1; }
-          tag="v$version"
+          set -euo pipefail
 
-          if git rev-parse -q --verify "refs/tags/$tag" >/dev/null; then
-            echo "$tag exists — this merge is not a release." >> "$GITHUB_STEP_SUMMARY"
-            echo "Bump MonitorVersion.string to ship one." >> "$GITHUB_STEP_SUMMARY"
+          current="$(sed -n 's/.*static let string = "\(.*\)".*/\1/p' \
+              Sources/MonitorCore/Version.swift)"
+          [ -n "$current" ] || { echo "no version in Version.swift" >&2; exit 1; }
+
+          # Escape hatch: a pull request that set the version itself ships that
+          # version untouched, exactly as it did before any of this was
+          # automatic.
+          if ! git rev-parse -q --verify "refs/tags/v$current" >/dev/null; then
+            echo "tag=v$current" >> "$GITHUB_OUTPUT"
+            echo "sha=$GITHUB_SHA" >> "$GITHUB_OUTPUT"
+            echo "Version.swift already says $current — releasing that." \
+                >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
 
-          echo "tag=$tag" >> "$GITHUB_OUTPUT"
-          echo "Releasing $tag" >> "$GITHUB_STEP_SUMMARY"
+          # Labels of the pull request this commit came from. A direct push to
+          # main belongs to no pull request, which is simply no labels.
+          labels="$(gh api "repos/$GITHUB_REPOSITORY/commits/$GITHUB_SHA/pulls" \
+              --jq '.[].labels[].name' | sort -u || true)"
+
+          if grep -qx 'release:skip' <<<"$labels"; then
+            echo "Labelled release:skip — publishing nothing." \
+                >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          # Documentation and workflow changes do not earn a version. The test
+          # is "nothing outside these paths changed", so a merge that touches
+          # docs *and* code still ships.
+          changed="$(git diff --name-only "$GITHUB_SHA^" "$GITHUB_SHA")"
+          if [ -n "$changed" ] \
+              && ! grep -qvE '^(docs/|\.github/|[^/]*\.md$)' <<<"$changed"; then
+            echo "Documentation only — publishing nothing." \
+                >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          level="patch"
+          if grep -qx 'release:minor' <<<"$labels"; then level="minor"; fi
+          if grep -qx 'release:major' <<<"$labels"; then level="major"; fi
+
+          IFS=. read -r major minor patch <<<"$current"
+          case "$level" in
+            major) major=$((major + 1)); minor=0; patch=0 ;;
+            minor) minor=$((minor + 1)); patch=0 ;;
+            patch) patch=$((patch + 1)) ;;
+          esac
+          next="$major.$minor.$patch"
+
+          if git rev-parse -q --verify "refs/tags/v$next" >/dev/null; then
+            echo "v$next already exists — refusing to overwrite it." >&2
+            exit 1
+          fi
+
+          sed -i "s/static let string = \"$current\"/static let string = \"$next\"/" \
+              Sources/MonitorCore/Version.swift
+          # A no-op sed means the literal moved or changed shape. Better to
+          # stop than to tag a commit that still says the old version.
+          if git diff --quiet; then
+            echo "version rewrite did nothing" >&2
+            exit 1
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email \
+              "41898282+github-actions[bot]@users.noreply.github.com"
+          # The marker is load-bearing: without it this commit starts another
+          # run of this workflow, which bumps the version again, forever.
+          git commit -qam "Version $next [skip ci]"
+          git push -q origin HEAD:main
+
+          echo "tag=v$next" >> "$GITHUB_OUTPUT"
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "Releasing v$next ($level bump from $current)" \
+              >> "$GITHUB_STEP_SUMMARY"
 
       # The app is signed ad-hoc, not with a Developer ID, and it is not
       # notarized. macOS quarantines anything a browser downloads, so without
@@ -73,6 +158,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.check.outputs.tag }}
+          # The bump commit, not the merge commit: the tag has to point at the
+          # code that carries this version number, or `monitor.app` reports the
+          # one before it.
+          SHA: ${{ steps.check.outputs.sha }}
         run: |
           command -v gh >/dev/null 2>&1 \
               || { echo "gh is not installed on this runner" >&2; exit 1; }
@@ -92,7 +181,7 @@ jobs:
           NOTES
 
           gh release create "$TAG" \
-              --target "$GITHUB_SHA" \
+              --target "$SHA" \
               --title "monitor ${TAG#v}" \
               --notes-file notes.md \
               --generate-notes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,7 @@ Tests/             MonitorCoreTests, MonitorSourcesTests, MonitorStoreTests
 docs/              README.md is the index
 .github/workflows/
   ci.yml           build, test, release build, CLI smoke test, lint
-  release.yml      tags a version bump merged to main, publishes the release
+  release.yml      bumps the version on a merge to main, tags it, releases it
   package.yml      reusable: builds monitor.app, zips it, attaches it to a tag
 ```
 
@@ -143,12 +143,22 @@ are no component-level AGENTS.md files.
   `docs/sensors.md` is the survey of what a Mac exposes and what it costs.
 - **The panel has two sections.** Performance above the rule, sensors below.
   The sensor section vanishes on a machine that reports none of it.
-- **Releasing is a version bump, nothing else.** Merge a pull request that
-  changes `MonitorVersion.string` and `release.yml` tags that commit, publishes
-  a release, and attaches `monitor-<version>.zip` built by `package.yml`. A
-  merge that leaves the version alone publishes nothing, which is what most
-  merges should do. A release published by hand from the GitHub UI gets its zip
-  the same way.
+- **Releasing is a merge, nothing else.** `release.yml` bumps
+  `MonitorVersion.string` itself on every merge to main, commits it back as
+  `Version x.y.z [skip ci]`, tags it, publishes the release and attaches
+  `monitor-<version>.zip` built by `package.yml`. **Never remove the
+  `[skip ci]`** — it is what stops the workflow triggering itself into an
+  endless bump.
+  - **The default is a patch bump.** `release:minor` or `release:major` on the
+    pull request says otherwise, so the size of a release is decided in review
+    rather than remembered at merge time. Labels rather than Conventional
+    Commit prefixes, because the commit style here is prose.
+  - **Two ways to publish nothing:** a `release:skip` label, or a merge that
+    touched only `docs/`, `.github/` and top-level `*.md`. A merge touching
+    docs *and* code still ships.
+  - **Two escape hatches:** a pull request that sets `MonitorVersion.string`
+    itself ships exactly that version, and a release published by hand from the
+    GitHub UI gets its zip the same way.
 - **The version lives in `MonitorCore/Version.swift`.** The About panel reads
   it at runtime and `make-app.sh` greps that file when it writes `Info.plist`,
   so a bundled build and `swift run monitor` cannot claim different versions.
@@ -244,7 +254,10 @@ are no component-level AGENTS.md files.
   workflow rather than listening for `release: published`, because a release
   created with the default `GITHUB_TOKEN` does not fire that event. Splitting
   them into two independent workflows would publish releases with no zip
-  attached.
+  attached. It also pushes to the branch it watches, which is a loop unless
+  both locks stay on: `[skip ci]` in the bump commit, and the `if:` guard on
+  the `tag` job that ignores a commit carrying it. The tag targets the bump
+  commit rather than `GITHUB_SHA`, or the zip reports the version before it.
 
 ## Troubleshooting
 
@@ -261,6 +274,13 @@ are no component-level AGENTS.md files.
   the candidate list in `GPUSource`.
 - **A pull request reports no CI**: it came from a fork, and the jobs skip fork
   pull requests on purpose. Re-run from a branch in this repository.
+- **A pull request reports no CI and did not come from a fork**: its commit
+  message or pull request body contains the skip-ci marker, probably while
+  *describing* the release workflow. GitHub reads that marker anywhere in a
+  commit message and starts no run at all, and a squash merge takes the pull
+  request body as the commit message — so a merge like that would also skip
+  the release. Write the marker as "skip-ci" in prose and keep the literal
+  form inside `release.yml`.
 - **CPU shows no cluster series**: correct on a machine with one performance
   level, or when the `hw.perflevel*` core counts do not sum to the core count.
   `CPUSource.readClusters` returns empty rather than guess a wrong split.


### PR DESCRIPTION
Shipping was a version bump merged by hand — a second pull request whose whole content was one string literal, which is a step that exists only because nobody had written this down. `release.yml` does it now.

## How the number is chosen

**The default is a patch bump.** A `release:minor` or `release:major` label on the pull request says otherwise, so the size of a release is settled during review, on the pull request, rather than remembered at merge time.

Labels rather than Conventional Commit prefixes: the commit style here is prose (see `AGENTS.md`), and putting `feat:` in front of every subject would be a tax on all of them for the sake of two merges in ten.

Four labels created on the repo: `release:major`, `release:minor`, `release:patch`, `release:skip`.

## What publishes nothing

- A `release:skip` label.
- A merge that touched only `docs/`, `.github/` and top-level `*.md`. The test is "nothing outside those paths changed", so a merge touching docs *and* code still ships.

## Escape hatches, both kept

- A pull request that sets `MonitorVersion.string` itself ships exactly that version — the automatic path is the default, not the only way.
- A release published by hand from the GitHub UI still gets its zip from `package.yml`.

## The loop guard

The bump is committed back to main with a skip-ci marker in its message. That marker is load-bearing twice over: GitHub starts no run for the commit, and the `tag` job's `if:` refuses one carrying it anyway. A workflow that pushes to the branch it watches has to be unable to answer itself, and one lock felt thin for a failure whose shape is an infinite loop.

The release now targets the bump commit rather than `GITHUB_SHA`. `package.yml` checks out the tag and greps `Version.swift` for the name of the zip, so a tag left on the merge commit would ship `monitor-<previous>.zip`.

**This description writes "skip-ci" rather than the literal marker on purpose.** The first push of this branch spelled it out in the commit message and GitHub started no workflow run at all — it reads that string anywhere in a message. A squash merge takes this body as the commit message, so spelling it out here would skip the release as well. `AGENTS.md` gains a troubleshooting entry for it.

## Verified

`actionlint` is clean on both workflows. The version arithmetic was exercised locally against every case: unlabelled → patch, `release:minor` → minor, `release:major` → 2.0.0, skip label, docs-only, docs+code (ships), and 1.9.9 → 1.10.0 for the carry.

Merging this is its own first test: it changes `.github/` **and** `AGENTS.md`, both on the docs-only list, so it should publish nothing. The merge after it is the one that ships v1.1.1.