### PR TITLE
Arrange the panel: drag to reorder, sliders to resize, both remembered

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,6 +136,8 @@ are no component-level AGENTS.md files.
   rather than swap, the drop target is half a tile so the last position in a row
   is reachable, and a card can be dragged across the section rule — the
   performance/sensor split is a default, not a rule about what belongs where.
+  The drag payload is plain text behind a private prefix, **not** a custom
+  `UTType` — see Troubleshooting for why.
   The sensor section is drawn whenever the machine has sensors *at all* rather
   than when it holds a card, so dragging the last one out does not remove the
   target needed to drag it back.
@@ -316,6 +318,19 @@ are no component-level AGENTS.md files.
 
 ## Troubleshooting
 
+- **Nothing on the panel can be dragged at all**: something hit-testable is
+  sitting above the tile. A drop target must not be an `.overlay` with a
+  `contentShape` — an overlay is above the content, so it swallows the
+  mouse-down and `.draggable` never sees a press. `ReorderDrag` uses one
+  `DropDelegate` over the tile and reads `DropInfo.location` to tell the halves
+  apart; the width comes from a background `GeometryReader`, which is not
+  hit-testable.
+- **Dragging works in `monitor.app` but not in `swift run monitor`**: something
+  in the drag payload needs an `Info.plist`, and the development build has no
+  bundle. This is why the payload is plain text behind a private prefix rather
+  than a custom `UTType(exportedAs:)` — that route silently matched no drop
+  destination at all when unbundled. Verify drags with `swift run`, not only
+  with a packaged build.
 - **A rate metric shows nothing on the first tick**: correct by design. Counters
   need two readings. `monitorctl read` takes two ticks for this reason.
 - **The window opens behind other apps, or the app is missing from Cmd-Tab**:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,14 +64,17 @@ look at it in the app.
 Sources/
   MonitorCore/     metric model, ring buffer, downsampling, gauge auto-ranging,
                    seven-segment digit mapping, formatting, the sampling clock,
-                   the layout and sampling preference models. No macOS APIs — so all of it is
-                   testable without a machine to read.
+                   the layout, arrangement and sampling preference models. No
+                   macOS APIs — so all of it is testable without a machine to
+                   read.
   MonitorSources/  the readers: CPU, memory, disk, network, GPU, SMC sensors
                    (temperature, fans, power), and the registry that lists them.
                    One file per source, plus SMC.swift for the SMC transport.
   MonitorUI/       Theme (palette + Layout density), GaugeView, SevenSegmentText,
                    ChartCard, FlowLayout, DashboardView, PreferencesView,
-                   AppModel, LayoutPreferencesStore (layout + sampling)
+                   SizePopover, ReorderDrag (drag-to-reorder for both grids),
+                   AppModel, LayoutPreferencesStore (layout, sampling,
+                   arrangement)
   MonitorStore/    SQLite history and retention. Designed and tested but NOT
                    linked into the app — see "Guardrails" below.
   monitor/         the app target (@main SwiftUI App) and its AppDelegate
@@ -124,6 +127,25 @@ are no component-level AGENTS.md files.
   this working right now against what it can do" (disk, network throughput). A
   chart answers "what has been happening" (CPU, memory). `LayoutDefaults`
   encodes the split — but as an opening position, not a rule.
+- **The panel is arranged by dragging, and stored.** `PanelArrangement` (in
+  `MonitorCore`) holds where every tile sits and how big tiles are; the order
+  used to be recomputed from `LayoutDefaults` on every access, and those
+  constants are now the **seed** for it rather than the order itself. Keep the
+  two apart: **`LayoutPreferences` is what is drawn, `PanelArrangement` is where
+  it goes.** Two structs, two preference keys. Reordering is insert-before
+  rather than swap, the drop target is half a tile so the last position in a row
+  is reachable, and a card can be dragged across the section rule — the
+  performance/sensor split is a default, not a rule about what belongs where.
+  The sensor section is drawn whenever the machine has sensors *at all* rather
+  than when it holds a card, so dragging the last one out does not remove the
+  target needed to drag it back.
+- **Every gesture writes once, when it ends.** `AppModel.arrangement`
+  deliberately has no saving `didSet`, unlike `layout` beside it: a checkbox
+  changes once when clicked, but a slider fires on every frame of a drag and a
+  drag crosses several drop targets on the way to the one it wants. Mutate it
+  freely during a gesture, then call `commitArrangement()`. Adding a `didSet`
+  that saves would turn one decision into hundreds of writes — the thing
+  `docs/storage.md` exists to prevent.
 - **The layout is chosen per metric, in preferences.** Cmd-, opens a tabbed
   window. Its **Layout** tab lists every metric with a Gauge checkbox and a
   Chart checkbox, grouped into collapsible sections whose headings carry the
@@ -212,7 +234,10 @@ are no component-level AGENTS.md files.
   mutable state between reads (previous ticks, a `RateTracker`, a cached
   interface list) and the sampler is the only caller.
 - Every layout constant lives in `Theme.Layout`, not in the views. Card size,
-  column count and density are one decision, not eight.
+  column count and density are one decision, not eight. The three *resizable*
+  sizes are the exception: their bounds are in `PanelSize` in `MonitorCore`,
+  because a stored size has to be clamped by the value type that holds it.
+  `Theme.Layout` forwards to them, so views still read one place.
 - Tests are one `@Suite` per area with `@Test` cases. `MonitorCoreTests` use
   fixed inputs; `MonitorSourcesTests` read this machine and assert shape and
   plausible range.
@@ -252,6 +277,9 @@ are no component-level AGENTS.md files.
   a refactor. Preferences are the exception that proves the rule: layout
   choices go to `UserDefaults` under `wtf.evan.monitor`, which is a write when
   somebody ticks a checkbox, not a write every half second forever.
+- **Never save the arrangement on change.** It is mutated on every frame of a
+  drag and every frame of a slider. Save when the gesture ends — see
+  `commitArrangement`.
 - Never report a fabricated value when a source fails. Throw
   `MetricSourceError` and let the UI say "not available". A plausible wrong
   number in a monitoring tool is worse than a gap, because nobody checks it.

--- a/Scripts/make-app.sh
+++ b/Scripts/make-app.sh
@@ -95,6 +95,26 @@ cat > "$app/Contents/Info.plist" <<PLIST
     <!-- The window is designed against a dark ground; see Theme. -->
     <key>NSRequiresAquaSystemAppearance</key>
     <false/>
+    <!--
+      The drag type used to reorder tiles on the panel (see ReorderDrag.swift).
+      Declared so the system knows it rather than warning about an undeclared
+      identifier. It is deliberately a private type: the panel neither accepts
+      text dragged in from another app nor offers its internals to one, so it
+      has no filename extension and no MIME type.
+    -->
+    <key>UTExportedTypeDeclarations</key>
+    <array>
+      <dict>
+        <key>UTTypeIdentifier</key>
+        <string>wtf.evan.monitor.panel-tile</string>
+        <key>UTTypeDescription</key>
+        <string>Monitor panel tile</string>
+        <key>UTTypeConformsTo</key>
+        <array>
+          <string>public.data</string>
+        </array>
+      </dict>
+    </array>
 </dict>
 </plist>
 PLIST

--- a/Scripts/make-app.sh
+++ b/Scripts/make-app.sh
@@ -95,26 +95,6 @@ cat > "$app/Contents/Info.plist" <<PLIST
     <!-- The window is designed against a dark ground; see Theme. -->
     <key>NSRequiresAquaSystemAppearance</key>
     <false/>
-    <!--
-      The drag type used to reorder tiles on the panel (see ReorderDrag.swift).
-      Declared so the system knows it rather than warning about an undeclared
-      identifier. It is deliberately a private type: the panel neither accepts
-      text dragged in from another app nor offers its internals to one, so it
-      has no filename extension and no MIME type.
-    -->
-    <key>UTExportedTypeDeclarations</key>
-    <array>
-      <dict>
-        <key>UTTypeIdentifier</key>
-        <string>wtf.evan.monitor.panel-tile</string>
-        <key>UTTypeDescription</key>
-        <string>Monitor panel tile</string>
-        <key>UTTypeConformsTo</key>
-        <array>
-          <string>public.data</string>
-        </array>
-      </dict>
-    </array>
 </dict>
 </plist>
 PLIST

--- a/Sources/MonitorCore/LayoutPreferences.swift
+++ b/Sources/MonitorCore/LayoutPreferences.swift
@@ -3,11 +3,19 @@ import Foundation
 /// What the panel draws when nobody has said otherwise.
 ///
 /// These lists were hard-coded in the dashboard before the layout could be
