### PR TITLE
Sign with a Developer ID and notarize, when there is one to sign with

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -43,7 +43,20 @@ jobs:
       - name: Test
         run: swift test
 
+      # Signing and notarizing are opt-in through repository variables, and both
+      # are all-or-nothing once set. The credentials live in the runner's own
+      # keychain — this is a Mac on a desk, not a disposable VM — so nothing
+      # secret passes through GitHub and these two variables are only names.
+      #
+      #   SIGN_IDENTITY    e.g. "Developer ID Application: NAME (TEAMID)"
+      #   NOTARY_PROFILE   a notarytool credential profile on that Mac
+      #
+      # Unset, a release is ad-hoc signed and unnotarized, exactly as before.
+      # Set, a failure to sign or notarize fails the release rather than
+      # quietly publishing a zip nobody can open. See docs/signing.md.
       - name: Build monitor.app
+        env:
+          MONITOR_SIGN_IDENTITY: ${{ vars.SIGN_IDENTITY }}
         run: Scripts/make-app.sh
 
       # ditto, not zip: a bundle holds symlinks and extended attributes, and
@@ -57,8 +70,23 @@ jobs:
           name="monitor-${version}.zip"
           ditto -c -k --keepParent .build/monitor.app "$name"
           echo "name=$name" >> "$GITHUB_OUTPUT"
-          echo "sha=$(shasum -a 256 "$name" | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
-          ls -lh "$name"
+
+      # Between zipping and the checksum, because notarize.sh rebuilds the zip
+      # around the stapled bundle: a checksum taken before this describes a file
+      # that no longer exists.
+      - name: Notarize
+        if: vars.NOTARY_PROFILE != ''
+        env:
+          MONITOR_NOTARY_PROFILE: ${{ vars.NOTARY_PROFILE }}
+        run: Scripts/notarize.sh .build/monitor.app "${{ steps.package.outputs.name }}"
+
+      - name: Checksum
+        id: checksum
+        env:
+          ZIP: ${{ steps.package.outputs.name }}
+        run: |
+          echo "sha=$(shasum -a 256 "$ZIP" | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+          ls -lh "$ZIP"
 
       # Uploaded on every run, released or not, so a manual run is a way to get
       # a build without publishing anything.
@@ -74,7 +102,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ inputs.tag }}
           ZIP: ${{ steps.package.outputs.name }}
-          SHA: ${{ steps.package.outputs.sha }}
+          SHA: ${{ steps.checksum.outputs.sha }}
         run: |
           if ! command -v gh >/dev/null 2>&1; then brew install gh; fi
           # The checksum rides along as a file rather than a line in the notes:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,11 +148,10 @@ jobs:
           echo "Releasing v$next ($level bump from $current)" \
               >> "$GITHUB_STEP_SUMMARY"
 
-      # The app is signed ad-hoc, not with a Developer ID, and it is not
-      # notarized. macOS quarantines anything a browser downloads, so without
-      # these two sentences a first launch is a dialog saying the app is
-      # damaged. The honest explanation belongs on the download page, not in an
-      # issue somebody files a week later.
+      # What the notes say about the first launch depends on whether the build
+      # is notarized, and NOTARY_PROFILE is what decides that (see package.yml).
+      # Telling people to right-click an app that opens perfectly well teaches
+      # them to do it to everything, which is worse than saying nothing.
       - name: Create release
         if: steps.check.outputs.tag != ''
         env:
@@ -162,12 +161,17 @@ jobs:
           # code that carries this version number, or `monitor.app` reports the
           # one before it.
           SHA: ${{ steps.check.outputs.sha }}
+          NOTARIZED: ${{ vars.NOTARY_PROFILE != '' }}
         run: |
           command -v gh >/dev/null 2>&1 \
               || { echo "gh is not installed on this runner" >&2; exit 1; }
           cat > notes.md <<'NOTES'
           Download the zip below, unzip it, and drag `monitor.app` to
           Applications. macOS 14 or later, Apple silicon or Intel.
+          NOTES
+
+          if [ "$NOTARIZED" != "true" ]; then
+            cat >> notes.md <<'NOTES'
 
           **First launch:** the app is not signed with a Developer ID and not
           notarized, so macOS blocks it. Right-click the app and choose Open,
@@ -179,6 +183,7 @@ jobs:
 
           Building it yourself avoids all of that — `Scripts/make-app.sh`.
           NOTES
+          fi
 
           gh release create "$TAG" \
               --target "$SHA" \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,7 @@ swift run monitorctl watch --json --count 5        # machine-readable, bounded
 swiftformat Sources Tests --lint --cache ignore    # CI lint gate
 Scripts/make-app.sh [dest]       # wrap the release binary in monitor.app
 Scripts/make-icon.swift out.icns # draw the app icon (make-app.sh calls this)
