### PR TITLE
Take the hottest of every die sensor, and give sensors their own interval

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,14 +64,14 @@ look at it in the app.
 Sources/
   MonitorCore/     metric model, ring buffer, downsampling, gauge auto-ranging,
                    seven-segment digit mapping, formatting, the sampling clock,
-                   the layout preferences model. No macOS APIs — so all of it is
+                   the layout and sampling preference models. No macOS APIs — so all of it is
                    testable without a machine to read.
   MonitorSources/  the readers: CPU, memory, disk, network, GPU, SMC sensors
                    (temperature, fans, power), and the registry that lists them.
                    One file per source, plus SMC.swift for the SMC transport.
   MonitorUI/       Theme (palette + Layout density), GaugeView, SevenSegmentText,
                    ChartCard, FlowLayout, DashboardView, PreferencesView,
-                   AppModel, LayoutPreferencesStore
+                   AppModel, LayoutPreferencesStore (layout + sampling)
   MonitorStore/    SQLite history and retention. Designed and tested but NOT
                    linked into the app — see "Guardrails" below.
   monitor/         the app target (@main SwiftUI App) and its AppDelegate
@@ -79,7 +79,8 @@ Sources/
 Scripts/           make-app.sh, which builds monitor.app, make-icon.swift,
                    which draws its icon, and notarize.sh, which notarizes and
                    staples a Developer ID build
-Tests/             MonitorCoreTests, MonitorSourcesTests, MonitorStoreTests
+Tests/             MonitorCoreTests, MonitorSourcesTests, MonitorStoreTests,
+                   MonitorUITests
 docs/              README.md is the index
 .github/workflows/
   ci.yml           build, test, release build, CLI smoke test, lint
@@ -124,7 +125,7 @@ are no component-level AGENTS.md files.
   chart answers "what has been happening" (CPU, memory). `LayoutDefaults`
   encodes the split — but as an opening position, not a rule.
 - **The layout is chosen per metric, in preferences.** Cmd-, opens a tabbed
-  window whose one tab, Layout, lists every metric with a Gauge checkbox and a
+  window. Its **Layout** tab lists every metric with a Gauge checkbox and a
   Chart checkbox, grouped into collapsible sections whose headings carry the
   same two checkboxes for the whole group. The two columns are not symmetrical:
   **a gauge is per metric, a chart is per group.** Ticking Network In and Network Out gives two dials and *one*
@@ -132,11 +133,19 @@ are no component-level AGENTS.md files.
   other. `LayoutPreferences` (in `MonitorCore`, so the merge rules are testable)
   tracks which metrics it has an opinion about as well as which are on —
   otherwise a metric added by a later version is indistinguishable from one
-  somebody switched off, and stays silently missing.
-- **One clock.** `Sampler.tick(at:)` reads every source at one timestamp so a
-  batch lines up on the x-axis. A source that throws is logged and skipped for
-  that tick only. `AppModel` samples at 0.5 s into a 1200-point ring buffer —
-  ten minutes of history, all of it in memory.
+  somebody switched off, and stays silently missing. Its **Sampling** tab sets
+  the two rates: performance and sensors.
+- **One clock, but not one rate.** `Sampler.tick(at:)` reads every source at
+  one timestamp so a batch lines up on the x-axis. A source that throws is
+  logged and skipped for that tick only. `AppModel` samples at 0.5 s into a
+  1200-point ring buffer — ten minutes of history, all of it in memory.
+  A source that cannot produce a new value that often declares a
+  `minimumInterval` and is read on every *n*th tick of the same clock, never on
+  a timer of its own: its samples must land on the same timestamps as
+  everything else. `SMCSource` declares 1 s because the SMC refreshes at 1 Hz,
+  measured — see `docs/sensors.md`. **A skipped source is not a failed one**:
+  `ingest` must exclude it from the unavailable set, or its cards grey
+  themselves out on every tick in between.
 - **Sensors are found, not assumed.** `SMCSource` scans the SMC's key table at
   launch and declares a metric only if this machine publishes sensors for it —
   so a fanless Mac shows no Fans card rather than one reading zero, and an Intel

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,6 +143,10 @@ are no component-level AGENTS.md files.
   `TC0P` feeds the same CPU metric as Apple silicon's `Tp01`. Everything it
   reads is unprivileged; root is needed only to *write* a key, which it cannot.
   `docs/sensors.md` is the survey of what a Mac exposes and what it costs.
+  **How many keys a family has is wildly model-dependent** — 84 GPU sensors and
+  23 CPU ones on a 16-inch MacBook Pro, none of it predictable from the model
+  name — so never hard-code a count or a list per model, and never sample a
+  subset of a family whose metric claims to be the hottest of it.
 - **The panel has two sections.** Performance above the rule, sensors below.
   The sensor section vanishes on a machine that reports none of it.
 - **Releasing is a merge, nothing else.** `release.yml` bumps

--- a/Package.swift
+++ b/Package.swift
@@ -52,5 +52,9 @@ let package = Package(
             name: "MonitorSourcesTests",
             dependencies: ["MonitorSources", "MonitorCore"]),
         .testTarget(name: "MonitorStoreTests", dependencies: ["MonitorStore", "MonitorCore"]),
+        // AppModel decides what the panel draws and which sources are read on
+        // a given tick. Both are arithmetic, and both are wrong in ways that
+        // look like a rendering glitch, so they are worth testing directly.
+        .testTarget(name: "MonitorUITests", dependencies: ["MonitorUI", "MonitorCore"]),
     ]
 )

--- a/Sources/MonitorCore/Formatting.swift
+++ b/Sources/MonitorCore/Formatting.swift
@@ -55,6 +55,19 @@ public enum Format {
         return String(format: "%.1f%@", value, unit)
     }
 