-/// chosen. They live here now because they are two different things at once:
-/// the starting state of a fresh preference set, and the order things appear
-/// in. Order matters as much as membership — a dial or a card that moves
-/// between launches is one you have to hunt for, so enabling a metric adds it
-/// to a fixed position rather than wherever the registry happened to yield it.
+/// chosen, and they were the panel's order until it could be dragged.
+///
+/// They are now the **seed** for that order, not the order itself:
+/// `PanelArrangement` holds where every tile actually sits, and reads these
+/// once to decide where a tile it has never seen belongs. Order still matters
+/// as much as membership — a dial that moves between launches is one you have
+/// to hunt for — which is why a metric switched on lands at a considered
+/// position rather than wherever the registry happened to yield it, and why a
+/// sensor that appears when you plug in a dock lands among its own kind rather
+/// than at the end.
+///
+/// Read these to answer "where does this go if nobody has said"; read
+/// `PanelArrangement` to answer "where is this".
 public enum LayoutDefaults {
     /// The dials on the wall, left to right.
     ///

--- a/Sources/MonitorCore/PanelArrangement.swift
+++ b/Sources/MonitorCore/PanelArrangement.swift
@@ -1,0 +1,365 @@
+import Foundation
+
+/// One resizable dimension of the panel: how small, how large, and where it
+/// starts.
+///
+/// A struct rather than three loose constants because the three always travel
+/// together — a slider needs all of them, and a stored size is only meaningful
+/// against the bounds it was clamped to.
+public struct SizeRange: Equatable, Sendable {
+    public let minimum: Double
+    public let maximum: Double
+    public let initial: Double
+
+    public init(minimum: Double, maximum: Double, initial: Double) {
+        self.minimum = minimum
+        self.maximum = maximum
+        self.initial = initial
+    }
+
+    public func clamp(_ value: Double) -> Double {
+        // A NaN read back from a corrupt preference compares false against both
+        // bounds and would survive `min`/`max` untouched, then propagate into
+        // the grid's column width. Send it to the starting size instead.
+        guard value.isFinite else { return initial }
+        return Swift.min(Swift.max(minimum, value), maximum)
+    }
+
+    public var bounds: ClosedRange<Double> { minimum...maximum }
+}
+
+/// How big the three resizable things are allowed to get.
+///
+/// These live in `MonitorCore` rather than in `Theme.Layout` because they are
+/// now part of the stored model: `PanelArrangement` clamps to them when it
+/// loads, and a stored size has to be checked against bounds the value type can
+/// see. `Theme.Layout` forwards to them, so the views still read one place.
+public enum PanelSize {
+    /// Dials are square, so this is their height too. The floor is where the
+    /// readout stops being legible; the ceiling is a sanity limit, and on a
+    /// window narrower than one row of ceiling-sized dials the real limit is
+    /// the width, which only the view can know.
+    public static let gauge = SizeRange(minimum: 90, maximum: 360, initial: 130)
+    /// Minimum card width, which is really a column count in disguise: 260
+    /// gives four columns at 1180pt and three at 900.
+    public static let chartWidth = SizeRange(minimum: 200, maximum: 600, initial: 260)
+    /// The plot area alone, not counting the card's header and padding. Still a
+    /// *minimum*, so a shorter window scrolls rather than squeezing.
+    public static let chartHeight = SizeRange(minimum: 100, maximum: 400, initial: 125)
+}
+
+/// Where every tile sits, and how big the tiles are.
+///
+/// The panel's order used to be *derived*: the dashboard recomputed it from the
+/// constants in `LayoutDefaults` on every access. Once a dial can be dragged,
+/// order is data, and this is where it lives.
+///
+/// Note what this is not. `LayoutPreferences` says **what is drawn**; this says
+/// **where it goes and how big it is**. Two structs and two preference keys, so
+/// a corrupt arrangement costs a layout rather than every checkbox somebody
+/// ticked.
+///
+/// A value type in `MonitorCore` so the merge and move rules are testable
+/// without a window to drag things around in.
+public struct PanelArrangement: Codable, Equatable, Sendable {
+    /// Which side of the rule a chart card sits on.
+    ///
+    /// The split is a starting position, not a rule about what belongs where:
+    /// a card can be dragged across, because the pairing somebody cares about
+    /// may well be CPU load beside CPU temperature.
+    public enum ChartSection: String, Codable, CaseIterable, Sendable {
+        case performance, sensors
+    }
+
+    /// Raw strings rather than `MetricID`, for the same reason
+    /// `LayoutPreferences` uses them: this is what gets written to preferences,
+    /// and a bare list of strings is the shape that survives a change to the
+    /// type.
+    private var gauges: [String]
+    private var performance: [String]
+    private var sensors: [String]
+
+    private var gaugeSizeValue: Double
+    private var chartWidthValue: Double
+    private var chartHeightValue: Double
+
+    /// Clamped on the way in, so no caller can store a size the panel cannot
+    /// draw — including a decoder reading a value somebody edited by hand.
+    public var gaugeSize: Double {
+        get { gaugeSizeValue }
+        set { gaugeSizeValue = PanelSize.gauge.clamp(newValue) }
+    }
+
+    public var chartWidth: Double {
+        get { chartWidthValue }
+        set { chartWidthValue = PanelSize.chartWidth.clamp(newValue) }
+    }
+
+    public var chartHeight: Double {
+        get { chartHeightValue }
+        set { chartHeightValue = PanelSize.chartHeight.clamp(newValue) }
+    }
+
+    /// Spelled out so the stored JSON carries the public names rather than the
+    /// backing properties, and so `init(from:)` below can be written by hand.
+    private enum CodingKeys: String, CodingKey {
+        case gauges, performance, sensors
+        case gaugeSizeValue = "gaugeSize"
+        case chartWidthValue = "chartWidth"
+        case chartHeightValue = "chartHeight"
+    }
+
+    /// Written out rather than synthesised because a synthesised one assigns
+    /// straight to the stored properties and skips the clamping setters — so a
+    /// preference edited by hand, or written by a version with different
+    /// bounds, would come back as a column width the grid cannot draw.
+    ///
+    /// Every field is optional on the way in: a stored arrangement from a
+    /// version that did not have one should adopt its default, not fail to
+    /// decode and take the whole layout with it.
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        try self.init(
+            gauges: (container.decodeIfPresent([String].self, forKey: .gauges) ?? [])
+                .map { MetricID($0) },
+            performance: container.decodeIfPresent(
+                [String].self, forKey: .performance
+            ) ?? [],
+            sensors: container.decodeIfPresent([String].self, forKey: .sensors) ?? [],
+            gaugeSize: container.decodeIfPresent(Double.self, forKey: .gaugeSizeValue)
+                ?? PanelSize.gauge.initial,
+            chartWidth: container.decodeIfPresent(Double.self, forKey: .chartWidthValue)
+                ?? PanelSize.chartWidth.initial,
+            chartHeight: container.decodeIfPresent(Double.self, forKey: .chartHeightValue)
+                ?? PanelSize.chartHeight.initial
+        )
+    }
+
+    public init(
+        gauges: [MetricID] = [],
+        performance: [String] = [],
+        sensors: [String] = [],
+        gaugeSize: Double = PanelSize.gauge.initial,
+        chartWidth: Double = PanelSize.chartWidth.initial,
+        chartHeight: Double = PanelSize.chartHeight.initial
+    ) {
+        self.gauges = gauges.map(\.rawValue)
+        // A group named in both lists would draw two cards for one group, so
+        // the first mention wins and the duplicate is dropped.
+        let above = performance.uniqued()
+        self.performance = above
+        self.sensors = sensors.uniqued().filter { !above.contains($0) }
+        gaugeSizeValue = PanelSize.gauge.clamp(gaugeSize)
+        chartWidthValue = PanelSize.chartWidth.clamp(chartWidth)
+        chartHeightValue = PanelSize.chartHeight.clamp(chartHeight)
+    }
+
+    // MARK: - Reading
+
+    /// Every metric that has a place on the wall, left to right.
+    ///
+    /// This is a position, not a decision to draw: whether a dial appears is
+    /// `LayoutPreferences.showsGauge`. Keeping a position for a metric that is
+    /// switched off is the point — turn it back on and it returns to where it
+    /// was rather than to the end of the row.
+    public var gaugeOrder: [MetricID] { gauges.map { MetricID($0) } }
+
+    public func groupOrder(in section: ChartSection) -> [String] {
+        switch section {
+        case .performance: performance
+        case .sensors: sensors
+        }
+    }
+
+    /// Which side of the rule a group is on, or nil if the arrangement has
+    /// never heard of it.
+    public func section(of group: String) -> ChartSection? {
+        if performance.contains(group) { return .performance }
+        if sensors.contains(group) { return .sensors }
+        return nil
+    }
+
+    // MARK: - Moving
+
+    /// Moves a dial to sit immediately before `other`, or to the end when
+    /// `other` is nil.
+    ///
+    /// Insert-before rather than swap. For two adjacent dials the two are
+    /// indistinguishable; for anything further apart swap flings an unrelated
+    /// dial across the wall to the space you just left, which is not what
+    /// dragging something looks like anywhere else.
+    ///
+    /// Stated in terms of the neighbour rather than an index on purpose: the
+    /// caller has a drop target, not a number, and computing the number means
+    /// remembering that removing the dragged item shifts everything after it.
+    public mutating func moveGauge(_ metric: MetricID, before other: MetricID?) {
+        gauges = Self.move(metric.rawValue, before: other?.rawValue, in: gauges)
+    }
+
+    /// Moves a chart card within its section, or across the rule into another
+    /// one. `other` nil puts it at the end of the destination section.
+    public mutating func moveGroup(
+        _ group: String, to section: ChartSection, before other: String? = nil
+    ) {
+        performance.removeAll { $0 == group }
+        sensors.removeAll { $0 == group }
+        switch section {
+        case .performance: performance = Self.insert(group, before: other, in: performance)
+        case .sensors: sensors = Self.insert(group, before: other, in: sensors)
+        }
+    }
+
+    /// Removing first and inserting second is what makes the neighbour form
+    /// safe: by the time the index is looked up, the list no longer contains
+    /// the thing being moved.
+    private static func move(_ item: String, before other: String?,
+                             in list: [String]) -> [String]
+    {
+        // Dropping something onto itself is a gesture that ended where it
+        // started, not a request to move it to the end.
+        guard item != other else { return list }
+        var moved = list
+        moved.removeAll { $0 == item }
+        return insert(item, before: other, in: moved)
+    }
+
+    private static func insert(
+        _ item: String, before other: String?, in list: [String]
+    ) -> [String] {
+        var inserted = list
+        if let other, let index = inserted.firstIndex(of: other) {
+            inserted.insert(item, at: index)
+        } else {
+            // No neighbour, or a neighbour that is not in this list: the end is
+            // the only position that is certainly valid.
+            inserted.append(item)
+        }
+        return inserted
+    }
+
+    // MARK: - Defaults and merging
+
+    /// The panel as it ships: `LayoutDefaults` order, with everything else
+    /// slotted in behind it.
+    public static func defaults(for descriptors: [MetricDescriptor]) -> PanelArrangement {
+        PanelArrangement(
+            gauges: defaultGaugeOrder(for: descriptors),
+            performance: defaultGroups(.performance, for: descriptors),
+            sensors: defaultGroups(.sensors, for: descriptors)
+        )
+    }
+
+    /// Gives anything the arrangement has not seen a position, and moves
+    /// nothing that already has one.
+    ///
+    /// `LayoutPreferences` needs a separate `known` set to do this, because in
+    /// a set of what is switched on, "off" and "never heard of" are both
+    /// absence. Order has no such ambiguity — **not being in the list is what
+    /// unknown means** — so no extra bookkeeping is needed here.
+    ///
+    /// A new metric lands where it would have been rather than at the end: plug
+    /// in a dock and its network card appears among the others, not below the
+    /// sensors.
+    ///
+    /// Entries for metrics this machine no longer reports are left alone. They
+    /// draw nothing, because the panel only draws what it has a descriptor for,
+    /// and keeping them means an external GPU that comes back finds its old
+    /// place still waiting.
+    public func adoptingDefaults(for descriptors: [MetricDescriptor]) -> PanelArrangement {
+        var merged = self
+        merged.gauges = Self.merge(
+            gauges, into: Self.defaultGaugeOrder(for: descriptors).map(\.rawValue)
+        )
+        // Groups merge against both lists at once. Checking only the
+        // destination would put a group somebody dragged below the rule back
+        // above it as well, and draw its card twice.
+        let placed = Set(performance).union(sensors)
+        for section in ChartSection.allCases {
+            let wanted = Self.defaultGroups(section, for: descriptors)
+                .filter { !placed.contains($0) }
+            let existing = section == .performance ? performance : sensors
+            let result = Self.merge(
+                existing, into: Self.defaultGroups(section, for: descriptors),
+                adding: Set(wanted)
+            )
+            switch section {
+            case .performance: merged.performance = result
+            case .sensors: merged.sensors = result
+            }
+        }
+        return merged
+    }
+
+    /// Walks the default order and inserts anything missing after the last
+    /// default item that *is* present, which is what "where it would have been"
+    /// means when most of the list has been rearranged.
+    ///
+    /// `additions` limits what may be inserted; everything already placed
+    /// elsewhere is excluded by the caller.
+    private static func merge(
+        _ current: [String], into defaults: [String], adding additions: Set<String>? = nil
+    ) -> [String] {
+        let present = Set(current)
+        var merged = current
+        // Where the last default item we have already seen sits in the result,
+        // so a run of new items lands in its own order rather than reversed.
+        var anchor = 0
+        for item in defaults {
+            if let index = merged.firstIndex(of: item) {
+                // Never backwards. Once somebody has rearranged things, the
+                // stored order and the default order disagree, and following
+                // the default's idea of position would drag the anchor back up
+                // the list — so the next new item lands before things that
+                // should precede it.
+                anchor = Swift.max(anchor, index + 1)
+                continue
+            }
+            guard !present.contains(item) else { continue }
+            guard additions?.contains(item) ?? true else { continue }
+            merged.insert(item, at: Swift.min(anchor, merged.count))
+            anchor += 1
+        }
+        return merged
+    }
+
+    /// Named dials first so the four the app opens with never move, then
+    /// everything else by metric id. Every metric gets a position, not only the
+    /// ones drawn today — see `gaugeOrder`.
+    private static func defaultGaugeOrder(for descriptors: [MetricDescriptor]) -> [MetricID] {
+        let known = Set(LayoutDefaults.gaugeOrder)
+        let ids = Set(descriptors.map(\.id))
+        let named = LayoutDefaults.gaugeOrder.filter(ids.contains)
+        let rest = descriptors.map(\.id)
+            .filter { !known.contains($0) }
+            .sorted { $0.rawValue < $1.rawValue }
+        return named + rest
+    }
+
+    /// A group's default side of the rule. Anything `LayoutDefaults` does not
+    /// name — "Disk Ops", "Network Packets", "Memory Paging" — is performance,
+    /// because that is what it is, and goes after the named cards.
+    private static func defaultGroups(
+        _ section: ChartSection, for descriptors: [MetricDescriptor]
+    ) -> [String] {
+        let available = descriptors.map(\.group).uniqued()
+        switch section {
+        case .performance:
+            let named = Set(
+                LayoutDefaults.performanceGroupOrder + LayoutDefaults.sensorGroupOrder
+            )
+            return LayoutDefaults.performanceGroupOrder.filter(available.contains)
+                + available.filter { !named.contains($0) }.sorted()
+        case .sensors:
+            return LayoutDefaults.sensorGroupOrder.filter(available.contains)
+        }
+    }
+}
+
+extension [String] {
+    /// First mention wins, order preserved. `Set` would lose the order, which
+    /// is the only thing this type stores.
+    func uniqued() -> [String] {
+        var seen = Set<String>()
+        return filter { seen.insert($0).inserted }
+    }
+}