+Scripts/notarize.sh app zip      # notarize a Developer ID build and staple it
 ```
 
 `monitorctl` exists because sampling is the part most likely to be wrong and the
@@ -75,8 +76,9 @@ Sources/
                    linked into the app — see "Guardrails" below.
   monitor/         the app target (@main SwiftUI App) and its AppDelegate
   monitorctl/      headless CLI harness
-Scripts/           make-app.sh, which builds monitor.app, and make-icon.swift,
-                   which draws its icon
+Scripts/           make-app.sh, which builds monitor.app, make-icon.swift,
+                   which draws its icon, and notarize.sh, which notarizes and
+                   staples a Developer ID build
 Tests/             MonitorCoreTests, MonitorSourcesTests, MonitorStoreTests
 docs/              README.md is the index
 .github/workflows/
@@ -159,6 +161,14 @@ are no component-level AGENTS.md files.
   - **Two escape hatches:** a pull request that sets `MonitorVersion.string`
     itself ships exactly that version, and a release published by hand from the
     GitHub UI gets its zip the same way.
+- **Signing is off until two repository variables are set.** `SIGN_IDENTITY`
+  and `NOTARY_PROFILE` turn on Developer ID signing and notarization in
+  `package.yml`; unset, a release is ad-hoc signed exactly as before. Set,
+  failing to sign or notarize fails the release rather than publishing a zip
+  nobody can open. The credentials live in the Mac runner's keychain, not in
+  GitHub secrets. **`notarize.sh` rebuilds the zip after stapling** — `stapler`
+  writes into the bundle, not the archive, so the uploaded copy is unstapled
+  until it is made again. `docs/signing.md` is the setup.
 - **The version lives in `MonitorCore/Version.swift`.** The About panel reads
   it at runtime and `make-app.sh` greps that file when it writes `Info.plist`,
   so a bundled build and `swift run monitor` cannot claim different versions.

--- a/Scripts/make-app.sh
+++ b/Scripts/make-app.sh
@@ -12,9 +12,19 @@
 #   Scripts/make-app.sh              # build into .build/monitor.app
 #   Scripts/make-app.sh ~/Applications   # and copy it there
 #
-# No signing identity is used. The bundle is signed ad-hoc, which is what a
-# locally built app needs to keep a stable identity across launches. Shipping it
-# to another Mac needs a Developer ID and notarization, which this does not do.
+# Signing is by identity when there is one and ad-hoc when there is not:
+#
+#   MONITOR_SIGN_IDENTITY   codesign identity. Set it and signing must succeed;
+#                           the script fails rather than quietly shipping an
+#                           ad-hoc bundle nobody can install.
+#   unset                   a "Developer ID Application" identity in the
+#                           keychain is used if one is there, and an ad-hoc
+#                           signature if not.
+#
+# An ad-hoc signature is right for a local build — it keeps the app's identity
+# stable across rebuilds so macOS does not forget what it remembered about it —
+# and useless for shipping, because Gatekeeper rejects a downloaded copy. See
+# docs/signing.md.
 
 set -euo pipefail
 
@@ -89,10 +99,37 @@ cat > "$app/Contents/Info.plist" <<PLIST
 </plist>
 PLIST
 
-# Ad-hoc signature. Without one the bundle still runs, but macOS treats it as a
-# different app on every rebuild and forgets anything it remembered about it.
-codesign --force --sign - --timestamp=none "$app" >/dev/null 2>&1 \
-    || echo "warning: could not sign $app; it will still run" >&2
+# The identity to sign with: whatever was asked for, or a Developer ID in the
+# keychain, or nothing.
+identity="${MONITOR_SIGN_IDENTITY:-}"
+required=1
+if [ -z "$identity" ]; then
+    required=0
+    identity="$(security find-identity -v -p codesigning 2>/dev/null \
+        | sed -n 's/.*"\(Developer ID Application: .*\)"/\1/p' | head -1)"
+fi
+
+if [ -n "$identity" ]; then
+    # --options runtime and a secure timestamp are not optional extras: the
+    # notary service rejects a bundle without either, and both are impossible
+    # to add afterwards without signing again.
+    echo "Signing as ${identity}…"
+    if ! codesign --force --deep --options runtime --timestamp \
+            --sign "$identity" "$app"; then
+        echo "error: could not sign $app as $identity" >&2
+        exit 1
+    fi
+    codesign --verify --strict --verbose=2 "$app" 2>&1 | sed 's/^/  /'
+elif [ "$required" -eq 1 ]; then
+    echo "error: MONITOR_SIGN_IDENTITY is set but empty" >&2
+    exit 1
+else
+    # Ad-hoc. Without a signature the bundle still runs, but macOS treats it as
+    # a different app on every rebuild and forgets anything it remembered.
+    codesign --force --sign - --timestamp=none "$app" >/dev/null 2>&1 \
+        || echo "warning: could not sign $app; it will still run" >&2
+    echo "Signed ad-hoc — fine locally, not installable on another Mac."
+fi
 
 echo "Built $app"
 

--- a/Scripts/notarize.sh
+++ b/Scripts/notarize.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+#
+# Notarize a signed monitor.app and staple the ticket to it.
+#
+# Usage:
+#   Scripts/notarize.sh .build/monitor.app monitor-1.1.0.zip
+#
+# Needs a notarytool credential profile in the keychain, named by
+# MONITOR_NOTARY_PROFILE. Create it once per machine:
+#
+#   xcrun notarytool store-credentials monitor-notary \
+#       --apple-id you@example.com --team-id 94S5PZTVPY --password <app-specific>
+#
+# The zip is an argument rather than something this builds, because the caller
+# has already made one and notarization takes an archive: the notary service
+# does not accept a bare .app.
+#
+# **The zip is rebuilt at the end, and that is the point.** `stapler` writes the
+# ticket into the bundle, not into the archive, so the copy that was uploaded is
+# still unstapled. Publishing that one gives every downloader a Gatekeeper round
+# trip to Apple on first launch, and a straight failure if they are offline.
+#
+# See docs/signing.md.
+
+set -euo pipefail
+
+app="${1:-}"
+zip="${2:-}"
+profile="${MONITOR_NOTARY_PROFILE:-}"
+
+[ -d "$app" ] || { echo "usage: $0 <app> <zip>" >&2; exit 1; }
+[ -f "$zip" ] || { echo "usage: $0 <app> <zip>" >&2; exit 1; }
+[ -n "$profile" ] || { echo "MONITOR_NOTARY_PROFILE is not set" >&2; exit 1; }
+
+# A bundle signed ad-hoc is refused by the notary service with a message that
+# does not say so. Catching it here costs one command and a minute of waiting.
+if ! codesign --verify --strict --deep "$app" 2>/dev/null \
+    || ! codesign -dv "$app" 2>&1 | grep -q '^Authority=Developer ID Application'; then
+    echo "error: $app is not signed with a Developer ID Application identity" >&2
+    echo "       notarization would be rejected; see docs/signing.md" >&2
+    exit 1
+fi
+
+echo "Submitting ${zip} to the notary service…"
+# --wait, because the whole point here is that the zip we publish is stapled,
+# and stapling needs the ticket to exist. Apple usually answers in a couple of
+# minutes.
+xcrun notarytool submit "$zip" --keychain-profile "$profile" --wait
+
+echo "Stapling the ticket to ${app}…"
+xcrun stapler staple "$app"
+xcrun stapler validate "$app"
+
+echo "Rebuilding ${zip} around the stapled bundle…"
+rm -f "$zip"
+ditto -c -k --keepParent "$app" "$zip"
+
+# Gatekeeper's own verdict, which is the question a downloader is really asking.
+# It reads the staple rather than calling Apple, so this passes with the network
+# off — which is the difference stapling buys.
+spctl --assess --type execute --verbose=2 "$app"
+
+echo "Notarized and stapled."

--- a/Scripts/notarize.sh
+++ b/Scripts/notarize.sh
@@ -34,8 +34,14 @@ profile="${MONITOR_NOTARY_PROFILE:-}"
 
 # A bundle signed ad-hoc is refused by the notary service with a message that
 # does not say so. Catching it here costs one command and a minute of waiting.
-if ! codesign --verify --strict --deep "$app" 2>/dev/null \
-    || ! codesign -dv "$app" 2>&1 | grep -q '^Authority=Developer ID Application'; then
+# Two traps in one line, both of which reported a correctly signed bundle as
+# unsigned. `-dv` prints no Authority lines at all — that needs `-dvv`. And
+# `grep -q` exits on the first match, which SIGPIPEs codesign, which under
+# `set -o pipefail` fails the whole pipeline. Hence a capture and a test.
+authority="$(codesign -dvv "$app" 2>&1 \
+    | grep '^Authority=Developer ID Application' || true)"
+
+if ! codesign --verify --strict --deep "$app" 2>/dev/null || [ -z "$authority" ]; then
     echo "error: $app is not signed with a Developer ID Application identity" >&2
     echo "       notarization would be rejected; see docs/signing.md" >&2
     exit 1

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ The index. Each file below is the reference for one part of the app.
 | [sensors.md](sensors.md) | What a Mac exposes about heat, fans and power, what it costs to read, and what needs root |
 | [ui.md](ui.md) | Gauges vs charts, the auto-ranging dial, and the rules that keep a chart honest |
 | [storage.md](storage.md) | Why v1 writes nothing to disk, and the SSD-endurance arithmetic for when it does |
+| [signing.md](signing.md) | Developer ID signing and notarization: what the app needs, and the one-time setup on the Mac runner |
 | [roadmap.md](roadmap.md) | What is deliberately not in v1, in the order it is likely to arrive |
 
 ## Quick start

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,8 @@ The index. Each file below is the reference for one part of the app.
 | [sensors.md](sensors.md) | What a Mac exposes about heat, fans and power, what it costs to read, and what needs root |
 | [ui.md](ui.md) | Gauges vs charts, the auto-ranging dial, and the rules that keep a chart honest |
 | [storage.md](storage.md) | Why v1 writes nothing to disk, and the SSD-endurance arithmetic for when it does |
-| [signing.md](signing.md) | Developer ID signing and notarization: what the app needs, and the one-time setup on the Mac runner |
+| [signing.md](signing.md) | What this repository does with a Developer ID: the scripts, the two variables, and the setup on the Mac runner |
+| [developer-id-runbook.md](developer-id-runbook.md) | Signing and notarizing a Mac app from nothing, app-agnostic, with the stumbling blocks that cost time |
 | [roadmap.md](roadmap.md) | What is deliberately not in v1, in the order it is likely to arrive |
 
 ## Quick start

--- a/docs/developer-id-runbook.md
+++ b/docs/developer-id-runbook.md
@@ -1,0 +1,274 @@
+# Developer ID runbook
+
+How to take a Mac app from "macOS says it is damaged" to "it opens", once, from
+nothing. Written while doing it for `monitor`, so the stumbling blocks at the
+bottom are the ones that actually cost time rather than the ones a tutorial
+imagines.
+
+Nothing here is specific to this app. Substitute your own bundle id, team id and
+item names and it works for the next one. `signing.md` is the shorter document:
+what this repository does with the result.
+
+## What the words mean
+
+Three things happen, in order, and they are often confused with each other:
+
+1. **Signing** attaches your identity to the bundle. It says who built it.
+2. **Notarization** sends the signed bundle to Apple, which scans it and issues
+   a ticket. It says Apple has looked at it.
+3. **Stapling** writes that ticket into the bundle, so the check works offline.
+
+Skip the third and the app still passes — by asking Apple at every first launch,
+on a machine that may have no network. Skip the second and Gatekeeper refuses.
+
+## The certificate you need
+
+| Certificate | Lane |
+|---|---|
+| Apple Development | building and running on your own machines |
+| Apple Distribution | Mac App Store, TestFlight |
+| **Developer ID Application** | **an app people download and run themselves** |
+
+Only the third works for a direct download. This is the first place to lose an
+hour: the Certificates page shows Distribution certificates that look plausible
+and are valid for something else entirely.
+
+**No App ID is required.** A Developer ID app is distributed outside the store,
+so the bundle id needs nothing registered on the Identifiers page.
+
+Only the **Account Holder** can create one.
+
+## The procedure
+
+### 1. Decide which Mac holds the private key
+
+Whichever Mac generates the key ends up holding it. If a build server does the
+signing, generating there is one less transfer. Generating on a laptop is fine
+too — the key moves as a `.p12`.
+
+### 2. Generate a key and a certificate request
+
+Keychain Access → Certificate Assistant → *Request a Certificate From a
+Certificate Authority*, saved to disk, is the path Apple documents. It puts the
+key straight into the keychain where `codesign` looks for it.
+
+`openssl` works as well and is easier to script:
+
+```sh
+openssl req -new -newkey rsa:2048 -nodes \
+    -keyout devid.key -out devid.csr \
+    -subj "/emailAddress=you@example.com/CN=Your Name/C=US"
+```
+
+The key is a loose PEM this way, so it has to be imported deliberately later.
+
+### 3. Ask Apple for the certificate
+
+developer.apple.com → Certificates, Identifiers & Profiles → Certificates →
+**+** → **Developer ID Application**. Upload the `.csr`, download the `.cer`.
+
+### 4. Check that the certificate matches the key
+
+Do this before anything depends on it. Comparing the public halves is cheap and
+prints no secret:
+
+```sh
+openssl x509 -inform DER -in developerID_application.cer -pubkey -noout \
+    | openssl md5
+openssl pkey -in devid.key -pubout | openssl md5
+```
+
+Two identical hashes mean the pair is right. Different ones mean the `.cer`
+answers a different request, and everything after this would fail with an error
+about the key being unavailable.
+
+### 5. Import the identity
+
+From a `.p12`:
+
+```sh
+security import identity.p12 -k login.keychain-db -T /usr/bin/codesign
+```
+
+From a loose key and certificate, which import separately:
+
+```sh
+security import developerID_application.cer -k login.keychain-db
+security import devid.key -k login.keychain-db -T /usr/bin/codesign
+```
+
+Confirm — this is the string you will refer to everywhere afterwards:
+
+```sh
+security find-identity -v -p codesigning | grep "Developer ID Application"
+```
+
+### 6. Make a `.p12` and back it up
+
+The `.p12` is the certificate and its key together, and it is the only way to
+move the identity to another Mac. **Losing the key means revoking the
+certificate and starting again**, so back it up before relying on it.
+
+```sh
+openssl x509 -inform DER -in developerID_application.cer -out devid.pem
+export PW="$(op read 'op://<vault>/<item>/password')"
+openssl pkcs12 -export -legacy -inkey devid.key -in devid.pem \
+    -name "Developer ID Application: NAME (TEAMID)" \
+    -out identity.p12 -passout env:PW
+unset PW
+```
+
+Store the `.p12` **and its password on the same 1Password item**, so restoring
+is one lookup rather than two that can drift apart.
+
+Keychain Access → My Certificates → right-click the identity → Export produces
+the same thing with the certificate chain included, if the clicking is
+preferable.
+
+### 7. Register notarization credentials
+
+`notarytool` needs an **app-specific** password from appleid.apple.com, not the
+Apple ID password. Store it in a named keychain profile:
+
+```sh
+xcrun notarytool store-credentials <profile> \
+    --apple-id you@example.com --team-id TEAMID --password <app-specific>
+```
+
+Keep the app-specific password in 1Password too. The profile cannot be read back
+out, so a rebuilt machine means a new password otherwise.
+
+Verify immediately. It costs nothing and the alternative is finding out twenty
+minutes into a submission:
+
+```sh
+xcrun notarytool history --keychain-profile <profile>
+```
+
+"No submission history" with no error is a pass.
+
+### 8. Sign
+
+```sh
+codesign --force --deep --options runtime --timestamp \
+    --sign "Developer ID Application: NAME (TEAMID)" MyApp.app
+codesign --verify --strict --verbose=2 MyApp.app
+```
+
+`--options runtime` and `--timestamp` are not optional. The notary service
+rejects a bundle without either, and **neither can be added afterwards** — a
+missing one means signing again from the start.
+
+### 9. Notarize, staple, and zip again
+
+```sh
+ditto -c -k --keepParent MyApp.app MyApp.zip
+xcrun notarytool submit MyApp.zip --keychain-profile <profile> --wait
+xcrun stapler staple MyApp.app
+rm MyApp.zip && ditto -c -k --keepParent MyApp.app MyApp.zip
+```
+
+`ditto`, not `zip`: a bundle holds symlinks and extended attributes that `zip`
+flattens.
+
+The last line is the step most easily lost. See the stumbling blocks.
+
+### 10. Verify like a downloader
+
+```sh
+codesign -dvv MyApp.app                    # Authority=Developer ID Application…
+xcrun stapler validate MyApp.app           # The validate action worked!
+spctl --assess --type execute -vv MyApp.app
+```
+
+`spctl` is the real question. Its two answers:
+
+```
+rejected   source=Unnotarized Developer ID   signed, ticket missing
+accepted   source=Notarized Developer ID     ready to publish
+```
+
+### 11. Automate it
+
+Signing needs the private key, so the job has to run somewhere the key is. On a
+self-hosted Mac, keep the credentials in that machine's keychain and pass only
+*names* through CI — an identity string and a profile name, neither secret. On a
+hosted runner there is no choice but to import a `.p12` from a secret into a
+temporary keychain and delete it afterwards.
+
+Make it fail loudly. A release that silently falls back to an ad-hoc signature
+publishes a download nobody can open, and the failure surfaces as a bug report
+from a stranger a week later.
+
+## Stumbling blocks
+
+Every one of these cost real time.
+
+**Apple Distribution is not Developer ID.** The Certificates page lists
+Distribution certificates that are valid, current, and useless for this. Read
+the Type column.
+
+**`codesign -dv` prints no `Authority` lines.** Verbosity 1 shows none at all,
+so a script that greps for the signing authority always finds nothing. Use
+`-dvv`.
+
+**`grep -q` plus `set -o pipefail` is a false failure.** `grep -q` exits on the
+first match, which SIGPIPEs the command feeding it, which under `pipefail` fails
+the whole pipeline. Checking for a signature this way reports *unsigned* on a
+bundle that is signed correctly, which is the worst direction for a check to be
+wrong in. Capture the output and test the variable instead.
+
+**Stapling writes to the bundle, not to the archive.** The zip that was uploaded
+is still unstapled after `stapler` runs. Publishing it means every download
+phones Apple on first launch and fails outright when offline. **Rebuild the zip
+after stapling.**
+
+**Hardened runtime and the timestamp cannot be added later.** Notarization
+rejects a bundle without them, and the fix is a full re-sign. Put both in the
+signing command from the start.
+
+**The Apple ID password does not work with `notarytool`.** It needs an
+app-specific password. The error does not make that obvious.
+
+**Notarization is queue time.** A few minutes is typical, twenty happens, and
+neither means anything is wrong. `notarytool history` distinguishes *In
+Progress* from a real failure. Budget for it in CI: a `--wait` holds the runner
+for the duration.
+
+**A `.p12` password must reach `openssl` through the environment.** `PW=…` sets
+a shell variable; `-passout env:PW` reads the environment. Without `export` it
+fails with "No environment variable PW".
+
+**`op item create --generate-password` only works on Login and Password items.**
+So a generated password and a file attachment cannot be created in one command
+on an API Credential item. Create the item as a Password and attach the file to
+it afterwards.
+
+**`op item create` has no `--password` flag.** The value is an assignment. To
+keep it out of shell history, read it into a variable first with `read -rs`.
+
+**A build server may have no login keychain.** A runner installed as a
+LaunchDaemon runs without a login session, so `codesign` cannot reach the key
+and hangs on a dialog nobody will answer. Run it as a LaunchAgent under a real
+user, or give the job a dedicated keychain it unlocks itself. Either way the key
+needs its partition list opened for non-interactive use:
+
+```sh
+security set-key-partition-list -S apple-tool:,apple:,codesign: \
+    -s -k <keychain-password> login.keychain-db
+```
+
+**The certificate expires with the membership**, not five years out. This
+matters less than it looks: a build signed *and notarized* while the certificate
+was valid keeps working afterwards, because the secure timestamp proves when it
+was signed. Expiry stops new signing, not old downloads.
+
+## When notarization is rejected
+
+```sh
+xcrun notarytool log <submission-id> --keychain-profile <profile>
+```
+
+The log names the file and the reason. The common three are a missing hardened
+runtime, a missing secure timestamp, and a bundle signed ad-hoc — all of which
+are decided back at step 8.

--- a/docs/signing.md
+++ b/docs/signing.md
@@ -1,0 +1,126 @@
+# Signing and notarization
+
+A local build is signed ad-hoc and that is correct. An ad-hoc signature keeps
+the app's identity stable across rebuilds, so macOS does not forget what it
+remembered about it, and costs nothing.
+
+A **downloaded** copy is a different question. macOS quarantines anything a
+browser writes to disk, and an ad-hoc bundle fails that check with a dialog
+saying the app is damaged — which is not what happened, and is indistinguishable
+from what it would say about something that really was. Getting rid of that
+needs two things, in order: a Developer ID signature, then a notarization ticket
+stapled to the bundle.
+
+Both are **off by default**. Nothing below has to exist for a release to build.
+
+## What the app needs
+
+| Certificate | What it is for |
+|---|---|
+| Apple Development | building and running on your own machines |
+| Apple Distribution | the Mac App Store and TestFlight |
+| **Developer ID Application** | **an app people download and run themselves** |
+
+Only the third one satisfies Gatekeeper for a direct download. The first two are
+a different distribution lane and will not do, however valid they are.
+
+Create it at [developer.apple.com](https://developer.apple.com/account/resources/certificates)
+→ Certificates → **Developer ID Application**. It needs the Account Holder role
+on the team, and it is an interactive, one-time job.
+
+## One-time setup on the Mac runner
+
+Signing and notarizing happen in `package.yml`, on the self-hosted macOS runner.
+The credentials live in that machine's keychain rather than in GitHub secrets:
+it is a Mac on a desk, not a disposable VM, so there is no reason to put a
+private key where it can leak.
+
+**1. Install the certificate.** Export it from your keychain as a `.p12` and
+import it on the runner, or create it there in the first place. Confirm:
+
+```sh
+security find-identity -v -p codesigning | grep "Developer ID Application"
+```
+
+**2. Let a non-interactive session use the key.** A login keychain will
+otherwise put up a password dialog nobody is there to answer, and `codesign`
+hangs until the job times out:
+
+```sh
+security unlock-keychain login.keychain-db
+security set-key-partition-list -S apple-tool:,apple:,codesign: \
+    -s -k <keychain-password> login.keychain-db
+```
+
+If the runner runs as a LaunchDaemon it has no login keychain at all. Run it as
+a LaunchAgent under your user, or give it a dedicated keychain and unlock that
+in the job.
+
+**3. Store notarization credentials.** An app-specific password from
+appleid.apple.com, kept in a named profile:
+
+```sh
+xcrun notarytool store-credentials monitor-notary \
+    --apple-id you@example.com --team-id <TEAMID> --password <app-specific>
+```
+
+Keep the app-specific password in 1Password as well — `monitor-notary-password`
+in Code Secrets — because the profile on the runner is not readable back out and
+rebuilding that Mac would otherwise mean generating a new one.
+
+**4. Turn it on.** Two repository *variables* — not secrets, since both are only
+names:
+
+```sh
+gh variable set SIGN_IDENTITY --body "Developer ID Application: NAME (TEAMID)"
+gh variable set NOTARY_PROFILE --body "monitor-notary"
+```
+
+From the next release on, `package.yml` signs and notarizes, and the release
+notes drop the right-click-to-open paragraph.
+
+## What the scripts do
+
+`Scripts/make-app.sh` signs with `MONITOR_SIGN_IDENTITY` when it is set, a
+Developer ID identity from the keychain when it is not, and ad-hoc when there is
+neither. Setting the variable makes signing **required** — the script fails
+rather than quietly producing an ad-hoc bundle that will not install anywhere.
+
+It signs with `--options runtime` and a secure timestamp. Neither is optional:
+the notary service rejects a bundle without them, and neither can be added
+afterwards without signing again.
+
+`Scripts/notarize.sh` submits the zip, waits, staples the ticket to the bundle
+and **rebuilds the zip**. That last step is the one that is easy to miss.
+`stapler` writes into the bundle, not into the archive, so the zip that was
+uploaded is still unstapled: publishing it gives every downloader a round trip
+to Apple on first launch, and a plain failure if they are offline. The zip has
+to be made again, after stapling, around the stapled bundle.
+
+## Doing it by hand
+
+```sh
+Scripts/make-app.sh
+ditto -c -k --keepParent .build/monitor.app monitor-1.1.0.zip
+MONITOR_NOTARY_PROFILE=monitor-notary \
+    Scripts/notarize.sh .build/monitor.app monitor-1.1.0.zip
+```
+
+## Checking it worked
+
+```sh
+codesign -dv --verbose=4 .build/monitor.app   # Authority=Developer ID Application…
+xcrun stapler validate .build/monitor.app     # The validate action worked!
+spctl --assess --type execute -vv .build/monitor.app   # accepted, Notarized Developer ID
+```
+
+`spctl` is the one that answers the question a downloader is really asking. It
+reads the staple rather than calling Apple, so it passes with the network off —
+which is exactly the difference stapling buys.
+
+## When notarization is rejected
+
+`xcrun notarytool log <submission-id> --keychain-profile monitor-notary` prints
+the reason. The common ones here would be a missing hardened runtime, a missing
+secure timestamp, or a bundle signed ad-hoc — all three of which `make-app.sh`
+and `notarize.sh` now refuse to produce.

--- a/docs/signing.md
+++ b/docs/signing.md
@@ -1,5 +1,10 @@
 # Signing and notarization
 
+**Setting this up from nothing, here or for another app?**
+[developer-id-runbook.md](developer-id-runbook.md) is the procedure, with the
+parts that cost time called out. This document is the shorter one: what this
+repository does with the result.
+
 A local build is signed ad-hoc and that is correct. An ad-hoc signature keeps
 the app's identity stable across rebuilds, so macOS does not forget what it
 remembered about it, and costs nothing.

--- a/docs/signing.md
+++ b/docs/signing.md
@@ -26,7 +26,15 @@ a different distribution lane and will not do, however valid they are.
 
 Create it at [developer.apple.com](https://developer.apple.com/account/resources/certificates)
 → Certificates → **Developer ID Application**. It needs the Account Holder role
-on the team, and it is an interactive, one-time job.
+on the team, and it is an interactive, one-time job. No App ID has to be
+registered: a Developer ID app is distributed outside the store, so
+`wtf.evan.monitor` needs nothing declared to Apple.
+
+The certificate expires with the membership rather than five years out, and
+that matters less than it looks. A build signed *and notarized* while the
+certificate was valid keeps working after it expires, because the secure
+timestamp proves when it was signed. Expiry stops new signing, not old
+downloads.
 
 ## One-time setup on the Mac runner
 
@@ -35,11 +43,22 @@ The credentials live in that machine's keychain rather than in GitHub secrets:
 it is a Mac on a desk, not a disposable VM, so there is no reason to put a
 private key where it can leak.
 
-**1. Install the certificate.** Export it from your keychain as a `.p12` and
-import it on the runner, or create it there in the first place. Confirm:
+**1. Install the certificate.** The identity travels as a `.p12` — the
+certificate and its private key together. Restore it from 1Password
+(`monitor-devid-p12` in Code Secrets, password and file on the same item) and
+import it:
 
 ```sh