+    /// A sampling interval as a *setting*: "1 s", "1.5 s".
+    ///
+    /// Not `duration`, which formats a measurement and would render half a
+    /// second as "500.0 ms". A whole number gets no decimal point, because
+    /// "1.0 s" beside "1.5 s" reads as a reading rather than a choice; anything
+    /// else keeps its half, which `%.0f` would round away. A picker that offers
+    /// 1.5 s and then labels it 2 s is worse than one that does not offer it.
+    public static func interval(_ seconds: TimeInterval) -> String {
+        seconds == seconds.rounded()
+            ? String(format: "%.0f s", seconds)
+            : String(format: "%.1f s", seconds)
+    }
+
     public static func duration(_ seconds: Double) -> String {
         if seconds >= 1 { return String(format: "%.2f s", seconds) }
         if seconds >= 0.001 { return String(format: "%.1f ms", seconds * 1000) }

--- a/Sources/MonitorCore/MetricSource.swift
+++ b/Sources/MonitorCore/MetricSource.swift
@@ -17,6 +17,20 @@ public protocol MetricSource: Sendable {
     /// Read once. Throw rather than return zeros: a failed read and an idle
     /// system must not look the same on a chart.
     func read(at timestamp: TimeInterval) throws -> SampleBatch
+
+    /// The shortest interval at which this source can produce a *new* value.
+    ///
+    /// Not a preference and not a cost limit — a fact about the hardware
+    /// underneath. Reading faster than this returns the previous value again,
+    /// so the sampler skips the call entirely.
+    ///
+    /// Zero, the default, means "as fast as you like": a counter read from
+    /// mach or IOKit is current whenever it is asked.
+    var minimumInterval: TimeInterval { get }
+}
+
+public extension MetricSource {
+    var minimumInterval: TimeInterval { 0 }
 }
 
 /// Why a source could not be used on this machine.

--- a/Sources/MonitorCore/Sampler.swift
+++ b/Sources/MonitorCore/Sampler.swift
@@ -10,6 +10,13 @@ public protocol SampleSink: Sendable {
 /// All sources are read on the same tick so their samples share a timestamp and
 /// line up on the x-axis. A source that throws is logged and skipped for that
 /// tick — one broken reader must not stop the rest.
+///
+/// A source may be read on only *some* ticks — sensors refresh once a second,
+/// so reading them at 2 Hz costs an IOKit round trip to be told the same number
+/// again. That is still one clock: a slow source is sampled on every nth tick
+/// of the same clock, not on a second timer. Its samples therefore land on
+/// exactly the same timestamps as everything else, which is what stops two
+/// series drifting apart on the x-axis.
 public actor Sampler {
     public private(set) var interval: TimeInterval
     private let sources: [any MetricSource]
@@ -56,12 +63,18 @@ public actor Sampler {
 
     /// Read every source once and forward the result. Public so `monitorctl`
     /// and the tests can drive sampling without a clock.
+    ///
+    /// `skipping` names sources to leave alone this tick, by `id`. A skipped
+    /// source contributes no samples, which is not the same as failing: the UI
+    /// keeps the last value and draws nothing new, rather than greying the card
+    /// out.
     @discardableResult
-    public func tick(at timestamp: TimeInterval = Date()
-        .timeIntervalSince1970) async -> SampleBatch
-    {
+    public func tick(
+        at timestamp: TimeInterval = Date().timeIntervalSince1970,
+        skipping: Set<String> = []
+    ) async -> SampleBatch {
         var samples: [Sample] = []
-        for source in sources {
+        for source in sources where !skipping.contains(source.id) {
             do {
                 let batch = try source.read(at: timestamp)
                 samples.append(contentsOf: batch.samples)

--- a/Sources/MonitorCore/SamplingPreferences.swift
+++ b/Sources/MonitorCore/SamplingPreferences.swift
@@ -18,12 +18,21 @@ public struct SamplingPreferences: Codable, Equatable, Sendable {
     /// sensors are sampled on it rather than on a second timer of their own.
     public var sensors: TimeInterval
 
-    public static let performanceChoices: [TimeInterval] = [0.25, 0.5, 1, 2]
+    /// Half a second to five, in half seconds.
+    ///
+    /// The floor is half a second because that is where the gauges stop
+    /// stepping visibly: the needle animation can smooth a gap but cannot
+    /// invent detail that was never sampled.
+    public static let performanceChoices: [TimeInterval] =
+        stride(from: 0.5, through: 5.0, by: 0.5).map(\.self)
 
-    /// 10 s is absent on purpose. At that interval a die that climbed 20 °C
-    /// between two readings shows as a straight line between them, and the
-    /// chart says the machine warmed gently when it did not.
-    public static let sensorChoices: [TimeInterval] = [1, 2, 5]
+    /// One second to five, in seconds.
+    ///
+    /// One is the floor because the SMC refreshes at 1 Hz and anything faster
+    /// re-reads the same bits. Five is the ceiling because past it a die that
+    /// climbed 20 °C between readings draws as a straight line, and the chart
+    /// then says the machine warmed gently when it did not.
+    public static let sensorChoices: [TimeInterval] = [1, 2, 3, 4, 5]
 
     public static let `default` = SamplingPreferences(performance: 0.5, sensors: 1)
 
@@ -34,12 +43,21 @@ public struct SamplingPreferences: Codable, Equatable, Sendable {
 
     /// What the sensors are actually read at.
     ///
-    /// Sensors ride the master clock, so their interval is rounded up to a
-    /// whole number of ticks. Asking for 1 s while the master runs at 2 s gets
-    /// 2 s — the slower of the two wins, and the panel says so rather than
-    /// claiming a rate it cannot deliver.
+    /// Sensors ride the master clock, so their interval can only be a whole
+    /// number of ticks. Two things follow, and the panel spells both out rather
+    /// than showing a rate it does not honour:
+    ///
+    ///  - Asking for 1 s while the master runs at 2 s gets 2 s. Sensors cannot
+    ///    be read more often than the clock they ride.
+    ///  - Asking for 2 s while the master runs at 1.5 s gets 1.5 s, because 2
+    ///    is not a multiple of 1.5 and one tick is nearer than two.
     public var effectiveSensorInterval: TimeInterval {
         performance * Double(sensorTickDivisor)
+    }
+
+    /// Whether the rate asked for is the rate delivered.
+    public var sensorIntervalIsExact: Bool {
+        abs(effectiveSensorInterval - sensors) < 0.001
     }
 
     /// How many master ticks pass between sensor reads. Always at least one.

--- a/Sources/MonitorCore/SamplingPreferences.swift
+++ b/Sources/MonitorCore/SamplingPreferences.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+/// How often each kind of source is read.
+///
+/// Two rates rather than one, because the two answer to different hardware.
+/// Disk and network counters are current whenever they are asked, so the rate
+/// there is a choice about how much detail you want. The SMC is not: it
+/// refreshes its temperature and power keys **once a second**, and reading them
+/// at 2 Hz returns the same bits twice.
+///
+/// That was measured rather than assumed — see `docs/sensors.md`. On a 16-inch
+/// MacBook Pro under load, sampling sensors at 0.5 s and at 1 s produce
+/// bit-identical traces; the difference only appears at 2 s and beyond.
+public struct SamplingPreferences: Codable, Equatable, Sendable {
+    /// How often counters and load are read: the master clock.
+    public var performance: TimeInterval
+    /// How often sensors are read. Never faster than the master clock, because
+    /// sensors are sampled on it rather than on a second timer of their own.
+    public var sensors: TimeInterval
+
+    public static let performanceChoices: [TimeInterval] = [0.25, 0.5, 1, 2]
+
+    /// 10 s is absent on purpose. At that interval a die that climbed 20 °C
+    /// between two readings shows as a straight line between them, and the
+    /// chart says the machine warmed gently when it did not.
+    public static let sensorChoices: [TimeInterval] = [1, 2, 5]
+
+    public static let `default` = SamplingPreferences(performance: 0.5, sensors: 1)
+
+    public init(performance: TimeInterval = 0.5, sensors: TimeInterval = 1) {
+        self.performance = performance
+        self.sensors = sensors
+    }
+
+    /// What the sensors are actually read at.
+    ///
+    /// Sensors ride the master clock, so their interval is rounded up to a
+    /// whole number of ticks. Asking for 1 s while the master runs at 2 s gets
+    /// 2 s — the slower of the two wins, and the panel says so rather than
+    /// claiming a rate it cannot deliver.
+    public var effectiveSensorInterval: TimeInterval {
+        performance * Double(sensorTickDivisor)
+    }
+
+    /// How many master ticks pass between sensor reads. Always at least one.
+    public var sensorTickDivisor: Int {
+        guard performance > 0 else { return 1 }
+        return max(1, Int((sensors / performance).rounded()))
+    }
+}

--- a/Sources/MonitorSources/SMCSource.swift
+++ b/Sources/MonitorSources/SMCSource.swift
@@ -107,10 +107,9 @@ public final class SMCSource: MetricSource, @unchecked Sendable {
             let wanted = temperatures.filter { key in
                 prefixes.contains(where: { key.name.hasPrefix($0) }) || exact.contains(key.name)
             }
-            // Capped because reading a key costs an IOKit round trip and a
-            // machine can publish twenty CPU die sensors. Six of them, read
-            // twice a second forever, is a cost worth paying; twenty is not,
-            // and they move together anyway.
+            // Every matching key, not a sample of them. `hottest` means the
+            // hottest of what this machine publishes, and taking the first few
+            // in registry order would quietly make it mean something else.
             return Array(wanted.prefix(maximumKeysPerSensor))
         }
 
@@ -227,6 +226,29 @@ public final class SMCSource: MetricSource, @unchecked Sendable {
 
     /// Where Apple silicon starts throttling, and so the top of a chart.
     private static let temperatureCeiling = 110.0
-    private static let maximumKeysPerSensor = 6
+
+    /// A bound on how many keys one sensor may read, not a sampling policy.
+    ///
+    /// It was six, which was wrong in a way that did not look wrong: a machine
+    /// with more die sensors than that reported the hottest of an arbitrary
+    /// six, while the metric said "hottest". A 16-inch MacBook Pro publishes 23
+    /// `Tp…` keys, so the reading could sit three degrees under the real peak
+    /// and nothing anywhere said so.
+    ///
+    /// The cost is real but smaller than the wrongness. One key costs about
+    /// 0.15 ms, and the same machine publishes **84** `Tg…` GPU sensors on top
+    /// of the 23 CPU ones, so the whole source goes from 3.9 ms to 15.5 ms per
+    /// tick. Measured, not estimated — the six was estimated, and that is how
+    /// it came to be wrong.
+    ///
+    /// This is now high enough never to bind on any Mac seen so far. It exists
+    /// so a machine that publishes something absurd cannot make the sampler
+    /// unbounded, not to decide which sensors count.
+    ///
+    /// Key counts vary enormously between models: a machine with one GPU
+    /// sensor and a machine with 84 are both normal, and the count is not
+    /// predictable from the model name. Everything here is discovered at
+    /// launch for that reason.
+    private static let maximumKeysPerSensor = 64
     private static let maximumFans = 4
 }

--- a/Sources/MonitorSources/SMCSource.swift
+++ b/Sources/MonitorSources/SMCSource.swift
@@ -28,6 +28,21 @@ import MonitorCore
 public final class SMCSource: MetricSource, @unchecked Sendable {
     public let id = "sensors"
 
+    /// The SMC refreshes its temperature and power keys once a second.
+    ///
+    /// Measured, not assumed: sampled at 5 Hz under load, `Tp…` values change
+    /// on 22% of reads, and the gaps between changes cluster at 0.9 s and 1.1 s
+    /// — a 1 Hz clock beating against the sampling rate. The value quantum is
+    /// 1/64 °C, so identical consecutive reads are genuinely no new value
+    /// rather than a rounded one. Decimating a 5 Hz trace to 1 s reproduces it
+    /// exactly; the first losses appear at 2 s. `docs/sensors.md` has the
+    /// numbers.
+    ///
+    /// Fan tachometers are the exception — they change on 95% of reads at
+    /// 5 Hz — but they ride the same IOKit round trip as everything else here,
+    /// so they cannot be read faster without paying for the rest.
+    public let minimumInterval: TimeInterval = 1.0
+
     public static let cpuTemperature = MetricID("sensor.temperature.cpu")
     public static let gpuTemperature = MetricID("sensor.temperature.gpu")
     public static let storageTemperature = MetricID("sensor.temperature.storage")

--- a/Sources/MonitorUI/AppModel.swift
+++ b/Sources/MonitorUI/AppModel.swift
@@ -26,17 +26,45 @@ public final class AppModel {
     public var layout: LayoutPreferences {
         didSet {
             guard layout != oldValue else { return }
-            LayoutPreferencesStore.save(layout)
+            LayoutPreferencesStore.save(layout, to: defaults)
         }
     }
 
-    /// Half a second by default rather than one. Reading every source costs
-    /// well under a millisecond, and at 1 Hz the gauges visibly step: the
-    /// needle animation can smooth the gap, but it cannot invent detail that
-    /// was never sampled, so a short spike between ticks is simply missed.
-    public var interval: TimeInterval = 0.5 {
-        didSet { Task { await sampler.setInterval(interval) } }
+    /// Where preferences are read and written.
+    ///
+    /// Injected rather than reached for, so a test can build a model without
+    /// editing the preferences of whoever is running it. That is not a
+    /// hypothetical: the first run of these tests turned on a gauge in the real
+    /// panel and left it there.
+    private let defaults: UserDefaults
+
+    /// How often each kind of source is read.
+    ///
+    /// Half a second for counters rather than one: reading them costs well
+    /// under a millisecond, and at 1 Hz the gauges visibly step — the needle
+    /// animation can smooth the gap, but it cannot invent detail that was never
+    /// sampled, so a short spike between ticks is simply missed.
+    ///
+    /// One second for sensors, because that is how often the SMC has anything
+    /// new to say.
+    public var sampling: SamplingPreferences = .default {
+        didSet {
+            guard sampling != oldValue else { return }
+            SamplingPreferencesStore.save(sampling, to: defaults)
+            Task { await sampler.setInterval(sampling.performance) }
+        }
     }
+
+    /// The master clock, which is also the counter sources' rate.
+    public var interval: TimeInterval {
+        get { sampling.performance }
+        set { sampling.performance = newValue }
+    }
+
+    /// Ticks since the pump started, so a slow source can be read on every nth
+    /// one. A counter rather than a deadline per source: it cannot drift, and
+    /// every sample still lands on a master tick's timestamp.
+    private var tickCount = 0
 
     /// How much live history to keep: ten minutes at two samples a second.
     public let historyCapacity = 1200
@@ -45,14 +73,28 @@ public final class AppModel {
     private let sampler: Sampler
     private var pump: Task<Void, Never>?
 
-    public init(sources: [any MetricSource] = SourceRegistry.makeAll()) {
+    public init(
+        sources: [any MetricSource] = SourceRegistry.makeAll(),
+        defaults: UserDefaults = LayoutPreferencesStore.suite
+    ) {
+        self.defaults = defaults
         let all = sources.flatMap(\.descriptors)
         descriptors = Dictionary(
             all.map { ($0.id, $0) },
             uniquingKeysWith: { first, _ in first }
         )
-        sampler = Sampler(sources: sources, sinks: [], interval: 0.5)
-        layout = LayoutPreferencesStore.load(for: all)
+        metricsBySource = Dictionary(
+            sources.map { ($0.id, Set($0.descriptors.map(\.id))) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        slowSources = sources
+            .filter { $0.minimumInterval > 0 }
+            .map { (id: $0.id, minimum: $0.minimumInterval) }
+
+        let stored = SamplingPreferencesStore.load(from: defaults)
+        sampling = stored
+        sampler = Sampler(sources: sources, sinks: [], interval: stored.performance)
+        layout = LayoutPreferencesStore.load(for: all, from: defaults)
 
         // A scale for every metric, not only the ones a dial shows today. Any
         // metric can be given a dial in preferences, and auto-ranging needs
@@ -69,8 +111,10 @@ public final class AppModel {
         pump = Task { [weak self] in
             while !Task.isCancelled {
                 guard let self else { return }
-                let batch = await sampler.tick()
-                ingest(batch)
+                let skipped = sourcesToSkipThisTick()
+                let batch = await sampler.tick(skipping: skipped)
+                ingest(batch, skipped: skipped)
+                tickCount += 1
                 try? await Task.sleep(for: .seconds(interval))
             }
         }
@@ -81,7 +125,31 @@ public final class AppModel {
         pump = nil
     }
 
-    func ingest(_ batch: SampleBatch) {
+    /// Metric ids per source, so a source skipped this tick can be excluded
+    /// from the "produced nothing, must be broken" test below.
+    private let metricsBySource: [String: Set<MetricID>]
+
+    /// Sources that cannot produce a new value on every tick, with the floor
+    /// the hardware imposes.
+    private let slowSources: [(id: String, minimum: TimeInterval)]
+
+    /// Which sources to leave alone on this tick.
+    ///
+    /// A slow source is read at whichever is longer: the floor its hardware
+    /// imposes, or the interval asked for in preferences. Rounded to a whole
+    /// number of master ticks, so its samples share timestamps with everything
+    /// else instead of drifting against them.
+    private func sourcesToSkipThisTick() -> Set<String> {
+        var skipped: Set<String> = []
+        for source in slowSources {
+            let wanted = max(source.minimum, sampling.sensors)
+            let divisor = max(1, Int((wanted / max(interval, 0.001)).rounded()))
+            if tickCount % divisor != 0 { skipped.insert(source.id) }
+        }
+        return skipped
+    }
+
+    func ingest(_ batch: SampleBatch, skipped: Set<String> = []) {
         var seen: Set<MetricID> = []
         for sample in batch.samples {
             seen.insert(sample.metric)
@@ -92,8 +160,16 @@ public final class AppModel {
             scales[sample.metric]?.update(value: sample.value, at: sample.timestamp)
         }
         // A metric with a descriptor that produced no sample this tick is a
-        // source that failed or is not present on this machine.
-        unavailable = Set(descriptors.keys).subtracting(seen).subtracting(warmingUp)
+        // source that failed or is not present on this machine — unless it was
+        // simply not asked. A sensor read once a second must not grey its card
+        // out on the ticks in between.
+        let notAsked = skipped.reduce(into: Set<MetricID>()) { ids, source in
+            ids.formUnion(metricsBySource[source] ?? [])
+        }
+        unavailable = Set(descriptors.keys)
+            .subtracting(seen)
+            .subtracting(warmingUp)
+            .subtracting(notAsked)
     }
 
     /// Rate metrics have no value on the first tick by design, so they must not

--- a/Sources/MonitorUI/DashboardView.swift
+++ b/Sources/MonitorUI/DashboardView.swift
@@ -247,11 +247,17 @@ public struct DashboardView: View {
             .pickerStyle(.segmented)
         }
         ToolbarItem {
-            Picker("Rate", selection: $model.interval) {
-                Text("0.25 s").tag(TimeInterval(0.25))
-                Text("0.5 s").tag(TimeInterval(0.5))
-                Text("1 s").tag(TimeInterval(1))
-                Text("2 s").tag(TimeInterval(2))
+            // The same list preferences offers, not a second one. A rate set
+            // here and a rate set there are one setting, and a toolbar that
+            // offered 0.25 s while the Sampling tab did not would show an empty
+            // picker in preferences whenever it was chosen.
+            //
+            // The sensor rate is deliberately not here: it is set once and left
+            // alone, while this one gets changed while you are watching.
+            Picker("Rate", selection: $model.sampling.performance) {
+                ForEach(SamplingPreferences.performanceChoices, id: \.self) { seconds in
+                    Text(Format.interval(seconds)).tag(seconds)
+                }
             }
         }
     }

--- a/Sources/MonitorUI/LayoutPreferencesStore.swift
+++ b/Sources/MonitorUI/LayoutPreferencesStore.swift
@@ -9,7 +9,7 @@ import MonitorCore
 /// endurance — a monitor runs all day, and a sample every half second forever
 /// costs real writes. A checkbox written when somebody ticks it costs nothing,
 /// and the alternative is a preferences pane that forgets.
-enum LayoutPreferencesStore {
+public enum LayoutPreferencesStore {
     static let key = "layout.preferences"
 
     /// Named explicitly rather than taken from `.standard`.
@@ -22,7 +22,7 @@ enum LayoutPreferencesStore {
     /// Computed rather than stored because a `static let` holding a
     /// non-`Sendable` class is a concurrency error under Swift 6, and
     /// `UserDefaults` is cheap to ask for and shared behind the scenes anyway.
-    static var suite: UserDefaults { UserDefaults(suiteName: domain) ?? .standard }
+    public static var suite: UserDefaults { UserDefaults(suiteName: domain) ?? .standard }
 
     static let domain = "wtf.evan.monitor"
 
@@ -43,6 +43,33 @@ enum LayoutPreferencesStore {
     static func save(_ preferences: LayoutPreferences, to defaults: UserDefaults = suite) {
         guard let data = try? JSONEncoder().encode(preferences) else {
             log.error("Could not encode layout preferences")
+            return
+        }
+        defaults.set(data, forKey: key)
+    }
+}
+
+/// The sampling rates, kept beside the layout in the same domain.
+enum SamplingPreferencesStore {
+    static let key = "sampling.preferences"
+
+    static func load(from defaults: UserDefaults = LayoutPreferencesStore.suite)
+        -> SamplingPreferences
+    {
+        guard let data = defaults.data(forKey: key),
+              let stored = try? JSONDecoder().decode(SamplingPreferences.self, from: data)
+        else {
+            return .default
+        }
+        return stored
+    }
+
+    static func save(
+        _ preferences: SamplingPreferences,
+        to defaults: UserDefaults = LayoutPreferencesStore.suite
+    ) {
+        guard let data = try? JSONEncoder().encode(preferences) else {
+            log.error("Could not encode sampling preferences")
             return
         }
         defaults.set(data, forKey: key)

--- a/Sources/MonitorUI/PreferencesView.swift
+++ b/Sources/MonitorUI/PreferencesView.swift
@@ -19,6 +19,8 @@ public struct PreferencesView: View {
         TabView {
             LayoutTab(model: model)
                 .tabItem { Label("Layout", systemImage: "square.grid.2x2") }
+            SamplingTab(model: model)
+                .tabItem { Label("Sampling", systemImage: "timer") }
         }
         .frame(width: 460, height: 520)
     }
@@ -170,6 +172,75 @@ struct LayoutTab: View {
             Spacer()
         }
         .padding(16)
+    }
+}
+
+/// How often each kind of source is read.
+///
+/// Two rates rather than one, because the hardware underneath differs. Counters
+/// are current whenever they are asked, so their rate is a choice about detail.
+/// The SMC refreshes once a second, so anything faster reads the same number
+/// twice — which is why the sensor list starts at 1 s rather than offering the
+/// 0.25 s the counters allow.
+struct SamplingTab: View {
+    @Bindable var model: AppModel
+
+    var body: some View {
+        Form {
+            Section {
+                Picker("Performance", selection: $model.sampling.performance) {
+                    ForEach(SamplingPreferences.performanceChoices, id: \.self) { seconds in
+                        Text(label(seconds)).tag(seconds)
+                    }
+                }
+            } footer: {
+                Text(
+                    "CPU, memory, disk and network. These are read straight from "
+                        + "the kernel and are current whenever they are asked, so "
+                        + "this is a choice about how much detail you want."
+                )
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Section {
+                Picker("Sensors", selection: $model.sampling.sensors) {
+                    ForEach(SamplingPreferences.sensorChoices, id: \.self) { seconds in
+                        Text(label(seconds)).tag(seconds)
+                    }
+                }
+                if model.sampling.effectiveSensorInterval != model.sampling.sensors {
+                    // Sensors ride the master clock, so they cannot run faster
+                    // than it. Saying so beats silently ignoring the setting.
+                    Text(
+                        "Sampling every \(label(model.sampling.effectiveSensorInterval)): "
+                            + "sensors cannot be read more often than the "
+                            + "performance rate."
+                    )
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                }
+            } footer: {
+                Text(
+                    "Temperature, fans and power. The SMC refreshes these once a "
+                        + "second, so 1 s is as fast as there is anything new to "
+                        + "read — and reading it costs about four times what "
+                        + "everything else costs put together."
+                )
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .formStyle(.grouped)
+    }
+
+    private func label(_ seconds: TimeInterval) -> String {
+        seconds < 1
+            ? String(format: "%.2g s", seconds)
+            : String(format: "%.0f s", seconds)
     }
 }
 

--- a/Sources/MonitorUI/PreferencesView.swift
+++ b/Sources/MonitorUI/PreferencesView.swift
@@ -3,11 +3,11 @@ import SwiftUI
 
 /// The preferences window, opened with Cmd-, from the app menu.
 ///
-/// Tabbed, with one tab in it. That looks like overkill until the second tab
-/// arrives — a `TabView` added later moves every control down by the height of
-/// the tab bar, and a preferences window that changes shape between versions is
-/// one people have to re-learn. The frame is fixed for the same reason: a
-/// settings window is not a document window.
+/// Two tabs: what the panel draws, and how often it is read. The tab bar was
+/// there when there was only one, because a `TabView` added later moves every
+/// control down by its height, and a preferences window that changes shape
+/// between versions is one people have to re-learn. The frame is fixed for the
+/// same reason: a settings window is not a document window.
 public struct PreferencesView: View {
     @Bindable private var model: AppModel
 
@@ -180,8 +180,8 @@ struct LayoutTab: View {
 /// Two rates rather than one, because the hardware underneath differs. Counters
 /// are current whenever they are asked, so their rate is a choice about detail.
 /// The SMC refreshes once a second, so anything faster reads the same number
-/// twice — which is why the sensor list starts at 1 s rather than offering the
-/// 0.25 s the counters allow.
+/// twice — which is why the sensor list starts at 1 s and steps in whole
+/// seconds, while the counters step in halves.
 struct SamplingTab: View {
     @Bindable var model: AppModel
 
@@ -190,7 +190,7 @@ struct SamplingTab: View {
             Section {
                 Picker("Performance", selection: $model.sampling.performance) {
                     ForEach(SamplingPreferences.performanceChoices, id: \.self) { seconds in
-                        Text(label(seconds)).tag(seconds)
+                        Text(Format.interval(seconds)).tag(seconds)
                     }
                 }
             } footer: {
@@ -207,15 +207,16 @@ struct SamplingTab: View {
             Section {
                 Picker("Sensors", selection: $model.sampling.sensors) {
                     ForEach(SamplingPreferences.sensorChoices, id: \.self) { seconds in
-                        Text(label(seconds)).tag(seconds)
+                        Text(Format.interval(seconds)).tag(seconds)
                     }
                 }
-                if model.sampling.effectiveSensorInterval != model.sampling.sensors {
-                    // Sensors ride the master clock, so they cannot run faster
-                    // than it. Saying so beats silently ignoring the setting.
+                if !model.sampling.sensorIntervalIsExact {
+                    // Sensors ride the master clock, so the rate asked for is
+                    // not always the rate delivered. Saying which one is real
+                    // beats silently ignoring the setting.
                     Text(
-                        "Sampling every \(label(model.sampling.effectiveSensorInterval)): "
-                            + "sensors cannot be read more often than the "
+                        "Actually every \(Format.interval(model.sampling.effectiveSensorInterval)) — "
+                            + "sensors are read on whole ticks of the "
                             + "performance rate."
                     )
                     .font(.callout)
@@ -235,12 +236,6 @@ struct SamplingTab: View {
             }
         }
         .formStyle(.grouped)
-    }
-
-    private func label(_ seconds: TimeInterval) -> String {
-        seconds < 1
-            ? String(format: "%.2g s", seconds)
-            : String(format: "%.0f s", seconds)
     }
 }
 

--- a/Tests/MonitorCoreTests/SamplingPreferencesTests.swift
+++ b/Tests/MonitorCoreTests/SamplingPreferencesTests.swift
@@ -9,8 +9,40 @@ struct SamplingPreferencesTests {
         #expect(SamplingPreferences(performance: 0.5, sensors: 1).sensorTickDivisor == 2)
         #expect(SamplingPreferences(performance: 0.5, sensors: 2).sensorTickDivisor == 4)
         #expect(SamplingPreferences(performance: 0.5, sensors: 5).sensorTickDivisor == 10)
-        #expect(SamplingPreferences(performance: 0.25, sensors: 1).sensorTickDivisor == 4)
         #expect(SamplingPreferences(performance: 1, sensors: 1).sensorTickDivisor == 1)
+        #expect(SamplingPreferences(performance: 1, sensors: 3).sensorTickDivisor == 3)
+    }
+
+    /// Every pair the pickers can produce has to land somewhere sane. With
+    /// halves on one side and whole seconds on the other, most pairs do not
+    /// divide evenly.
+    @Test("every offered combination gives a usable interval")
+    func everyCombination() {
+        for performance in SamplingPreferences.performanceChoices {
+            for sensors in SamplingPreferences.sensorChoices {
+                let preferences = SamplingPreferences(
+                    performance: performance, sensors: sensors
+                )
+                #expect(preferences.sensorTickDivisor >= 1)
+                // Never faster than the SMC can refresh, and never faster than
+                // the clock it rides.
+                #expect(preferences.effectiveSensorInterval >= performance)
+                #expect(preferences.effectiveSensorInterval >= 0.5)
+            }
+        }
+    }
+
+    /// 2 s is not a multiple of 1.5 s, so it cannot be delivered exactly. One
+    /// tick is nearer than two, and the panel says which it actually got.
+    @Test("a rate that is not a whole number of ticks reports what it got")
+    func inexactRate() {
+        let preferences = SamplingPreferences(performance: 1.5, sensors: 2)
+        #expect(preferences.sensorTickDivisor == 1)
+        #expect(preferences.effectiveSensorInterval == 1.5)
+        #expect(!preferences.sensorIntervalIsExact)
+
+        let exact = SamplingPreferences(performance: 0.5, sensors: 2)
+        #expect(exact.sensorIntervalIsExact)
     }
 
     /// The slower of the two wins. Sensors are sampled on the master clock, so
@@ -26,7 +58,22 @@ struct SamplingPreferencesTests {
     @Test("the effective interval is what the divisor actually produces")
     func effective() {
         #expect(SamplingPreferences(performance: 0.5, sensors: 2).effectiveSensorInterval == 2)
-        #expect(SamplingPreferences(performance: 0.25, sensors: 5).effectiveSensorInterval == 5)
+        #expect(SamplingPreferences(performance: 1, sensors: 4).effectiveSensorInterval == 4)
+    }
+
+    @Test("the pickers offer what was asked for")
+    func choices() {
+        #expect(SamplingPreferences.performanceChoices.first == 0.5)
+        #expect(SamplingPreferences.performanceChoices.last == 5)
+        #expect(SamplingPreferences.performanceChoices.count == 10)
+        #expect(SamplingPreferences.sensorChoices == [1, 2, 3, 4, 5])
+        // The default has to be selectable, or the picker opens showing nothing.
+        #expect(SamplingPreferences.performanceChoices.contains(
+            SamplingPreferences.default.performance
+        ))
+        #expect(SamplingPreferences.sensorChoices.contains(
+            SamplingPreferences.default.sensors
+        ))
     }
 
     /// A zero would divide by zero on the way to a tick count.

--- a/Tests/MonitorCoreTests/SamplingPreferencesTests.swift
+++ b/Tests/MonitorCoreTests/SamplingPreferencesTests.swift
@@ -1,0 +1,53 @@
+import Foundation
+@testable import MonitorCore
+import Testing
+
+@Suite("SamplingPreferences")
+struct SamplingPreferencesTests {
+    @Test("sensors ride the master clock as a whole number of ticks")
+    func divisor() {
+        #expect(SamplingPreferences(performance: 0.5, sensors: 1).sensorTickDivisor == 2)
+        #expect(SamplingPreferences(performance: 0.5, sensors: 2).sensorTickDivisor == 4)
+        #expect(SamplingPreferences(performance: 0.5, sensors: 5).sensorTickDivisor == 10)
+        #expect(SamplingPreferences(performance: 0.25, sensors: 1).sensorTickDivisor == 4)
+        #expect(SamplingPreferences(performance: 1, sensors: 1).sensorTickDivisor == 1)
+    }
+
+    /// The slower of the two wins. Sensors are sampled on the master clock, so
+    /// asking for 1 s while it runs at 2 s cannot deliver 1 s, and claiming
+    /// otherwise would put a rate on screen the app does not honour.
+    @Test("sensors never run faster than the master clock")
+    func clampedToMasterClock() {
+        let slow = SamplingPreferences(performance: 2, sensors: 1)
+        #expect(slow.sensorTickDivisor == 1)
+        #expect(slow.effectiveSensorInterval == 2)
+    }
+
+    @Test("the effective interval is what the divisor actually produces")
+    func effective() {
+        #expect(SamplingPreferences(performance: 0.5, sensors: 2).effectiveSensorInterval == 2)
+        #expect(SamplingPreferences(performance: 0.25, sensors: 5).effectiveSensorInterval == 5)
+    }
+
+    /// A zero would divide by zero on the way to a tick count.
+    @Test("a nonsense master clock does not divide by zero")
+    func degenerate() {
+        #expect(SamplingPreferences(performance: 0, sensors: 1).sensorTickDivisor == 1)
+    }
+
+    @Test("defaults are half a second and one second")
+    func defaults() {
+        #expect(SamplingPreferences.default.performance == 0.5)
+        #expect(SamplingPreferences.default.sensors == 1)
+        // 1 s is the floor because the SMC refreshes at 1 Hz; offering faster
+        // would be offering the same bits again.
+        #expect(SamplingPreferences.sensorChoices.first == 1)
+    }
+
+    @Test("preferences round-trip through JSON")
+    func roundTrip() throws {
+        let preferences = SamplingPreferences(performance: 0.25, sensors: 5)
+        let data = try JSONEncoder().encode(preferences)
+        #expect(try JSONDecoder().decode(SamplingPreferences.self, from: data) == preferences)
+    }
+}

--- a/Tests/MonitorUITests/AppModelTests.swift
+++ b/Tests/MonitorUITests/AppModelTests.swift
@@ -1,0 +1,122 @@
+import Foundation
+import MonitorCore
+@testable import MonitorUI
+import Testing
+
+/// A source that reports what it is told to, so the model can be driven without
+/// a machine to read.
+private final class StubSource: MetricSource, @unchecked Sendable {
+    let id: String
+    let descriptors: [MetricDescriptor]
+    let minimumInterval: TimeInterval
+    var value = 1.0
+
+    init(id: String, group: String, names: [String], minimumInterval: TimeInterval = 0) {
+        self.id = id
+        self.minimumInterval = minimumInterval
+        descriptors = names.map {
+            MetricDescriptor(
+                id: MetricID("\(id).\($0)"), name: $0, group: group, unit: .celsius
+            )
+        }
+    }
+
+    func read(at timestamp: TimeInterval) throws -> SampleBatch {
+        SampleBatch(
+            timestamp: timestamp,
+            samples: descriptors
+                .map { Sample(metric: $0.id, timestamp: timestamp, value: value) }
+        )
+    }
+}
+
+@MainActor
+@Suite("AppModel")
+struct AppModelTests {
+    /// One throwaway defaults domain, wiped before each model is built.
+    ///
+    /// Two things this avoids. Without a domain of its own, each test reads and
+    /// writes the preferences of whoever is running it — the first version of
+    /// these tests turned on a gauge in the real panel and left it there, then
+    /// leaked that state into the next test in the file. And a *fresh* domain
+    /// per test would be worse in a quieter way: `suiteName` domains persist,
+    /// so a uuid each time writes a new plist on every run, forever.
+    private static let domain = "wtf.evan.monitor.tests"
+
+    private static func makeModel() -> (AppModel, StubSource, StubSource) {
+        let fast = StubSource(id: "disk", group: "Disk", names: ["Read"])
+        let slow = StubSource(
+            id: "sensors", group: "Temperature", names: ["CPU"], minimumInterval: 1
+        )
+        let defaults = UserDefaults(suiteName: domain)!
+        defaults.removePersistentDomain(forName: domain)
+        return (AppModel(sources: [fast, slow], defaults: defaults), fast, slow)
+    }
+
+    /// One tick is one batch carrying every source's samples, which is what
+    /// `Sampler.tick` returns. Ingesting them separately would look like two
+    /// ticks that each lost a source.
+    private static func batch(
+        _ sources: [StubSource], at timestamp: TimeInterval
+    ) -> SampleBatch {
+        SampleBatch(
+            timestamp: timestamp,
+            samples: sources.flatMap { (try? $0.read(at: timestamp))?.samples ?? [] }
+        )
+    }
+
+    /// The bug this guards against looks like a rendering glitch: a sensor read
+    /// once a second produced no sample on the ticks in between, the model took
+    /// that for a failed source, and the card greyed itself out twice a second.
+    @Test("a source that was not asked is not reported unavailable")
+    func skippedIsNotUnavailable() {
+        let (model, fast, slow) = Self.makeModel()
+        let now = Date().timeIntervalSince1970
+
+        model.ingest(Self.batch([fast, slow], at: now), skipped: [])
+        #expect(model.unavailable.isEmpty)
+
+        // A tick that deliberately left the sensors alone.
+        model.ingest(Self.batch([fast], at: now + 0.5), skipped: ["sensors"])
+        #expect(model.unavailable.isEmpty)
+    }
+
+    /// The other half: a source that was asked and produced nothing is broken,
+    /// and must still say so.
+    @Test("a source that was asked and gave nothing is unavailable")
+    func silentSourceIsUnavailable() {
+        let (model, fast, slow) = Self.makeModel()
+        let now = Date().timeIntervalSince1970
+
+        model.ingest(Self.batch([fast, slow], at: now), skipped: [])
+        #expect(model.unavailable.isEmpty)
+
+        // Asked for, nothing came back.
+        model.ingest(Self.batch([fast], at: now + 0.5), skipped: [])
+        #expect(model.unavailable.contains(MetricID("sensors.CPU")))
+    }
+
+    @Test("the layout defaults leave the panel as it shipped")
+    func defaultLayout() {
+        let (model, _, _) = Self.makeModel()
+        // Temperature is charted by default; a stub disk metric is not on any
+        // of the named lists, so it lands in neither until it is ticked.
+        #expect(model.layout.showsChart(MetricID("sensors.CPU")))
+        #expect(model.sensorGroups.contains { $0.name == "Temperature" })
+    }
+
+    @Test("a group with nothing ticked draws no card")
+    func emptyGroupHasNoCard() {
+        let (model, _, _) = Self.makeModel()
+        model.layout.setChart(false, for: MetricID("sensors.CPU"))
+        #expect(!model.sensorGroups.contains { $0.name == "Temperature" })
+    }
+
+    @Test("enabling a gauge puts it on the wall")
+    func gaugeOrder() {
+        let (model, _, _) = Self.makeModel()
+        #expect(model.gaugeMetrics.isEmpty)
+        model.layout.setGauge(true, for: MetricID("sensors.CPU"))
+        #expect(model.gaugeMetrics == [MetricID("sensors.CPU")])
+    }
+}

--- a/docs/sensors.md
+++ b/docs/sensors.md
@@ -83,19 +83,44 @@ same CPU metric as Apple silicon's `Tp01`.
 
 | Metric | Keys | Notes |
 |--------|------|-------|
-| `sensor.temperature.cpu` | `Tp…`, `Te…`; Intel `TC0P`/`TC0D`/`TCXC` | hottest of up to six die sensors |
-| `sensor.temperature.gpu` | `Tg…`; Intel `TG0P`/`TG0D` | |
-| `sensor.temperature.storage` | `TH0…` | internal SSD |
-| `sensor.temperature.battery` | `TB…T` | |
+| `sensor.temperature.cpu` | `Tp…`, `Te…`; Intel `TC0P`/`TC0D`/`TCXC` | hottest die sensor |
+| `sensor.temperature.gpu` | `Tg…`; Intel `TG0P`/`TG0D` | hottest die sensor |
+| `sensor.temperature.storage` | `TH0…` | internal SSD, including the NAND sensor |
+| `sensor.temperature.battery` | `TB…T` | one metric per pack, hottest cell |
 | `sensor.temperature.enclosure` | `Ts…P` | the case, i.e. what your hands feel |
-| `sensor.temperature.ambient` | `TA…P` | absent on this machine |
+| `sensor.temperature.ambient` | `TA…P` | not published by every model |
 | `sensor.power.input` | `PDTR` | DC in |
 | `sensor.power.soc` | `PHPS` | package: CPU + GPU + memory |
-| `sensor.fan.N.speed` | `FNAc`, scaled by `FNMx` | absent on this machine |
+| `sensor.fan.N.speed` | `FNAc`, scaled by `FNMx` | fanless models publish none |
 
 Temperatures take the **hottest** of their sensors rather than the mean: the
 hot spot is what throttles the machine, and averaging fourteen die sensors
 hides the one that is about to.
+
+### How many keys is "their sensors"?
+
+Wildly model-dependent, and not predictable from the model name. A 16-inch
+MacBook Pro of 2026 publishes 568 readable keys, of which:
+
+| Family | Keys on that machine |
+|---|---|
+| GPU `Tg…` | 84 |
+| CPU `Tp…`/`Te…` | 23 |
+| SSD `TH0…` | 3 |
+| Battery `TB…T` | 3 |
+| Enclosure `Ts…P` | 2 |
+| Ambient `TA…P` | 0 |
+
+Another Mac will not match that table, which is the argument for discovering
+everything at launch rather than shipping a list per model. It is also why
+`hottest` must mean *all* of them: this source once read the first six of each
+family, so a machine with 23 die sensors reported the hottest of an arbitrary
+six and called it the hottest. On this machine that understated the CPU by
+three degrees.
+
+Reading them all costs about 0.15 ms per key, so a tick of this source runs
+around 15 ms here against 4 ms when it sampled six. That is the price of the
+metric meaning what it says.
 
 Charts are pinned to 0–110 °C rather than auto-scaled, for the same reason CPU
 load is pinned to 0–100%: a chart scaled to 2 °C of drift makes a cool machine

--- a/docs/sensors.md
+++ b/docs/sensors.md
@@ -122,6 +122,49 @@ Reading them all costs about 0.15 ms per key, so a tick of this source runs
 around 15 ms here against 4 ms when it sampled six. That is the price of the
 metric meaning what it says.
 
+## How often it is worth reading them
+
+**The SMC refreshes temperature and power once a second.** Sampled at 4.4 Hz
+for 17 minutes across an idle machine, a load ramp and a cooldown:
+
+| Sensor | Reads that changed | Median gap between changes | p90 |
+|---|---|---|---|
+| CPU temperature | 22.3% | 0.92 s | 1.14 s |
+| GPU temperature | 21.2% | 0.92 s | 1.15 s |
+| SoC power | 22.6% | 0.92 s | 1.13 s |
+| Fan 1 speed | 63.1% | 0.23 s | 0.24 s |
+
+A gap that sits at 0.9–1.1 s while sampling every 0.23 s is a 1 Hz clock
+beating against the sampler. It is not rounding: the value quantum is 1/64 °C,
+so an identical consecutive read is genuinely no new value. **Fan tachometers
+are the exception** — they change on most reads and resolve to 1 rpm — but they
+ride the same IOKit round trip as the rest, so they cannot be read faster
+without paying for everything else too.
+
+Decimating that trace to what a sampler would actually see, against the full
+rate as truth:
+
+| Interval | CPU worst error | GPU worst error | SoC peak missed |
+|---|---|---|---|
+| 0.5 s | 1.8 °C | 4.5 °C | 0.0 W |
+| **1 s** | **1.8 °C** | **4.5 °C** | **0.0 W** |
+| 2 s | 2.7 °C | 5.4 °C | 1.1 W |
+| 5 s | 5.8 °C | 8.8 °C | 19.3 W |
+| 10 s | 10.7 °C | 13.0 °C | 1.1 W |
+
+0.5 s and 1 s are identical, which is the whole argument: **1 s is the floor**,
+and everything faster is an IOKit round trip to be told the same number again.
+2 s costs under a degree of worst-case error and is a reasonable quiet setting.
+5 s is defensible for temperature and poor for power, which swings 19 W between
+readings. 10 s is not offered.
+
+Power is irreducibly spiky, and no interval fixes it: even at 0.5 s the worst
+gap between the chart and the truth is 35 W, because SoC power genuinely moves
+that far between the SMC's own updates.
+
+`SMCSource.minimumInterval` is 1 s for these reasons, and the sampler skips the
+source entirely on ticks that would fall inside it.
+
 Charts are pinned to 0–110 °C rather than auto-scaled, for the same reason CPU
 load is pinned to 0–100%: a chart scaled to 2 °C of drift makes a cool machine
 look like a fire.


### PR DESCRIPTION
Three commits, from one thread: comparing monitor's sensor list against another app's led to a real bug, and measuring the cost of fixing it led to a measured answer for how often sensors are worth reading at all.

## 1. `hottest` was the hottest of an arbitrary six

`SMCSource` read the first six keys of each family and reported the hottest of *those*, while the metric said hottest. This machine publishes **23 `Tp…` keys**, so the reading sat three degrees under the real peak and nothing said it was a sample.

| Metric | Before | After |
|---|---|---|
| CPU | 50 °C | **53 °C** |
| GPU | 46 °C | **48 °C** |
| SSD | 32 °C | **34 °C** |

The cap existed for cost, and the cost was estimated. Measured: 0.15 ms per key, and the same machine publishes **84 `Tg…` GPU sensors**, so the source goes 3.9 → 15.5 ms per tick. Worth paying — the alternative is a temperature wrong in the direction nobody checks. The constant stays as a bound, high enough never to bind.

Key counts are wildly model-dependent and unpredictable from the model name, so `docs/sensors.md` now presents them as an illustration from one machine, and `AGENTS.md` gains the rule: never hard-code a count per model, never sample a subset of a family whose metric claims to be the hottest of it.

## 2. Sensors get their own interval, floor 1 s

**Measured, not assumed.** Sampled at 4.4 Hz for 17 minutes across idle, a load ramp to 101 °C, and cooldown:

| Sensor | Reads that changed | Median gap | p90 |
|---|---|---|---|
| CPU / GPU temp, SoC power | ~22% | **0.92 s** | 1.14 s |
| Fan 1 | 63% | 0.23 s | 0.24 s |

A gap pinned at 0.9–1.1 s while sampling every 0.23 s is a 1 Hz clock. The quantum is 1/64 °C, so identical reads are genuinely no new value. Decimation confirms it: **0.5 s and 1 s reconstruct the truth identically**; the first losses appear at 2 s (under 1 °C), and 5 s misses SoC power peaks by 19 W.

So sensors sample at 1 s by default — halving what this source costs while losing nothing, which pays back §1 twice over.

**Still one clock.** A slow source declares `minimumInterval` and is read on every *n*th tick of the same clock, never its own timer, so its samples land on exactly the timestamps everything else uses. `SamplingPreferences` does that arithmetic in `MonitorCore` where it is testable.

**A skipped source is not a failed one.** `ingest` excludes it from the unavailable set — without that, a sensor read once a second greys its own cards out on every tick in between.

## 3. The rates, and where they are set

A new **Sampling** tab beside Layout — the second tab the tab bar was built for. Performance 0.5–5 s in halves, sensors 1–5 s in whole seconds. The toolbar's rate picker now reads the same list instead of its own hard-coded one, which included a 0.25 s that preferences could not display.

`Format.interval` because `%.0f` renders 1.5 s as "2 s", and a picker that offers a value then labels it as another is worse than one that does not offer it. A sensor rate that is not a whole multiple of the performance rate cannot be delivered exactly, so the tab prints what it actually got.

## Test coverage

`AppModel` had **no test target at all** despite owning real logic; this adds one. Writing it found that `AppModel` reached for the shared defaults suite, so the first run edited the preferences of whoever ran the tests. It now takes a `UserDefaults`, and the tests use a throwaway domain they wipe first — a uuid domain per test would have leaked a plist every run instead.

95 tests pass, swiftformat clean, release build clean. The Sampling tab and both pickers verified in the running app.