--- a/Sources/MonitorUI/AppModel.swift
+++ b/Sources/MonitorUI/AppModel.swift
@@ -30,6 +30,26 @@ public final class AppModel {
         }
     }
 
+    /// Where every tile sits and how big the tiles are.
+    ///
+    /// Separate from `layout` because the two answer different questions: that
+    /// one is what is drawn, this one is where it goes. Saved on every change
+    /// like the layout is — but the *callers* decide when a change happens.
+    /// A drag or a slider must call `commitArrangement` when the gesture ends
+    /// rather than assign on every frame; see `PanelArrangementStore`.
+    /// Deliberately without a `didSet` that saves, unlike `layout` beside it.
+    ///
+    /// A checkbox changes once when somebody clicks it, so saving on change is
+    /// right there. A drag and a slider change continuously while the gesture
+    /// is in flight, and the panel has to follow the pointer, so saving on
+    /// change would turn one decision into a write per frame — the thing the
+    /// endurance argument in `docs/storage.md` exists to prevent.
+    ///
+    /// So: mutate this freely during a gesture, and call `commitArrangement()`
+    /// when it ends. A mutation never committed is lost at the next launch,
+    /// which is the trade for not writing fifty times to move one dial.
+    public var arrangement: PanelArrangement
+
     /// Where preferences are read and written.
     ///
     /// Injected rather than reached for, so a test can build a model without
@@ -95,6 +115,7 @@ public final class AppModel {
         sampling = stored
         sampler = Sampler(sources: sources, sinks: [], interval: stored.performance)
         layout = LayoutPreferencesStore.load(for: all, from: defaults)
+        arrangement = PanelArrangementStore.load(for: all, from: defaults)
 
         // A scale for every metric, not only the ones a dial shows today. Any
         // metric can be given a dial in preferences, and auto-ranging needs
@@ -206,53 +227,48 @@ public final class AppModel {
 
     /// The dials on the wall, left to right.
     ///
-    /// `LayoutDefaults.gaugeOrder` first, so the four the app opens with never
-    /// move, then anything else that has been ticked, by metric id. Both halves
-    /// are fixed orders rather than registry order for the same reason: a dial
-    /// that moves between launches is a dial you stop glancing at.
+    /// Order comes from the arrangement, membership from the layout: the
+    /// arrangement holds a position for every metric, including the ones no
+    /// dial is drawn for, so switching one on returns it to where it was rather
+    /// than appending it to the end of the row.
     public var gaugeMetrics: [MetricID] {
-        let ordered = LayoutDefaults.gaugeOrder.filter {
+        arrangement.gaugeOrder.filter {
             descriptors[$0] != nil && layout.showsGauge($0)
         }
-        let rest = descriptors.keys
-            .filter { layout.showsGauge($0) && !LayoutDefaults.gaugeOrder.contains($0) }
-            .sorted { $0.rawValue < $1.rawValue }
-        return ordered + rest
     }
 
     /// Every group this machine reports, in the order the panel lays its cards
     /// out — which is the order the preferences list has to use as well, or the
     /// list and the window it configures disagree about where things are.
+    ///
+    /// So this reads the arrangement, exactly as the panel does. It was the
+    /// `LayoutDefaults` constants before anything could be dragged, and leaving
+    /// it that way is the way this breaks.
     public var groupOrder: [(name: String, metrics: [MetricID])] {
         let byName = Dictionary(
             groups().map { ($0.name, $0.metrics) }, uniquingKeysWith: { first, _ in first }
         )
-        let order = LayoutDefaults.performanceGroupOrder + extraGroupNames
-            + LayoutDefaults.sensorGroupOrder
+        let order = arrangement.groupOrder(in: .performance)
+            + arrangement.groupOrder(in: .sensors)
         return order.compactMap { name in
             byName[name].map { (name: name, metrics: $0) }
         }
     }
 
-    /// Groups nothing draws by default — "Disk Ops", "Network Packets",
-    /// "Memory Paging". They have to land somewhere once they are ticked, and
-    /// performance is what they are, so they go after the named performance
-    /// cards and before the section rule.
-    private var extraGroupNames: [String] {
-        let named = Set(
-            LayoutDefaults.performanceGroupOrder + LayoutDefaults.sensorGroupOrder
-        )
-        return groups().map(\.name).filter { !named.contains($0) }
-    }
-
     /// Chart cards above the section rule.
+    ///
+    /// A group nothing draws by default — "Disk Ops", "Network Packets",
+    /// "Memory Paging" — no longer needs special-casing into the gap before the
+    /// rule: `PanelArrangement.adoptingDefaults` gave it a position when it
+    /// first appeared, and this reads that.
     public var performanceGroups: [(name: String, metrics: [MetricID])] {
-        chartGroups(in: LayoutDefaults.performanceGroupOrder + extraGroupNames)
+        chartGroups(in: arrangement.groupOrder(in: .performance))
     }
 
-    /// Chart cards below the rule: temperature, fans, power.
+    /// Chart cards below the rule: temperature, fans, power by default, and
+    /// whatever has been dragged down there since.
     public var sensorGroups: [(name: String, metrics: [MetricID])] {
-        chartGroups(in: LayoutDefaults.sensorGroupOrder)
+        chartGroups(in: arrangement.groupOrder(in: .sensors))
     }
 
     /// Groups with at least one charted metric, in registry order. A group
@@ -300,9 +316,23 @@ public final class AppModel {
         }
     }
 
-    /// Puts every metric back to the layout the app ships with.
+    /// Puts every metric back to the layout the app ships with. Membership
+    /// only: where things sit and how big they are is `restoreDefaultArrangement`,
+    /// because "show me the default set of cards" and "put them back where they
+    /// started" are two different regrets.
     public func restoreDefaultLayout() {
         layout = LayoutPreferences.defaults(for: Array(descriptors.values))
+    }
+
+    /// Puts every tile back where it started, at the size it started.
+    public func restoreDefaultArrangement() {
+        arrangement = PanelArrangement.defaults(for: Array(descriptors.values))
+        commitArrangement()
+    }
+
+    /// Writes the arrangement out. Call this once, when a gesture ends.
+    public func commitArrangement() {
+        PanelArrangementStore.save(arrangement, to: defaults)
     }
 
     // MARK: - Gauge policy

--- a/Sources/MonitorUI/AppModel.swift
+++ b/Sources/MonitorUI/AppModel.swift
@@ -255,6 +255,18 @@ public final class AppModel {
         }
     }
 
+    /// Whether this machine reports anything that belongs below the rule.
+    ///
+    /// Asked of the *descriptors*, not of what the sensor section currently
+    /// holds, so the answer does not change when somebody drags the last sensor
+    /// card up into performance. A fanless, sensorless machine draws no section;
+    /// every other machine keeps one, empty or not, as somewhere to drop a card
+    /// back into.
+    public var hasSensors: Bool {
+        let sensors = Set(LayoutDefaults.sensorGroupOrder)
+        return descriptors.values.contains { sensors.contains($0.group) }
+    }
+
     /// Chart cards above the section rule.
     ///
     /// A group nothing draws by default — "Disk Ops", "Network Packets",

--- a/Sources/MonitorUI/ChartCard.swift
+++ b/Sources/MonitorUI/ChartCard.swift
@@ -13,17 +13,23 @@ public struct ChartCard: View {
     /// Seconds of history to show.
     public let window: TimeInterval
     public var isUnavailable: Bool = false
+    /// Height of the plot area, from the size popover. Still a *minimum*: a
+    /// card whose legend wraps to three lines grows rather than squeezing the
+    /// chart out of it.
+    public var plotHeight: Double = Theme.Layout.chartMinHeight
 
     public init(
         title: String,
         series: [(descriptor: MetricDescriptor, points: [Sample])],
         window: TimeInterval,
-        isUnavailable: Bool = false
+        isUnavailable: Bool = false,
+        plotHeight: Double = Theme.Layout.chartMinHeight
     ) {
         self.title = title
         self.series = series
         self.window = window
         self.isUnavailable = isUnavailable
+        self.plotHeight = plotHeight
     }
 
     public var body: some View {
@@ -146,7 +152,7 @@ public struct ChartCard: View {
         }
         .font(.system(size: Theme.Layout.cardLegend))
         .foregroundStyle(Theme.label)
-        .frame(maxWidth: .infinity, minHeight: Theme.Layout.chartMinHeight)
+        .frame(maxWidth: .infinity, minHeight: plotHeight)
     }
 
     /// Points inside the visible window, per series.
@@ -214,7 +220,7 @@ public struct ChartCard: View {
                     .foregroundStyle(Theme.label)
             }
         }
-        .frame(minHeight: Theme.Layout.chartMinHeight)
+        .frame(minHeight: plotHeight)
     }
 
     /// The visible time span, as raw timestamps.

--- a/Sources/MonitorUI/DashboardView.swift
+++ b/Sources/MonitorUI/DashboardView.swift
@@ -13,13 +13,6 @@ public struct DashboardView: View {
     /// Seconds of history in the charts.
     @State private var window: TimeInterval = 120
 
-    /// Edge length of one dial, and so the height of the gauge wall.
-    ///
-    /// The dial is square and the wall is one row, so this single number is what
-    /// the drag handle moves: pull the rule down by 40 points and the dials get
-    /// 40 points taller, which is what makes the handle appear to follow the
-    /// pointer rather than to drive something.
-    @State private var gaugeSize = Theme.Layout.gaugeDefault
     /// Size when the current drag began, so the gesture reads as an absolute
     /// offset. Accumulating deltas instead would let a drag past the limit build
     /// up credit that has to be dragged back off before the dial moves again.
@@ -27,6 +20,24 @@ public struct DashboardView: View {
     /// Width available to the wall, which is what really limits how big a dial
     /// can get before the row wraps.
     @State private var wallWidth = 0.0
+    /// Whether the toolbar's size popover is showing.
+    @State private var showsSizes = false
+
+    /// Edge length of one dial, and so the height of the gauge wall.
+    ///
+    /// The dial is square and the wall is one row, so this single number is
+    /// what both the drag handle and the popover's first slider move: pull the
+    /// rule down by 40 points and the dials get 40 points taller, which is what
+    /// makes the handle appear to follow the pointer rather than to drive
+    /// something.
+    ///
+    /// It lives on the model rather than in `@State` so it survives a relaunch.
+    /// The write does not happen here: the setter only updates the model, and
+    /// whoever ends the gesture calls `commitArrangement`.
+    private var gaugeSize: Double {
+        get { model.arrangement.gaugeSize }
+        nonmutating set { model.arrangement.gaugeSize = newValue }
+    }
 
     public init(model: AppModel = AppModel()) {
         _model = State(initialValue: model)
@@ -134,7 +145,14 @@ public struct DashboardView: View {
             wallWidth = width
             // A window narrowed under the current dials has to shrink them, or
             // the row wraps and the wall silently doubles in height.
-            gaugeSize = clamped(gaugeSize)
+            //
+            // Deliberately not committed. Narrowing the window is not a request
+            // to keep smaller dials forever, so the chosen size stays stored and
+            // comes back when there is room for it again. The guard matters as
+            // well: assigning during a layout pass invalidates the layout, and
+            // an unguarded write would do that on every pass.
+            let fitted = clamped(gaugeSize)
+            if fitted != gaugeSize { gaugeSize = fitted }
         }
     }
 
@@ -169,7 +187,11 @@ public struct DashboardView: View {
                         dragOrigin = origin
                         gaugeSize = clamped(origin + drag.translation.height)
                     }
-                    .onEnded { _ in dragOrigin = nil }
+                    .onEnded { _ in
+                        dragOrigin = nil
+                        // Once, here, rather than on every frame of the drag.
+                        model.commitArrangement()
+                    }
             )
             .accessibilityElement()
             .accessibilityLabel("Gauge size")
@@ -180,6 +202,8 @@ public struct DashboardView: View {
                 case .decrement: gaugeSize = clamped(gaugeSize - 20)
                 @unknown default: break
                 }
+                // A discrete step is a whole gesture, unlike a frame of a drag.
+                model.commitArrangement()
             }
     }
 
