### PR TITLE
Write down why signing failed on the runner: SessionCreate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,7 +179,11 @@ are no component-level AGENTS.md files.
   `package.yml`; unset, a release is ad-hoc signed exactly as before. Set,
   failing to sign or notarize fails the release rather than publishing a zip
   nobody can open. The credentials live in the Mac runner's keychain, not in
-  GitHub secrets. **`notarize.sh` rebuilds the zip after stapling** — `stapler`
+  GitHub secrets — which is why the runner's LaunchAgent needs
+  `SessionCreate = false`: with the default `true`, every job gets its own
+  security session, cannot reach the login keychain, and `codesign` fails with
+  `errSecInternalComponent`. A signing runner cannot be headless.
+  **`notarize.sh` rebuilds the zip after stapling** — `stapler`
   writes into the bundle, not the archive, so the uploaded copy is unstapled
   until it is made again. `docs/signing.md` is the setup.
 - **The version lives in `MonitorCore/Version.swift`.** The About panel reads

--- a/docs/developer-id-runbook.md
+++ b/docs/developer-id-runbook.md
@@ -258,6 +258,21 @@ security set-key-partition-list -S apple-tool:,apple:,codesign: \
     -s -k <keychain-password> login.keychain-db
 ```
 
+**`errSecInternalComponent` means the key is unreachable, not missing.** This
+is the one that costs an afternoon, because the message names nothing useful
+and the identity is right there in `security find-identity`. On a GitHub
+self-hosted runner the usual cause is `SessionCreate = true` in the LaunchAgent
+plist that `svc.sh` installs: it spawns each job into its own security session,
+which does not inherit the unlocked login keychain. Set it to `false`, then
+`launchctl bootout` and `bootstrap` the agent. A signing runner also needs
+somebody logged in at the console — it cannot be headless.
+
+**An SSH session does not inherit the GUI keychain unlock either.** Setting the
+machine up remotely, every `security` and `notarytool` command needs an
+explicit `security unlock-keychain` first, even though the same keychain is
+unlocked for the user sitting in front of it. That is a property of the setup
+session and says nothing about whether the build will work.
+
 **The certificate expires with the membership**, not five years out. This
 matters less than it looks: a build signed *and notarized* while the certificate
 was valid keeps working afterwards, because the secure timestamp proves when it

--- a/docs/signing.md
+++ b/docs/signing.md
@@ -80,6 +80,29 @@ If the runner runs as a LaunchDaemon it has no login keychain at all. Run it as
 a LaunchAgent under your user, or give it a dedicated keychain and unlock that
 in the job.
 
+**A LaunchAgent is not enough on its own.** GitHub's `svc.sh` writes
+`SessionCreate = true` into the runner's plist, which spawns every job into its
+own security session. That session does not inherit the login session's
+unlocked keychain, so `codesign` finds the identity, fails to reach its private
+key, and reports `errSecInternalComponent` — an error that says nothing about
+keychains. Turn it off and reload:
+
+```sh
+p=~/Library/LaunchAgents/actions.runner.<org>.<runner>.plist
+cp "$p" "$p.bak"
+/usr/libexec/PlistBuddy -c "Set :SessionCreate false" "$p"
+launchctl bootout gui/$(id -u)/actions.runner.<org>.<runner>
+launchctl bootstrap gui/$(id -u) "$p"
+```
+
+The job then runs in the console user's session and signs against the keychain
+unlocked at login. The alternative is to keep the separate session and unlock a
+keychain inside the job, which means putting its password in a GitHub secret —
+the thing keeping the credentials on the runner was meant to avoid.
+
+This needs somebody logged in at the console on that Mac. A runner that signs
+is a runner that is not headless.
+
 **3. Store notarization credentials.** An app-specific password from
 appleid.apple.com, kept in a named profile:
 


### PR DESCRIPTION
Signing and notarization are now **live on the Mac mini runner** — verified end to end. This records the one thing that went wrong on the way, because the error message names nothing useful.

## What happened

The first signed build failed with `errSecInternalComponent`, one line after `security find-identity` happily listed the identity.

The cause is the LaunchAgent GitHub's `svc.sh` installs: it sets **`SessionCreate = true`**, so every job is spawned into its own security session, and that session does not inherit the login keychain unlocked when the user logged in. `codesign` finds the certificate and cannot reach its private key.

Setting it `false` and reloading the agent fixes it, and keeps the credentials on the machine rather than in GitHub secrets — the alternative is a dedicated keychain whose password travels as a secret, which is exactly what keeping them on the runner was meant to avoid.

**The consequence worth stating out loud: a runner that signs cannot be headless.** Somebody has to be logged in at the console.

## Verified

Dispatched `package.yml` with no tag — it builds and uploads without publishing, which makes it a real dry run of the release path:

```
Signing as Developer ID Application: EVAN DAVID HOFFMAN (94S5PZTVPY)…
status: Accepted
The staple and validate action worked!
Rebuilding monitor-1.1.2.zip around the stapled bundle…
.build/monitor.app: accepted
source=Notarized Developer ID
```

And the artifact downloaded from that run, checked here rather than trusted:

```
Authority=Developer ID Application: EVAN DAVID HOFFMAN (94S5PZTVPY)
stapler: The validate action worked!
spctl: accepted — source=Notarized Developer ID
```

The same run settled a smaller doubt: `notarytool` finds a profile stored in the login keychain **without** being passed `--keychain`, despite `store-credentials` suggesting otherwise. `notarize.sh` does not need it.

Notarization took 17 seconds here against ~20 minutes for the first submission yesterday — that was Apple's queue, not our build.

## Also recorded

An SSH session does not inherit the GUI keychain unlock either, so remote setup needs an explicit `security unlock-keychain` — and that says nothing about whether builds will work, which is a confusing signal when you are debugging exactly this.

Docs only, so this publishes no release. The next code merge produces a signed, notarized, stapled one with the Gatekeeper paragraph dropped from the notes.