+security import monitor-devid.p12 -k login.keychain-db -T /usr/bin/codesign
 security find-identity -v -p codesigning | grep "Developer ID Application"
+```
+
+If the key was generated with `openssl` rather than Keychain Access it is a
+loose PEM, and the two halves import separately just as well:
+
+```sh
+security import developerID_application.cer -k login.keychain-db
+security import monitor-devid.key -k login.keychain-db -T /usr/bin/codesign
 ```
 
 **2. Let a non-interactive session use the key.** A login keychain will
@@ -64,9 +83,18 @@ xcrun notarytool store-credentials monitor-notary \
     --apple-id you@example.com --team-id <TEAMID> --password <app-specific>
 ```
 
-Keep the app-specific password in 1Password as well — `monitor-notary-password`
-in Code Secrets — because the profile on the runner is not readable back out and
-rebuilding that Mac would otherwise mean generating a new one.
+The password is an **app-specific** one from
+[appleid.apple.com](https://appleid.apple.com/account/manage), not the Apple ID
+password, which `notarytool` refuses. Keep it in 1Password as
+`monitor-notary-password` in Code Secrets: the profile on the runner cannot be
+read back out, so rebuilding that Mac would otherwise mean generating a new one.
+
+Check it took, which costs nothing and answers a question that is otherwise
+twenty minutes away:
+
+```sh
+xcrun notarytool history --keychain-profile monitor-notary
+```
 
 **4. Turn it on.** Two repository *variables* — not secrets, since both are only
 names:
@@ -116,7 +144,16 @@ spctl --assess --type execute -vv .build/monitor.app   # accepted, Notarized Dev
 
 `spctl` is the one that answers the question a downloader is really asking. It
 reads the staple rather than calling Apple, so it passes with the network off —
-which is exactly the difference stapling buys.
+which is exactly the difference stapling buys. Its two verdicts are worth
+recognising:
+
+```
+rejected   source=Unnotarized Developer ID   signed, ticket missing
+accepted   source=Notarized Developer ID     what a release should say
+```
+
+Notarization is queue time, not work: expect a few minutes, and do not be
+alarmed by twenty. `notarytool history` says whether it is still In Progress.
 
 ## When notarization is rejected
 


### PR DESCRIPTION
A downloaded copy of an ad-hoc signed app fails Gatekeeper with a dialog saying it is damaged — which is not what happened, and is indistinguishable from what macOS would say about something that really was. Fixing it needs a Developer ID signature and a notarization ticket stapled to the bundle.

**Both are off until two repository variables are set, so nothing about a release changes today.**

## Turning it on

Needs a **Developer ID Application** certificate, which does not exist on the team yet. `Apple Distribution` is a different distribution lane and will not do, however valid it is. `docs/signing.md` has the full setup; the short version is:

```sh
gh variable set SIGN_IDENTITY --body "Developer ID Application: NAME (TEAMID)"
gh variable set NOTARY_PROFILE --body "monitor-notary"
```

Credentials live in the Mac runner's keychain rather than GitHub secrets — it is a Mac on a desk, not a disposable VM — so both variables are only names rather than anything worth protecting.

Once set they are all-or-nothing: failing to sign or notarize **fails the release** rather than publishing a zip nobody can open. The failure mode that matters here is the quiet one.

## The two easy things to get wrong

- **`make-app.sh` signs with `--options runtime` and a secure timestamp.** Neither is an optional extra: the notary service rejects a bundle without them, and neither can be added afterwards without signing again.
- **`notarize.sh` rebuilds the zip after stapling.** `stapler` writes into the bundle, not into the archive, so the copy that was uploaded is still unstapled. Publishing that one gives every downloader a round trip to Apple on first launch and a plain failure if they are offline.

It also refuses to submit a bundle that is not Developer ID signed, because the notary service rejects that with a message that does not say so, a minute later.

## Release notes

The right-click-to-open paragraph is now conditional on the build being notarized. Telling people to right-click an app that opens perfectly well teaches them to do it to everything, which is worse than saying nothing.

## Verified

Exercised locally against the real `codesign`, using the Apple Development identity as a stand-in for the Developer ID that does not exist yet:

- No identity → ad-hoc, with a line saying so. `Signature=adhoc`.
- `MONITOR_SIGN_IDENTITY` set → real authority chain and `flags=0x10000(runtime)`, `codesign --verify --strict` passes.
- Bogus identity → exits 1 with "no identity found" rather than falling back.
- `notarize.sh` on a non-Developer-ID bundle → refuses, exit 1.
- `notarize.sh` with no profile → refuses, exit 1.

`shellcheck` clean on both scripts, `actionlint` clean on both workflows, 81 tests pass.

## Note on merging

This touches `Scripts/`, which is not on the docs-only skip list, so merging it ships **v1.1.1** — and that is worth having, because it is the first merge to exercise the runner pushing its own bump commit to `main`. Label it `release:skip` if you would rather not.