@@ -213,7 +237,8 @@ public struct DashboardView: View {
     private func charts(_ groups: [(name: String, metrics: [MetricID])]) -> some View {
         LazyVGrid(
             columns: [GridItem(
-                .adaptive(minimum: Theme.Layout.chartMinimum), spacing: Theme.Layout.gridSpacing
+                .adaptive(minimum: model.arrangement.chartWidth),
+                spacing: Theme.Layout.gridSpacing
             )],
             spacing: Theme.Layout.gridSpacing
         ) {
@@ -225,7 +250,8 @@ public struct DashboardView: View {
                         return (descriptor: descriptor, points: model.points(metric))
                     },
                     window: window,
-                    isUnavailable: group.metrics.allSatisfy(model.unavailable.contains)
+                    isUnavailable: group.metrics.allSatisfy(model.unavailable.contains),
+                    plotHeight: model.arrangement.chartHeight
                 )
             }
         }
@@ -245,6 +271,17 @@ public struct DashboardView: View {
                 Text("10 min").tag(TimeInterval(600))
             }
             .pickerStyle(.segmented)
+        }
+        ToolbarItem {
+            Button {
+                showsSizes.toggle()
+            } label: {
+                Label("Size", systemImage: "square.resize")
+            }
+            .help("Resize the gauges and charts")
+            .popover(isPresented: $showsSizes, arrowEdge: .bottom) {
+                SizePopover(model: model, gaugeCeiling: gaugeCeiling)
+            }
         }
         ToolbarItem {
             // The same list preferences offers, not a second one. A rate set

--- a/Sources/MonitorUI/DashboardView.swift
+++ b/Sources/MonitorUI/DashboardView.swift
@@ -22,6 +22,9 @@ public struct DashboardView: View {
     @State private var wallWidth = 0.0
     /// Whether the toolbar's size popover is showing.
     @State private var showsSizes = false
+    /// Which gap is currently showing an insertion line, if any. One value for
+    /// the whole panel: exactly one gap can be the target at a time.
+    @State private var dropTarget: DropTarget?
 
     /// Edge length of one dial, and so the height of the gauge wall.
     ///
@@ -53,15 +56,25 @@ public struct DashboardView: View {
                     gaugeWall
                     resizeHandle
                 }
-                charts(model.performanceGroups)
+                charts(model.performanceGroups, in: .performance)
                 // Sensors are a different question from performance. What the
                 // machine is doing and how hot it is getting are read at
                 // different moments and for different reasons, and mixing them
                 // into one grid means hunting for the temperature card among
                 // the throughput ones.
-                if !model.sensorGroups.isEmpty {
+                //
+                // Drawn whenever this machine has sensors *at all*, not only
+                // when the section currently holds a card. Drag the last one up
+                // and the section has to stay, or there is no target left to
+                // drag it back to. A machine that reports no sensors still
+                // shows nothing.
+                if model.hasSensors {
                     sectionRule
-                    charts(model.sensorGroups)
+                    if model.sensorGroups.isEmpty {
+                        emptySensorSection
+                    } else {
+                        charts(model.sensorGroups, in: .sensors)
+                    }
                 }
             }
             .padding(Theme.Layout.pagePadding)
@@ -133,6 +146,9 @@ public struct DashboardView: View {
                             .foregroundStyle(Theme.label)
                             .lineLimit(1)
                     }
+                    .reorderable(
+                        .gauge(metric.rawValue), target: $dropTarget, onDrop: dropGauge
+                    )
                 }
             }
         }
@@ -234,7 +250,10 @@ public struct DashboardView: View {
             .padding(.vertical, 2)
     }
 
-    private func charts(_ groups: [(name: String, metrics: [MetricID])]) -> some View {
+    private func charts(
+        _ groups: [(name: String, metrics: [MetricID])],
+        in section: PanelArrangement.ChartSection
+    ) -> some View {
         LazyVGrid(
             columns: [GridItem(
                 .adaptive(minimum: model.arrangement.chartWidth),
@@ -253,8 +272,70 @@ public struct DashboardView: View {
                     isUnavailable: group.metrics.allSatisfy(model.unavailable.contains),
                     plotHeight: model.arrangement.chartHeight
                 )
+                .reorderable(.chart(group.name), target: $dropTarget) { dragged, on, edge in
+                    dropChart(dragged, on: on, edge: edge, in: section)
+                }
             }
         }
+    }
+
+    /// What is left of the sensor section once every card has been dragged out
+    /// of it: a place to drop one back.
+    private var emptySensorSection: some View {
+        RoundedRectangle(cornerRadius: Theme.Layout.cardCorner)
+            .strokeBorder(
+                Theme.panelEdge, style: StrokeStyle(lineWidth: 1, dash: [4, 4])
+            )
+            .frame(height: 44)
+            .overlay(
+                Text("Drag a card here")
+                    .font(.system(size: Theme.Layout.cardLegend))
+                    .foregroundStyle(Theme.label)
+            )
+            .dropDestination(for: PanelTile.self) { items, _ in
+                guard let group = items.first?.chart else { return false }
+                model.arrangement.moveGroup(group, to: .sensors)
+                model.commitArrangement()
+                return true
+            }
+    }
+
+    // MARK: - Drops
+
+    /// Turns "the half of a tile that was hit" into the neighbour the model's
+    /// move wants. Trailing means before whatever comes next, which is the end
+    /// of the list when nothing does.
+    static func neighbour<T: Equatable>(
+        after target: T, in order: [T], edge: DropTarget.Edge
+    ) -> T? {
+        guard edge == .trailing else { return target }
+        guard let index = order.firstIndex(of: target) else { return nil }
+        let next = order.index(after: index)
+        return next < order.endIndex ? order[next] : nil
+    }
+
+    private func dropGauge(_ dragged: PanelTile, on target: PanelTile, edge: DropTarget.Edge) {
+        // A chart card dropped on the gauge wall is not a move anybody can make
+        // sense of, so it is refused rather than guessed at.
+        guard let moved = dragged.gauge, let onto = target.gauge else { return }
+        let order = gaugeMetrics
+        model.arrangement.moveGauge(
+            moved, before: Self.neighbour(after: onto, in: order, edge: edge)
+        )
+        model.commitArrangement()
+    }
+
+    private func dropChart(
+        _ dragged: PanelTile, on target: PanelTile, edge: DropTarget.Edge,
+        in section: PanelArrangement.ChartSection
+    ) {
+        guard let moved = dragged.chart, let onto = target.chart else { return }
+        let order = model.arrangement.groupOrder(in: section)
+        model.arrangement.moveGroup(
+            moved, to: section,
+            before: Self.neighbour(after: onto, in: order, edge: edge)
+        )
+        model.commitArrangement()
     }
 
     // MARK: - Toolbar

--- a/Sources/MonitorUI/LayoutPreferencesStore.swift
+++ b/Sources/MonitorUI/LayoutPreferencesStore.swift
@@ -75,3 +75,44 @@ enum SamplingPreferencesStore {
         defaults.set(data, forKey: key)
     }
 }
+
+/// Where the arrangement is kept: the same domain, its own key.
+///
+/// Its own key rather than a field on the layout, because the two answer
+/// different questions — `LayoutPreferences` is what is drawn, `PanelArrangement`
+/// is where it sits and how big it is. Separate keys mean a value this version
+/// cannot read costs one of them and not both.
+///
+/// This is still the documented exception to "the app writes nothing to disk":
+/// a write when somebody moves a card or lets go of a slider, not a write every
+/// half second forever. **Save on gesture end, never during** — a slider dragged
+/// across its travel fires continuously, and persisting each change would turn
+/// one decision into a per-frame write.
+enum PanelArrangementStore {
+    static let key = "panel.arrangement"
+
+    /// A first launch, a corrupt value and a missing key all end up in the same
+    /// place: the defaults for whatever this machine reports.
+    static func load(
+        for descriptors: [MetricDescriptor],
+        from defaults: UserDefaults = LayoutPreferencesStore.suite
+    ) -> PanelArrangement {
+        guard let data = defaults.data(forKey: key),
+              let stored = try? JSONDecoder().decode(PanelArrangement.self, from: data)
+        else {
+            return PanelArrangement.defaults(for: descriptors)
+        }
+        return stored.adoptingDefaults(for: descriptors)
+    }
+
+    static func save(
+        _ arrangement: PanelArrangement,
+        to defaults: UserDefaults = LayoutPreferencesStore.suite
+    ) {
+        guard let data = try? JSONEncoder().encode(arrangement) else {
+            log.error("Could not encode panel arrangement")
+            return
+        }
+        defaults.set(data, forKey: key)
+    }
+}

--- a/Sources/MonitorUI/ReorderDrag.swift
+++ b/Sources/MonitorUI/ReorderDrag.swift
@@ -1,0 +1,162 @@
+import MonitorCore
+import SwiftUI
+import UniformTypeIdentifiers
+
+/// What is being dragged around the panel.
+///
+/// One type for both grids, because the two carry different things — a dial is
+/// one metric, a card is a whole group — and a drop target must be able to
+/// refuse the wrong one. Without the distinction, dragging a dial onto a chart
+/// would be a move nobody can make sense of.
+enum PanelTile: Codable, Equatable, Hashable, Sendable {
+    case gauge(String)
+    case chart(String)
+
+    var gauge: MetricID? {
+        if case let .gauge(id) = self {
+            MetricID(id)
+        } else { nil }
+    }
+
+    var chart: String? {
+        if case let .chart(group) = self {
+            group
+        } else { nil }
+    }
+}
+
+extension PanelTile: Transferable {
+    /// Carried as JSON on a private type rather than as plain text, so the
+    /// panel neither accepts a string dragged in from another app nor offers
+    /// its internals to one.
+    static var transferRepresentation: some TransferRepresentation {
+        CodableRepresentation(contentType: .monitorPanelTile)
+    }
+}
+
+extension UTType {
+    static let monitorPanelTile = UTType(exportedAs: "wtf.evan.monitor.panel-tile")
+}
+
+/// Where an insertion indicator is showing, and for which tile.
+///
+/// One value for the whole panel rather than a flag per tile: exactly one gap
+/// can be the drop target at a time, and separate flags drift apart when a drag
+/// leaves one target and enters another in the same frame.
+struct DropTarget: Equatable {
+    var tile: PanelTile
+    /// Which side of `tile` the dragged thing would land on. The gap is always
+    /// *before* something in the model, so trailing means "before whatever
+    /// comes next", and at the end of a list it means the end.
+    var edge: Edge
+
+    enum Edge { case leading, trailing }
+}
+
+/// The line drawn in the gap a tile would drop into.
+///
+/// Drawn as an overlay on the neighbouring tile rather than as a real item in
+/// the grid: inserting a placeholder would reflow everything after it on every
+/// frame of the drag, which is the panel visibly rearranging itself under the
+/// pointer before anything has been dropped.
+struct InsertionIndicator: View {
+    var isShowing: Bool
+    var edge: HorizontalEdge
+
+    var body: some View {
+        HStack(spacing: 0) {
+            if edge == .trailing { Spacer(minLength: 0) }
+            RoundedRectangle(cornerRadius: 1.5)
+                .fill(Theme.needle)
+                .frame(width: 3)
+                .opacity(isShowing ? 1 : 0)
+            if edge == .leading { Spacer(minLength: 0) }
+        }
+        // The gap between tiles is `gridSpacing` wide, so the line sits in it
+        // rather than on top of the tile it belongs to.
+        .padding(.horizontal, -Theme.Layout.gridSpacing / 2)
+        .animation(.easeOut(duration: 0.12), value: isShowing)
+        .allowsHitTesting(false)
+    }
+}
+
+extension View {
+    /// Makes a tile draggable, and its two halves drop targets.
+    ///
+    /// Insert-before rather than swap. For two adjacent tiles the two are the
+    /// same gesture; for anything further apart swap flings an unrelated tile
+    /// across the panel into the space you just left, which is not what
+    /// dragging something looks like anywhere else.
+    ///
+    /// The drop target is *half* a tile, not a whole one, so the gap you are
+    /// aiming at is the nearer one. Whole-tile targets make the last position in
+    /// a row unreachable, because there is nothing after it to drop before.
+    /// The callback is handed the tile that was dropped on and which half of it
+    /// was hit, rather than a resolved neighbour. Only the view has the ordered
+    /// list, so only the view can turn "after this one" into "before the next
+    /// one" — and the model's move takes a neighbour precisely so nobody has to
+    /// compute an index that shifts when the dragged tile is removed.
+    func reorderable(
+        _ tile: PanelTile,
+        target: Binding<DropTarget?>,
+        onDrop: @escaping (_ dragged: PanelTile, _ droppedOn: PanelTile,
+                           _ edge: DropTarget.Edge) -> Void
+    ) -> some View {
+        modifier(ReorderableTile(tile: tile, target: target, onDrop: onDrop))
+    }
+}
+
+private struct ReorderableTile: ViewModifier {
+    let tile: PanelTile
+    @Binding var target: DropTarget?
+    let onDrop: (PanelTile, PanelTile, DropTarget.Edge) -> Void
+
+    func body(content: Content) -> some View {
+        content
+            .draggable(tile) {
+                // The drag preview. A shrunken, dimmed copy reads as "this is
+                // the thing you are holding" without repainting a live chart
+                // under the pointer at the sampling rate.
+                RoundedRectangle(cornerRadius: Theme.Layout.cardCorner)
+                    .fill(Theme.panel)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: Theme.Layout.cardCorner)
+                            .stroke(Theme.needle, lineWidth: 1)
+                    )
+                    .frame(width: 120, height: 60)
+            }
+            .overlay {
+                HStack(spacing: 0) {
+                    dropHalf(.leading)
+                    dropHalf(.trailing)
+                }
+            }
+            .overlay {
+                InsertionIndicator(
+                    isShowing: target?.tile == tile && target?.edge == .leading,
+                    edge: .leading
+                )
+                InsertionIndicator(
+                    isShowing: target?.tile == tile && target?.edge == .trailing,
+                    edge: .trailing
+                )
+            }
+    }
+
+    private func dropHalf(_ edge: DropTarget.Edge) -> some View {
+        Color.clear
+            .contentShape(Rectangle())
+            .dropDestination(for: PanelTile.self) { items, _ in
+                guard let dragged = items.first else { return false }
+                target = nil
+                onDrop(dragged, tile, edge)
+                return true
+            } isTargeted: { isTargeted in
+                if isTargeted {
+                    target = DropTarget(tile: tile, edge: edge)
+                } else if target?.tile == tile, target?.edge == edge {
+                    target = nil
+                }
+            }
+    }
+}

--- a/Sources/MonitorUI/ReorderDrag.swift
+++ b/Sources/MonitorUI/ReorderDrag.swift
@@ -26,16 +26,49 @@ enum PanelTile: Codable, Equatable, Hashable, Sendable {
 }
 
 extension PanelTile: Transferable {
-    /// Carried as JSON on a private type rather than as plain text, so the
-    /// panel neither accepts a string dragged in from another app nor offers
-    /// its internals to one.
+    /// Carried as text in a private format, and parsed strictly.
+    ///
+    /// A custom `UTType` would say what this is far better, and it was the
+    /// first attempt — but `UTType(exportedAs:)` needs a declaration in an
+    /// `Info.plist`, and `swift run monitor` has no bundle. The type went
+    /// unregistered, no drop destination ever matched it, and dragging did
+    /// nothing at all in exactly the build the development loop uses. A type
+    /// that only works when packaged is a type that gets broken between
+    /// packages.
+    ///
+    /// So: text, with a prefix nothing else produces. Foreign text dropped on
+    /// the panel fails to parse and the move is refused, which is the property
+    /// the custom type was there for.
     static var transferRepresentation: some TransferRepresentation {
-        CodableRepresentation(contentType: .monitorPanelTile)
+        ProxyRepresentation(exporting: \.encoded, importing: PanelTile.init(encoded:))
     }
-}
 
-extension UTType {
-    static let monitorPanelTile = UTType(exportedAs: "wtf.evan.monitor.panel-tile")
+    private static let prefix = "wtf.evan.monitor.tile"
+
+    var encoded: String {
+        switch self {
+        case let .gauge(id): "\(Self.prefix)/gauge/\(id)"
+        case let .chart(group): "\(Self.prefix)/chart/\(group)"
+        }
+    }
+
+    /// Splits on the first two separators only, so a group name containing one
+    /// survives the round trip.
+    init(encoded: String) throws {
+        let parts = encoded.split(
+            separator: "/",
+            maxSplits: 2,
+            omittingEmptySubsequences: false
+        )
+        guard parts.count == 3, parts[0] == Self.prefix, !parts[2].isEmpty else {
+            throw MetricSourceError.readFailed("drag payload", code: 0)
+        }
+        switch parts[1] {
+        case "gauge": self = .gauge(String(parts[2]))
+        case "chart": self = .chart(String(parts[2]))
+        default: throw MetricSourceError.readFailed("drag payload", code: 0)
+        }
+    }
 }
 
 /// Where an insertion indicator is showing, and for which tile.
@@ -111,6 +144,10 @@ private struct ReorderableTile: ViewModifier {
     @Binding var target: DropTarget?
     let onDrop: (PanelTile, PanelTile, DropTarget.Edge) -> Void
 
+    /// The tile's own width, so a drop can be told which half it landed in.
+    /// Measured from the background, which is not hit-testable — see below.
+    @State private var width = 0.0
+
     func body(content: Content) -> some View {
         content
             .draggable(tile) {
@@ -125,12 +162,30 @@ private struct ReorderableTile: ViewModifier {
                     )
                     .frame(width: 120, height: 60)
             }
-            .overlay {
-                HStack(spacing: 0) {
-                    dropHalf(.leading)
-                    dropHalf(.trailing)
+            .background(
+                GeometryReader { proxy in
+                    Color.clear
+                        .onAppear { width = proxy.size.width }
+                        .onChange(of: proxy.size.width) { _, new in width = new }
                 }
-            }
+            )
+            // One drop destination over the whole tile, with the half worked
+            // out from where the pointer is.
+            //
+            // The two halves were two `Color.clear` overlays with
+            // `contentShape(Rectangle())` before, and that is a trap worth
+            // remembering: an overlay sits *above* the content, so it swallowed
+            // the mouse-down and `.draggable` never saw a press. Nothing could
+            // be dragged at all. A drop destination does not need to be a hit
+            // target for ordinary clicks — a drag session hit-tests separately
+            // — so measuring the width from the background and asking the drop
+            // where it is costs nothing and leaves the press alone.
+            .onDrop(
+                of: [.utf8PlainText],
+                delegate: TileDrop(
+                    tile: tile, width: { width }, target: $target, onDrop: onDrop
+                )
+            )
             .overlay {
                 InsertionIndicator(
                     isShowing: target?.tile == tile && target?.edge == .leading,
@@ -142,21 +197,50 @@ private struct ReorderableTile: ViewModifier {
                 )
             }
     }
+}
 
-    private func dropHalf(_ edge: DropTarget.Edge) -> some View {
-        Color.clear
-            .contentShape(Rectangle())
-            .dropDestination(for: PanelTile.self) { items, _ in
-                guard let dragged = items.first else { return false }
-                target = nil
-                onDrop(dragged, tile, edge)
-                return true
-            } isTargeted: { isTargeted in
-                if isTargeted {
-                    target = DropTarget(tile: tile, edge: edge)
-                } else if target?.tile == tile, target?.edge == edge {
-                    target = nil
-                }
-            }
+/// Tracks which half of a tile the pointer is over, and resolves the drop.
+private struct TileDrop: DropDelegate {
+    let tile: PanelTile
+    /// Read at drop time rather than captured, because the delegate is rebuilt
+    /// on every body pass and the width is measured after the first one.
+    let width: () -> Double
+    @Binding var target: DropTarget?
+    let onDrop: (PanelTile, PanelTile, DropTarget.Edge) -> Void
+
+    private func edge(_ info: DropInfo) -> DropTarget.Edge {
+        let half = width() / 2
+        // Before the width is known, treat everything as the leading half:
+        // "insert before this tile" is the safe reading, and it is only ever
+        // the case for the first frame of the very first drag.
+        guard half > 0 else { return .leading }
+        return info.location.x < half ? .leading : .trailing
+    }
+
+    func dropEntered(info: DropInfo) {
+        target = DropTarget(tile: tile, edge: edge(info))
+    }
+
+    func dropUpdated(info: DropInfo) -> DropProposal? {
+        target = DropTarget(tile: tile, edge: edge(info))
+        return DropProposal(operation: .move)
+    }
+
+    func dropExited(info _: DropInfo) {
+        if target?.tile == tile { target = nil }
+    }
+
+    func performDrop(info: DropInfo) -> Bool {
+        guard let provider = info.itemProviders(for: [.utf8PlainText]).first
+        else { return false }
+        let edge = edge(info)
+        target = nil
+        // Loading is asynchronous even for a drag that never left this process,
+        // so the move happens a beat after the drop rather than inside it.
+        _ = provider.loadTransferable(type: PanelTile.self) { result in
+            guard case let .success(dragged) = result else { return }
+            Task { @MainActor in onDrop(dragged, tile, edge) }
+        }
+        return true
     }
 }

--- a/Sources/MonitorUI/SizePopover.swift
+++ b/Sources/MonitorUI/SizePopover.swift
@@ -1,0 +1,77 @@
+import MonitorCore
+import SwiftUI
+
+/// The three sliders behind the toolbar's Size button.
+///
+/// In the toolbar rather than in preferences for the same reason the sampling
+/// rate is: you change it while watching. Judging a dial size in one window
+/// while dragging a slider in another is guesswork.
+///
+/// A popover rather than three toolbar controls, because the toolbar already
+/// carries the history and rate pickers and three sliders beside them would
+/// leave no room for either.
+///
+/// **Gauges are one number** — the dial is square, so its edge length is its
+/// size. **Charts are two**, width and height independently, because a wide
+/// short card and a tall narrow one answer different questions and neither is a
+/// scaled copy of the other.
+struct SizePopover: View {
+    @Bindable var model: AppModel
+    /// The largest dial that still fits one row in this window, which only the
+    /// dashboard can know. The slider stops there rather than at the model's
+    /// ceiling, or the wall wraps and doubles in height.
+    var gaugeCeiling: Double
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            slider(
+                "Gauges",
+                value: $model.arrangement.gaugeSize,
+                range: PanelSize.gauge.minimum...max(PanelSize.gauge.minimum, gaugeCeiling)
+            )
+            slider(
+                "Chart width",
+                value: $model.arrangement.chartWidth,
+                range: PanelSize.chartWidth.bounds
+            )
+            slider(
+                "Chart height",
+                value: $model.arrangement.chartHeight,
+                range: PanelSize.chartHeight.bounds
+            )
+            Divider()
+            Button("Reset to defaults") { model.restoreDefaultArrangement() }
+                .controlSize(.small)
+        }
+        .padding(14)
+        .frame(width: 230)
+    }
+
+    /// Every slider here writes on release, never during the drag.
+    ///
+    /// The binding updates the panel live — it has to, or the slider is useless
+    /// — but the write to `UserDefaults` waits for `onEditingChanged` to go
+    /// false. A slider dragged across its travel fires on every frame, and
+    /// persisting each one turns a single decision into a few hundred writes.
+    /// That is the whole argument in `docs/storage.md`, at a smaller scale.
+    private func slider(
+        _ title: String, value: Binding<Double>, range: ClosedRange<Double>
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            HStack {
+                Text(title)
+                Spacer()
+                Text("\(Int(value.wrappedValue.rounded())) pt")
+                    .foregroundStyle(.secondary)
+                    // A width that does not change as the digits do, so the
+                    // label beside it cannot twitch while you drag.
+                    .monospacedDigit()
+            }
+            .font(.system(size: 11))
+            Slider(value: value, in: range) { editing in
+                if !editing { model.commitArrangement() }
+            }
+            .controlSize(.small)
+        }
+    }
+}

--- a/Sources/MonitorUI/Theme.swift
+++ b/Sources/MonitorUI/Theme.swift
@@ -1,3 +1,4 @@
+import MonitorCore
 import SwiftUI
 
 /// The instrument-panel palette.
@@ -28,26 +29,24 @@ public enum Theme {
     /// same place — a literal half-of-both left five cramped columns, wrapped
     /// legends, colliding time labels and a third of the window empty.
     public enum Layout {
-        /// Gauge dials are square, so this is their height too.
-        ///
-        /// The wall is resizable — the rule under it is a drag handle — so these
-        /// are the ends of that travel rather than a fixed size. The floor is
-        /// where the readout stops being legible; the ceiling is a sanity limit,
-        /// and on any window narrower than four ceiling-sized dials the real
-        /// limit is the width, computed by `DashboardView`.
-        public static let gaugeMinimum = 90.0
-        public static let gaugeMaximum = 360.0
-        /// Where the wall starts, and what it had been fixed at before it could
-        /// be dragged.
-        public static let gaugeDefault = 130.0
+        // The three resizable sizes are stored in `PanelArrangement`, so their
+        // bounds live beside it in `MonitorCore` — a stored size has to be
+        // clamped by the value type that holds it, and bounds the type cannot
+        // see are bounds it cannot enforce. These forward, so views still read
+        // one place. They are ends of travel now rather than fixed sizes: the
+        // current size comes from the model.
+        public static let gaugeMinimum = PanelSize.gauge.minimum
+        public static let gaugeMaximum = PanelSize.gauge.maximum
+        /// Where the wall starts, before anybody moves the slider.
+        public static let gaugeDefault = PanelSize.gauge.initial
         /// Height of the drag handle's hit area. The rule it draws is one point;
         /// this is how close the pointer has to get, and 11 is the smallest that
         /// does not feel like a game of darts.
         public static let dividerGrab = 11.0
-        /// Minimum chart card width. The grid fits as many columns as it can,
-        /// so this is really a column count in disguise: 260 gives four columns
-        /// at 1180pt and three at 900.
-        public static let chartMinimum = 260.0
+        /// Where the card width starts. The grid fits as many columns as it
+        /// can, so this is really a column count in disguise: 260 gives four
+        /// columns at 1180pt and three at 900.
+        public static let chartMinimum = PanelSize.chartWidth.initial
         /// The plot area alone, not counting the card's header and padding.
         ///
         /// Half what it was, because the panel now has two sections rather than
@@ -55,7 +54,7 @@ public enum Theme {
         /// height the sensor cards were always below the fold, and a chart you
         /// have to scroll to reach is a chart you stop looking at. It is still a
         /// *minimum*, so a shorter window scrolls rather than squeezing.
-        public static let chartMinHeight = 125.0
+        public static let chartMinHeight = PanelSize.chartHeight.initial
 
         public static let gridSpacing = 12.0
         public static let pagePadding = 14.0

--- a/Tests/MonitorCoreTests/PanelArrangementTests.swift
+++ b/Tests/MonitorCoreTests/PanelArrangementTests.swift
@@ -166,7 +166,8 @@ struct PanelArrangementTests {
         #expect(reloaded.section(of: "Temperature") == .performance)
         #expect(reloaded.groupOrder(in: .sensors).isEmpty)
         // And exactly one card, not one on each side.
-        #expect(reloaded.groupOrder(in: .performance).filter { $0 == "Temperature" }.count == 1)
+        let cards = reloaded.groupOrder(in: .performance).count { $0 == "Temperature" }
+        #expect(cards == 1)
     }
 
     @Test("Several new metrics keep their default order rather than arriving reversed")

--- a/Tests/MonitorCoreTests/PanelArrangementTests.swift
+++ b/Tests/MonitorCoreTests/PanelArrangementTests.swift
@@ -1,0 +1,271 @@
+import Foundation
+@testable import MonitorCore
+import Testing
+
+@Suite("PanelArrangement")
+struct PanelArrangementTests {
+    /// A stand-in machine: two disk rates, one network rate, one sensor.
+    static func descriptors() -> [MetricDescriptor] {
+        [
+            MetricDescriptor(
+                id: MetricID("disk.bytes.read"), name: "Read", group: "Disk",
+                unit: .bytesPerSecond
+            ),
+            MetricDescriptor(
+                id: MetricID("disk.bytes.written"), name: "Write", group: "Disk",
+                unit: .bytesPerSecond
+            ),
+            MetricDescriptor(
+                id: MetricID("net.bits.in"), name: "In", group: "Network",
+                unit: .bitsPerSecond
+            ),
+            MetricDescriptor(
+                id: MetricID("cpu.total"), name: "Total", group: "CPU", unit: .fraction
+            ),
+            MetricDescriptor(
+                id: MetricID("sensors.CPU"), name: "CPU", group: "Temperature",
+                unit: .celsius
+            ),
+        ]
+    }
+
+    // MARK: - Defaults
+
+    @Test("Dials the app opens with keep their order, and everything else follows")
+    func defaultGaugeOrder() {
+        let arrangement = PanelArrangement.defaults(for: Self.descriptors())
+        let order = arrangement.gaugeOrder
+        // The named four first, in LayoutDefaults order, minus the one this
+        // machine does not report.
+        #expect(order.prefix(3) == [
+            MetricID("disk.bytes.read"),
+            MetricID("disk.bytes.written"),
+            MetricID("net.bits.in"),
+        ])
+        // Every metric gets a position, not only the ones drawn by default.
+        #expect(Set(order) == Set(Self.descriptors().map(\.id)))
+    }
+
+    @Test("Groups start on the side of the rule LayoutDefaults puts them")
+    func defaultSections() {
+        let arrangement = PanelArrangement.defaults(for: Self.descriptors())
+        #expect(arrangement.groupOrder(in: .performance) == ["CPU", "Disk", "Network"])
+        #expect(arrangement.groupOrder(in: .sensors) == ["Temperature"])
+    }
+
+    @Test("A group LayoutDefaults does not name lands after the named performance cards")
+    func unnamedGroupIsPerformance() {
+        var descriptors = Self.descriptors()
+        descriptors.append(
+            MetricDescriptor(
+                id: MetricID("disk.ops.read"), name: "Reads", group: "Disk Ops",
+                unit: .operationsPerSecond
+            )
+        )
+        let arrangement = PanelArrangement.defaults(for: descriptors)
+        let performance = arrangement.groupOrder(in: .performance)
+        #expect(performance.last == "Disk Ops")
+        #expect(arrangement.section(of: "Disk Ops") == .performance)
+    }
+
+    // MARK: - Moving
+
+    @Test("A dial moves to sit before its drop target")
+    func moveGaugeBefore() {
+        var arrangement = PanelArrangement.defaults(for: Self.descriptors())
+        arrangement.moveGauge(MetricID("net.bits.in"), before: MetricID("disk.bytes.read"))
+        #expect(arrangement.gaugeOrder.prefix(2) == [
+            MetricID("net.bits.in"), MetricID("disk.bytes.read"),
+        ])
+    }
+
+    /// The bug the neighbour-based API exists to prevent: with indices, removing
+    /// the dragged item shifts every position after it, so moving something
+    /// rightwards lands one place short.
+    @Test("Moving a dial rightwards lands where the target was, not one short")
+    func moveGaugeRightwards() {
+        var arrangement = PanelArrangement(
+            gauges: [MetricID("a"), MetricID("b"), MetricID("c"), MetricID("d")]
+        )
+        arrangement.moveGauge(MetricID("a"), before: MetricID("d"))
+        #expect(arrangement.gaugeOrder.map(\.rawValue) == ["b", "c", "a", "d"])
+    }
+
+    @Test("A dial dropped past the end goes to the end")
+    func moveGaugeToEnd() {
+        var arrangement = PanelArrangement(
+            gauges: [MetricID("a"), MetricID("b"), MetricID("c")]
+        )
+        arrangement.moveGauge(MetricID("a"), before: nil)
+        #expect(arrangement.gaugeOrder.map(\.rawValue) == ["b", "c", "a"])
+    }
+
+    @Test("A dial dropped on itself does not move")
+    func dropOnSelfIsNoMove() {
+        let original = PanelArrangement(
+            gauges: [MetricID("a"), MetricID("b"), MetricID("c")]
+        )
+        var arrangement = original
+        arrangement.moveGauge(MetricID("b"), before: MetricID("b"))
+        #expect(arrangement == original)
+    }
+
+    @Test("A dial dropped next to something not on the wall goes to the end, not nowhere")
+    func unknownNeighbourAppends() {
+        var arrangement = PanelArrangement(gauges: [MetricID("a"), MetricID("b")])
+        arrangement.moveGauge(MetricID("a"), before: MetricID("nope"))
+        #expect(arrangement.gaugeOrder.map(\.rawValue) == ["b", "a"])
+    }
+
+    @Test("A card dragged across the rule changes section and leaves the old one")
+    func moveGroupAcrossTheRule() {
+        var arrangement = PanelArrangement.defaults(for: Self.descriptors())
+        arrangement.moveGroup("Temperature", to: .performance, before: "Disk")
+        #expect(arrangement.groupOrder(in: .performance) == [
+            "CPU", "Temperature", "Disk", "Network",
+        ])
+        #expect(arrangement.groupOrder(in: .sensors).isEmpty)
+        #expect(arrangement.section(of: "Temperature") == .performance)
+    }
+
+    @Test("A card reordered within its section stays in it")
+    func moveGroupWithinSection() {
+        var arrangement = PanelArrangement.defaults(for: Self.descriptors())
+        arrangement.moveGroup("Network", to: .performance, before: "CPU")
+        #expect(arrangement.groupOrder(in: .performance) == ["Network", "CPU", "Disk"])
+        #expect(arrangement.groupOrder(in: .sensors) == ["Temperature"])
+    }
+
+    // MARK: - Adopting defaults
+
+    @Test("A metric the arrangement has never seen lands at its default position")
+    func adoptsNewMetricAtDefaultPosition() {
+        // Somebody's stored arrangement, from before this machine reported the
+        // network. The two disk dials have been swapped, and that must survive.
+        var stored = PanelArrangement(
+            gauges: [MetricID("disk.bytes.written"), MetricID("disk.bytes.read")],
+            performance: ["Disk", "CPU"],
+            sensors: []
+        )
+        stored = stored.adoptingDefaults(for: Self.descriptors())
+        let order = stored.gaugeOrder.map(\.rawValue)
+        // The swap is untouched...
+        #expect(order.prefix(2) == ["disk.bytes.written", "disk.bytes.read"])
+        // ...and the newcomer is placed by the defaults, which put it after the
+        // two disk dials rather than at the end of everything.
+        #expect(order.firstIndex(of: "net.bits.in") == 2)
+        #expect(stored.groupOrder(in: .performance) == ["Disk", "CPU", "Network"])
+        #expect(stored.groupOrder(in: .sensors) == ["Temperature"])
+    }
+
+    @Test("A group moved across the rule is not put back by a later launch")
+    func adoptingDoesNotUndoACrossSectionMove() {
+        var stored = PanelArrangement.defaults(for: Self.descriptors())
+        stored.moveGroup("Temperature", to: .performance, before: nil)
+        let reloaded = stored.adoptingDefaults(for: Self.descriptors())
+        #expect(reloaded.section(of: "Temperature") == .performance)
+        #expect(reloaded.groupOrder(in: .sensors).isEmpty)
+        // And exactly one card, not one on each side.
+        #expect(reloaded.groupOrder(in: .performance).filter { $0 == "Temperature" }.count == 1)
+    }
+
+    @Test("Several new metrics keep their default order rather than arriving reversed")
+    func adoptsRunOfNewMetricsInOrder() throws {
+        var stored = PanelArrangement(gauges: [MetricID("cpu.total")])
+        stored = stored.adoptingDefaults(for: Self.descriptors())
+        let order = stored.gaugeOrder.map(\.rawValue)
+        let read = try #require(order.firstIndex(of: "disk.bytes.read"))
+        let written = try #require(order.firstIndex(of: "disk.bytes.written"))
+        let net = try #require(order.firstIndex(of: "net.bits.in"))
+        #expect(read < written)
+        #expect(written < net)
+    }
+
+    @Test("A metric this machine no longer reports is kept, not dropped")
+    func staleEntriesSurvive() throws {
+        var stored = PanelArrangement(gauges: [
+            MetricID("gpu.utilization"),
+            MetricID("cpu.total"),
+        ])
+        stored = stored.adoptingDefaults(for: Self.descriptors())
+        let order = stored.gaugeOrder.map(\.rawValue)
+        // Nothing draws it — the panel only draws what it has a descriptor for
+        // — but plug the display back in and its position is still here.
+        #expect(order.contains("gpu.utilization"))
+        // Its position is kept relative to the other entries that were stored
+        // with it. Where the *new* metrics land around it is not defined:
+        // nothing in the defaults mentions a metric the defaults do not know,
+        // so there is no answer to pin down.
+        let gpu = try #require(order.firstIndex(of: "gpu.utilization"))
+        let cpu = try #require(order.firstIndex(of: "cpu.total"))
+        #expect(gpu < cpu)
+    }
+
+    @Test("Adopting twice changes nothing the second time")
+    func adoptingIsIdempotent() {
+        let once = PanelArrangement(gauges: [MetricID("cpu.total")])
+            .adoptingDefaults(for: Self.descriptors())
+        #expect(once.adoptingDefaults(for: Self.descriptors()) == once)
+    }
+
+    // MARK: - Sizes
+
+    @Test("Sizes clamp to what the panel can draw")
+    func sizesClamp() {
+        var arrangement = PanelArrangement()
+        arrangement.gaugeSize = 10000
+        arrangement.chartWidth = 0
+        arrangement.chartHeight = -5
+        #expect(arrangement.gaugeSize == PanelSize.gauge.maximum)
+        #expect(arrangement.chartWidth == PanelSize.chartWidth.minimum)
+        #expect(arrangement.chartHeight == PanelSize.chartHeight.minimum)
+    }
+
+    @Test("A size that is not a number falls back to the starting size")
+    func nonFiniteSizeFallsBack() {
+        var arrangement = PanelArrangement()
+        arrangement.gaugeSize = .nan
+        #expect(arrangement.gaugeSize == PanelSize.gauge.initial)
+    }
+
+    @Test("An arrangement stored before a field existed still decodes")
+    func decodingToleratesMissingFields() throws {
+        let decoded = try JSONDecoder().decode(
+            PanelArrangement.self, from: Data(#"{"gauges":["cpu.total"]}"#.utf8)
+        )
+        #expect(decoded.gaugeOrder == [MetricID("cpu.total")])
+        #expect(decoded.gaugeSize == PanelSize.gauge.initial)
+        #expect(decoded.groupOrder(in: .sensors).isEmpty)
+    }
+
+    @Test("A size stored out of range is clamped when it is decoded")
+    func decodingClampsSizes() throws {
+        let json = """
+        {"gauges":[],"performance":[],"sensors":[],
+         "gaugeSize":9000,"chartWidth":1,"chartHeight":1}
+        """
+        let decoded = try JSONDecoder().decode(
+            PanelArrangement.self, from: Data(json.utf8)
+        )
+        #expect(decoded.gaugeSize == PanelSize.gauge.maximum)
+        #expect(decoded.chartWidth == PanelSize.chartWidth.minimum)
+    }
+
+    @Test("Round-trips through JSON unchanged")
+    func codableRoundTrip() throws {
+        var arrangement = PanelArrangement.defaults(for: Self.descriptors())
+        arrangement.moveGroup("Temperature", to: .performance, before: "Disk")
+        arrangement.gaugeSize = 200
+        let data = try JSONEncoder().encode(arrangement)
+        #expect(try JSONDecoder().decode(PanelArrangement.self, from: data) == arrangement)
+    }
+
+    @Test("A group named on both sides of the rule draws one card, not two")
+    func duplicateGroupIsDropped() {
+        let arrangement = PanelArrangement(
+            performance: ["Disk", "Disk", "CPU"], sensors: ["Disk", "Temperature"]
+        )
+        #expect(arrangement.groupOrder(in: .performance) == ["Disk", "CPU"])
+        #expect(arrangement.groupOrder(in: .sensors) == ["Temperature"])
+    }
+}

--- a/Tests/MonitorUITests/AppModelTests.swift
+++ b/Tests/MonitorUITests/AppModelTests.swift
@@ -119,4 +119,121 @@ struct AppModelTests {
         model.layout.setGauge(true, for: MetricID("sensors.CPU"))
         #expect(model.gaugeMetrics == [MetricID("sensors.CPU")])
     }
+
+    // MARK: - The arrangement
+
+    @Test("the panel draws dials in the arrangement's order, not the registry's")
+    func gaugesFollowTheArrangement() {
+        let (model, _, _) = Self.makeModel()
+        model.layout.setGauge(true, for: MetricID("sensors.CPU"))
+        model.layout.setGauge(true, for: MetricID("disk.Read"))
+        let first = model.gaugeMetrics
+        #expect(first.count == 2)
+
+        model.arrangement.moveGauge(first[1], before: first[0])
+        #expect(model.gaugeMetrics == [first[1], first[0]])
+    }
+
+    @Test("a card dragged across the rule draws in the other section")
+    func cardsFollowTheArrangement() {
+        let (model, _, _) = Self.makeModel()
+        #expect(model.sensorGroups.contains { $0.name == "Temperature" })
+
+        model.arrangement.moveGroup("Temperature", to: .performance)
+        #expect(model.performanceGroups.contains { $0.name == "Temperature" })
+        #expect(model.sensorGroups.isEmpty)
+    }
+
+    /// The comment on `groupOrder` has said this since before anything could be
+    /// dragged: the preferences list and the window it configures have to agree
+    /// about where things are. Reordering the panel while the Layout tab kept
+    /// `LayoutDefaults` order is the way that breaks.
+    @Test("the preferences list follows the panel's order")
+    func preferencesListFollowsThePanel() {
+        let (model, _, _) = Self.makeModel()
+        model.arrangement.moveGroup("Temperature", to: .performance, before: "Disk")
+        let listed = model.groupOrder.map(\.name)
+        let panel = (model.performanceGroups + model.sensorGroups).map(\.name)
+        #expect(listed == panel)
+        #expect(listed.first == "Temperature")
+    }
+
+    @Test("membership is still the layout, position is the arrangement")
+    func arrangementDoesNotDraw() {
+        let (model, _, _) = Self.makeModel()
+        // Every metric has a position, including the ones no dial is drawn for.
+        #expect(model.arrangement.gaugeOrder.contains(MetricID("sensors.CPU")))
+        #expect(model.gaugeMetrics.isEmpty)
+    }
+
+    /// A dial switched off keeps its place, so switching it back on returns it
+    /// to where it was rather than appending it to the end of the row.
+    @Test("a dial switched off and on again comes back to the same place")
+    func positionSurvivesBeingSwitchedOff() {
+        let (model, _, _) = Self.makeModel()
+        model.layout.setGauge(true, for: MetricID("sensors.CPU"))
+        model.layout.setGauge(true, for: MetricID("disk.Read"))
+        model.arrangement.moveGauge(MetricID("sensors.CPU"), before: MetricID("disk.Read"))
+
+        model.layout.setGauge(false, for: MetricID("sensors.CPU"))
+        #expect(model.gaugeMetrics == [MetricID("disk.Read")])
+        model.layout.setGauge(true, for: MetricID("sensors.CPU"))
+        #expect(model.gaugeMetrics == [MetricID("sensors.CPU"), MetricID("disk.Read")])
+    }
+
+    // MARK: - Persistence
+
+    @Test("a committed arrangement survives a relaunch")
+    func arrangementPersists() throws {
+        let defaults = try #require(UserDefaults(suiteName: Self.domain))
+        defaults.removePersistentDomain(forName: Self.domain)
+        let sources = [
+            StubSource(id: "disk", group: "Disk", names: ["Read"]),
+            StubSource(id: "sensors", group: "Temperature", names: ["CPU"]),
+        ]
+
+        let first = AppModel(sources: sources, defaults: defaults)
+        first.arrangement.moveGroup("Temperature", to: .performance, before: "Disk")
+        first.commitArrangement()
+
+        let second = AppModel(sources: sources, defaults: defaults)
+        #expect(second.arrangement.section(of: "Temperature") == .performance)
+        #expect(second.performanceGroups.map(\.name) == ["Temperature", "Disk"])
+    }
+
+    /// The whole reason `arrangement` has no saving `didSet`: a drag mutates it
+    /// on every frame, and every one of those must not reach `UserDefaults`.
+    @Test("an uncommitted change is not written")
+    func uncommittedChangeIsNotWritten() throws {
+        let defaults = try #require(UserDefaults(suiteName: Self.domain))
+        defaults.removePersistentDomain(forName: Self.domain)
+        let sources = [StubSource(id: "disk", group: "Disk", names: ["Read"])]
+
+        let first = AppModel(sources: sources, defaults: defaults)
+        first.arrangement.gaugeSize = 300
+        #expect(first.arrangement.gaugeSize == 300)
+
+        let second = AppModel(sources: sources, defaults: defaults)
+        #expect(second.arrangement.gaugeSize == PanelSize.gauge.initial)
+    }
+
+    @Test("restoring the arrangement puts everything back and writes it")
+    func restoreArrangement() throws {
+        let defaults = try #require(UserDefaults(suiteName: Self.domain))
+        defaults.removePersistentDomain(forName: Self.domain)
+        let sources = [
+            StubSource(id: "disk", group: "Disk", names: ["Read"]),
+            StubSource(id: "sensors", group: "Temperature", names: ["CPU"]),
+        ]
+
+        let first = AppModel(sources: sources, defaults: defaults)
+        first.arrangement.moveGroup("Temperature", to: .performance)
+        first.arrangement.gaugeSize = 300
+        first.commitArrangement()
+        first.restoreDefaultArrangement()
+
+        let second = AppModel(sources: sources, defaults: defaults)
+        #expect(second.arrangement.section(of: "Temperature") == .sensors)
+        #expect(second.arrangement.gaugeSize == PanelSize.gauge.initial)
+    }
 }

--- a/Tests/MonitorUITests/AppModelTests.swift
+++ b/Tests/MonitorUITests/AppModelTests.swift
@@ -237,3 +237,40 @@ struct AppModelTests {
         #expect(second.arrangement.gaugeSize == PanelSize.gauge.initial)
     }
 }
+
+/// The neighbour arithmetic behind a drop.
+///
+/// A drop lands on *half* a tile: the leading half means "before this one", the
+/// trailing half means "before whatever comes next". Getting the second one
+/// wrong is the classic reorder bug — every rightward drag lands one place short
+/// — and it is invisible in a screenshot, so it is pinned here.
+@Suite("Drop neighbours")
+struct DropNeighbourTests {
+    private func neighbour(
+        after target: String, in order: [String], edge: DropTarget.Edge
+    ) -> String? {
+        DashboardView.neighbour(after: target, in: order, edge: edge)
+    }
+
+    @Test("the leading half means before the tile itself")
+    func leadingEdge() {
+        #expect(neighbour(after: "b", in: ["a", "b", "c"], edge: .leading) == "b")
+    }
+
+    @Test("the trailing half means before whatever follows")
+    func trailingEdge() {
+        #expect(neighbour(after: "b", in: ["a", "b", "c"], edge: .trailing) == "c")
+    }
+
+    /// Nothing follows the last tile, and nil is what the model reads as "the
+    /// end". Without this the last position on a row is unreachable.
+    @Test("the trailing half of the last tile means the end")
+    func trailingEdgeOfLast() {
+        #expect(neighbour(after: "c", in: ["a", "b", "c"], edge: .trailing) == nil)
+    }
+
+    @Test("a tile that is not in the list drops at the end rather than nowhere")
+    func unknownTarget() {
+        #expect(neighbour(after: "z", in: ["a", "b"], edge: .trailing) == nil)
+    }
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ The index. Each file below is the reference for one part of the app.
 | [metrics.md](metrics.md) | Every metric, its unit and kind, and where the number comes from |
 | [sources.md](sources.md) | Writing a new `MetricSource`, and the system APIs each existing one uses |
 | [sensors.md](sensors.md) | What a Mac exposes about heat, fans and power, what it costs to read, and what needs root |
-| [ui.md](ui.md) | Gauges vs charts, the auto-ranging dial, and the rules that keep a chart honest |
+| [ui.md](ui.md) | Gauges vs charts, the auto-ranging dial, arranging the panel by dragging, and the rules that keep a chart honest |
 | [storage.md](storage.md) | Why v1 writes nothing to disk, and the SSD-endurance arithmetic for when it does |
 | [signing.md](signing.md) | What this repository does with a Developer ID: the scripts, the two variables, and the setup on the Mac runner |
 | [developer-id-runbook.md](developer-id-runbook.md) | Signing and notarizing a Mac app from nothing, app-agnostic, with the stumbling blocks that cost time |

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -47,12 +47,101 @@ looks exactly like one somebody switched off, and would be silently missing.
 `adoptingDefaults(for:)` gives an unseen metric its default and leaves every
 choice already made alone.
 
-Order is fixed, not derived. `LayoutDefaults.gaugeOrder` places the four dials
-the app opens with, and anything else ticked goes after them by metric id;
-`performanceGroupOrder` and `sensorGroupOrder` place the cards, with groups on
-neither list — `Disk Ops`, `Network Packets`, `Memory Paging` — landing after
-the named performance cards. A dial or a card that moves between launches is one
-you have to hunt for.
+## Arranging the panel
+
+Order used to be derived: the dashboard recomputed it from the `LayoutDefaults`
+constants on every access. Once a tile can be dragged, order is data, and
+`PanelArrangement` is where it lives — also in `MonitorCore`, also testable
+without a window.
+
+Keep the two apart. **`LayoutPreferences` is what is drawn. `PanelArrangement`
+is where it goes and how big it is.** Two structs and two preference keys, so a
+value this version cannot read costs one of them and not both.
+
+### Dragging
+
+Drag a dial along the wall, or a chart card around the grid, to reorder it.
+
+- **Insert-before, not swap.** For two adjacent tiles the two are the same
+  gesture. For anything further apart, swap flings an unrelated tile across the
+  panel into the space you just left, which is not what dragging something looks
+  like anywhere else.
+- **The drop target is half a tile.** The gap you are aiming at is the nearer
+  one. Whole-tile targets leave the last position in a row unreachable, because
+  there is nothing after it to drop before.
+- **A dial and a card are different things**, and a drop target refuses the
+  wrong one. `PanelTile` carries which, as a private drag type — the panel
+  neither accepts text dragged in from another app nor offers its internals to
+  one.
+
+The insertion line is an overlay on the neighbouring tile rather than a real
+item in the grid. A placeholder item would reflow everything after it on every
+frame of the drag, which is the panel rearranging itself under the pointer
+before anything has been dropped.
+
+### The rule between the sections
+
+Cards can be dragged across it. The performance/sensor split keeps its defaults
+but stops being a rule about what belongs where: if the pairing you care about
+is CPU load beside CPU temperature, you can have it.
+
+The section is drawn whenever the machine has sensors **at all**, not when the
+section currently holds a card, and shows a drop zone when empty. Drag the last
+sensor card up and the section has to stay, or there is nothing left to drag it
+back to. A machine that reports no sensors still shows nothing.
+
+### Sizes
+
+The toolbar's Size button opens three sliders: gauges, chart width, chart
+height. In the toolbar rather than in preferences for the same reason the
+sampling rate is — you change it while watching, and judging a dial size in one
+window while dragging a slider in another is guesswork.
+
+**Gauges are one number**, because the dial is square. **Charts are two**: a
+wide short card and a tall narrow one answer different questions, and neither is
+a scaled copy of the other. The rule under the gauge wall is still a drag handle
+and drives the same number as the first slider.
+
+The bounds live in `PanelSize` in `MonitorCore` rather than in `Theme.Layout`,
+because a stored size has to be clamped by the value type that holds it, and
+bounds the type cannot see are bounds it cannot enforce. `Theme.Layout` forwards
+to them, so views still read one place.
+
+### What is written, and when
+
+**Every gesture writes once, when it ends.** A slider dragged across its travel
+fires on every frame, and a drag crosses several drop targets on the way to the
+one it wants; persisting each change turns one decision into hundreds of writes.
+So `AppModel.arrangement` deliberately has no saving `didSet`, unlike `layout`
+beside it — a checkbox changes once when it is clicked, a drag does not. Mutate
+it freely during a gesture and call `commitArrangement()` at the end.
+
+Narrowing the window still shrinks the dials, so the row cannot wrap and
+silently double the height of the wall. That is not committed: it is not a
+request to keep smaller dials forever, so the chosen size comes back when there
+is room for it.
+
+### Where new things land
+
+`LayoutDefaults` is the seed for the order rather than the order itself.
+`adoptingDefaults(for:)` gives anything the arrangement has not seen a position
+and moves nothing that already has one, so a sensor that appears when you plug
+in a dock lands among its own kind rather than at the end.
+
+It needs no `known` set, unlike `LayoutPreferences`. In a set of what is
+switched on, "off" and "never heard of" are both absence; in a list of
+positions, **not being in the list is what unknown means**.
+
+Entries for metrics the machine no longer reports are kept. They draw nothing,
+because the panel only draws what it has a descriptor for, and an external GPU
+that comes back finds its old place waiting.
+
+A dial switched off keeps its position too, so switching it back on returns it
+to where it was rather than appending it to the end of the row.
+
+`AppModel.groupOrder` feeds the preferences list, so it reads the arrangement as
+well. The list and the window it configures have to agree about where things
+are; leaving that one on the `LayoutDefaults` constants is how this breaks.
 
 The choices are written to `UserDefaults` under `wtf.evan.monitor`, named
 explicitly rather than taken from `.standard`: `swift run monitor` has no

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -70,14 +70,36 @@ Drag a dial along the wall, or a chart card around the grid, to reorder it.
   one. Whole-tile targets leave the last position in a row unreachable, because
   there is nothing after it to drop before.
 - **A dial and a card are different things**, and a drop target refuses the
-  wrong one. `PanelTile` carries which, as a private drag type — the panel
-  neither accepts text dragged in from another app nor offers its internals to
-  one.
+  wrong one. `PanelTile` carries which, encoded as text behind a private prefix
+  and parsed strictly, so foreign text dropped on the panel fails to parse and
+  the move is refused.
 
 The insertion line is an overlay on the neighbouring tile rather than a real
 item in the grid. A placeholder item would reflow everything after it on every
 frame of the drag, which is the panel rearranging itself under the pointer
-before anything has been dropped.
+before anything has been dropped. It is `allowsHitTesting(false)`, and that
+matters — see below.
+
+### Two traps this walked into
+
+Both broke dragging completely while every test stayed green, so they are
+written down rather than left to be rediscovered.
+
+**A drop target must not be an overlay with a content shape.** The first version
+put two `Color.clear` halves in an `.overlay` with `contentShape(Rectangle())`,
+one per side, to tell leading from trailing. An overlay sits *above* the
+content, so it swallowed the mouse-down and `.draggable` never saw a press —
+nothing could be dragged at all. There is now one `DropDelegate` over the whole
+tile that asks `DropInfo.location` which half it is in, and the width comes from
+a background `GeometryReader`, which is not hit-testable.
+
+**A custom `UTType` needs an `Info.plist` declaration, and `swift run monitor`
+has no bundle.** The first version carried the payload as a private type via
+`UTType(exportedAs:)`. Unbundled, the type went unregistered, no drop
+destination ever matched it, and dragging did nothing in exactly the build the
+development loop uses. A type that only works when packaged is a type that gets
+broken between packages. The payload is plain text now, behind a prefix nothing
+else produces.
 
 ### The rule between the sections
 


### PR DESCRIPTION
Closes #18, closes #19, closes #20, closes #21, closes #22.

Order was *derived* — the dashboard recomputed it from the `LayoutDefaults`
constants on every access. Once a tile can be dragged, order is data.
`PanelArrangement` in `MonitorCore` is where it lives, beside `LayoutPreferences`
and under its own preference key.

Keep the two apart: **`LayoutPreferences` is what is drawn, `PanelArrangement`
is where it goes and how big it is.** Two structs and two keys, so a value this
version cannot read costs one of them and not both.

## What changed

- **Drag to reorder** dials on the wall and cards in the grid, with an
  insertion line in the gap the tile would land in.
- **Drag across the section rule.** The performance/sensor split keeps its
  defaults but stops being a rule about what belongs where.
- **Three size sliders** behind a toolbar Size button: gauges, chart width,
  chart height. Gauges are one number because the dial is square; charts are
  two, because a wide short card and a tall narrow one answer different
  questions.
- **All of it survives a relaunch.**

## Decisions worth reviewing

**Insert-before, not swap.** For adjacent tiles the two are the same gesture.
For anything further apart, swap flings an unrelated tile across the panel into
the space you just left.

**The drop target is half a tile.** The gap you aim at is the nearer one.
Whole-tile targets leave the last position in a row unreachable, because there
is nothing after it to drop before. The "trailing half of the last tile means
the end of the list" arithmetic is where reorder bugs live — every rightward
drag landing one place short — so it is a static function with tests rather
than something inlined in a view.

**Moves take a neighbour, not an index.** The caller has a drop target, and
turning it into an index means remembering that removing the dragged item
shifts everything after it.

**Two arrays for the chart sections, not one array plus a section field.**
Moving across the rule is then "remove from one, insert into the other", and
order and section cannot disagree.

**`adoptingDefaults` needs no `known` set**, unlike `LayoutPreferences`. In a
set of what is switched on, "off" and "never heard of" are both absence; in a
list of positions, not being in the list is what unknown means.

**Every gesture writes once, when it ends.** `AppModel.arrangement` deliberately
has no saving `didSet`: a checkbox changes once when clicked, but a slider fires
on every frame and a drag crosses several drop targets on the way to the one it
wants. This is the SSD-endurance rule in `docs/storage.md` at a smaller scale,
and there is a test asserting an uncommitted change is not written.

## Traps handled

- **The preferences list follows the panel.** `AppModel.groupOrder` feeds the
  Layout tab, and its comment has warned since before anything could be dragged
  that the list and the window it configures must agree about where things are.
- **The sensor section survives being emptied.** It is drawn whenever the
  machine has sensors *at all*, not when it holds a card, and shows a drop zone
  when empty. Otherwise dragging the last sensor card up removes the only
  target you could drag it back to.
- **Narrowing the window** still shrinks the dials so the row cannot wrap, but
  no longer persists that — it is not a request to keep smaller dials forever.
- **A dial switched off keeps its position**, so switching it back on returns it
  to where it was rather than to the end of the row.

## Verification

`swift build`, `swift build -c release`, 128 tests in 15 suites, and
`swiftformat --lint` all pass. `monitorctl read` still reads the machine, and
the app launches with no undeclared drag-type warning.

**Not yet verified by looking at it.** `AGENTS.md` is explicit that a UI change
is checked by running the app, and this machine has been locked with the display
off for the whole session, so every screenshot came back black. The drag
gestures, the insertion line and the popover need a human to actually drive them
before this merges.

https://claude.ai/code/session_01UPbN2SqYq8t2vcx2YWQTcs