### PR TITLE
Right-click a card to copy the picture or the numbers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,17 +64,17 @@ look at it in the app.
 Sources/
   MonitorCore/     metric model, ring buffer, downsampling, gauge auto-ranging,
                    seven-segment digit mapping, formatting, the sampling clock,
-                   the layout, arrangement and sampling preference models. No
-                   macOS APIs — so all of it is testable without a machine to
-                   read.
+                   the layout, arrangement and sampling preference models,
+                   CSV export. No macOS APIs — so all of it is testable
+                   without a machine to read.
   MonitorSources/  the readers: CPU, memory, disk, network, GPU, SMC sensors
                    (temperature, fans, power), and the registry that lists them.
                    One file per source, plus SMC.swift for the SMC transport.
   MonitorUI/       Theme (palette + Layout density), GaugeView, SevenSegmentText,
                    ChartCard, FlowLayout, DashboardView, PreferencesView,
                    SizePopover, ReorderDrag (drag-to-reorder for both grids),
-                   AppModel, LayoutPreferencesStore (layout, sampling,
-                   arrangement)
+                   CardExport (right-click to copy a card), AppModel,
+                   LayoutPreferencesStore (layout, sampling, arrangement)
   MonitorStore/    SQLite history and retention. Designed and tested but NOT
                    linked into the app — see "Guardrails" below.
   monitor/         the app target (@main SwiftUI App) and its AppDelegate
@@ -148,6 +148,18 @@ are no component-level AGENTS.md files.
   freely during a gesture, then call `commitArrangement()`. Adding a `didSet`
   that saves would turn one decision into hundreds of writes — the thing
   `docs/storage.md` exists to prevent.
+- **A card can be copied, and the copy is not what the panel shows.**
+  Right-click any tile for **Copy Image** (the tile rendered on its own with
+  `ImageRenderer`, not captured from the window) and **Copy Data** (the visible
+  window as CSV). `CSVExport` lives in `MonitorCore` so the row alignment and
+  the units are testable. Two rules: the export is cut to the window the card is
+  *drawing*, not the whole ten-minute buffer; and it carries **base units** —
+  `Format.baseUnit`, not `Format.unitLabel`. The panel pins disk to MB/s and
+  network to Mbit/s so the unit under a needle cannot move while you read it,
+  but the buffer holds bytes and bits, and a column headed `MB/s` carrying bytes
+  is the quiet kind of wrong. A series that missed a tick leaves an **empty
+  field, never a zero** — same reason a failed source greys a card out instead
+  of drawing a flat line.
 - **The layout is chosen per metric, in preferences.** Cmd-, opens a tabbed
   window. Its **Layout** tab lists every metric with a Gauge checkbox and a
   Chart checkbox, grouped into collapsible sections whose headings carry the

--- a/Sources/MonitorCore/CSVExport.swift
+++ b/Sources/MonitorCore/CSVExport.swift
@@ -1,0 +1,102 @@
+import Foundation
+
+/// Turns what a card is showing into a table somebody can paste into a
+/// spreadsheet.
+///
+/// In `MonitorCore` rather than beside the view, for the same reason the
+/// preference models are: the interesting part is the row alignment and the
+/// choice of units, and neither needs a window to test.
+///
+/// Two rules shape it. **Copy what the picture showed** — the buffer holds ten
+/// minutes and a card usually shows one or two, so the export is cut to the
+/// same window rather than handed over whole. And **copy what was stored, not
+/// what was drawn** — the panel pins disk to MB/s and network to Mbit/s
+/// because a unit under a needle must not move while you read it, but a
+/// spreadsheet has no needle and a divided number is a number somebody has to
+/// undo. The header names the unit so the two can never be confused.
+public enum CSVExport {
+    /// One column per series, one row per timestamp.
+    ///
+    /// - Parameters:
+    ///   - series: the card's series, in the order it draws them.
+    ///   - window: seconds of history the card is showing.
+    ///   - now: the right-hand edge of the chart. Defaults to the newest
+    ///     sample, which is what the card itself uses.
+    ///   - timeZone: the zone the timestamps are written in.
+    public static func text(
+        for series: [(descriptor: MetricDescriptor, points: [Sample])],
+        window: TimeInterval,
+        now: TimeInterval? = nil,
+        timeZone: TimeZone = .current
+    ) -> String {
+        let end = now ?? series.compactMap { $0.points.last?.timestamp }.max()
+            ?? Date().timeIntervalSince1970
+        let start = end - window
+
+        // One dictionary per series rather than a search per cell: a ten-minute
+        // buffer at two samples a second is 1200 points, and a card can carry
+        // seven series.
+        let visible = series.map { entry in
+            Dictionary(
+                entry.points
+                    .filter { $0.timestamp >= start && $0.timestamp <= end }
+                    .map { ($0.timestamp, $0.value) },
+                uniquingKeysWith: { _, latest in latest }
+            )
+        }
+
+        var stamps = Set<TimeInterval>()
+        for column in visible { stamps.formUnion(column.keys) }
+
+        var rows = [header(for: series)]
+        for timestamp in stamps.sorted() {
+            let fields = visible.map { column in
+                column[timestamp].map { number($0) } ?? ""
+            }
+            rows.append(row([time(timestamp, in: timeZone)] + fields))
+        }
+        return rows.joined(separator: "\n") + "\n"
+    }
+
+    private static func header(
+        for series: [(descriptor: MetricDescriptor, points: [Sample])]
+    ) -> String {
+        row(["Time"] + series.map { column($0.descriptor) })
+    }
+
+    /// "Disk Read (B/s)". The group is dropped when it only repeats the name,
+    /// which is the same rule the gauge captions use — "Fans Fans" reads as a
+    /// mistake.
+    static func column(_ descriptor: MetricDescriptor) -> String {
+        let name = descriptor.group == descriptor.name
+            ? descriptor.name
+            : "\(descriptor.group) \(descriptor.name)"
+        return "\(name) (\(Format.baseUnit(descriptor.unit)))"
+    }
+
+    /// Fixed decimals rather than Swift's shortest round-trip, which writes
+    /// small numbers in exponent form. `1e-05` is a valid double and a value
+    /// some spreadsheets read as text.
+    static func number(_ value: Double) -> String {
+        guard value.isFinite else { return "" }
+        return String(format: "%.4f", value)
+    }
+
+    static func time(_ timestamp: TimeInterval, in timeZone: TimeZone) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.timeZone = timeZone
+        return formatter.string(from: Date(timeIntervalSince1970: timestamp))
+    }
+
+    static func row(_ fields: [String]) -> String {
+        fields.map(escaped).joined(separator: ",")
+    }
+
+    /// RFC 4180: a field holding a comma, a quote or a newline is wrapped in
+    /// quotes, and its own quotes are doubled.
+    static func escaped(_ field: String) -> String {
+        guard field.contains(where: { $0 == "," || $0 == "\"" || $0 == "\n" || $0 == "\r" })
+        else { return field }
+        return "\"\(field.replacingOccurrences(of: "\"", with: "\"\""))\""
+    }
+}

--- a/Sources/MonitorCore/Formatting.swift
+++ b/Sources/MonitorCore/Formatting.swift
@@ -211,6 +211,30 @@ public enum Format {
         }
     }
 
+    /// The unit a value is *stored* in, for an export rather than a display.
+    ///
+    /// Not `unitLabel`. That one answers "what goes under the needle", and the
+    /// answer there is pinned: disk always reads MB/s and network always reads
+    /// Mbit/s, whatever the magnitude. The buffer holds neither — it holds
+    /// bytes per second and bits per second, and a percentage is a fraction
+    /// between zero and one. A CSV column headed "MB/s" carrying bytes is the
+    /// quiet kind of wrong this whole file exists to prevent.
+    public static func baseUnit(_ unit: MetricUnit) -> String {
+        switch unit {
+        case .fraction: "fraction"
+        case .bytes: "B"
+        case .bytesPerSecond: "B/s"
+        case .bitsPerSecond: "bit/s"
+        case .operationsPerSecond: "op/s"
+        case .count: "count"
+        case .hertz: "Hz"
+        case .celsius: "°C"
+        case .watts: "W"
+        case .rpm: "rpm"
+        case .seconds: "s"
+        }
+    }
+
     /// Just the number part, for a gauge readout whose unit is drawn separately.
     public static func magnitude(_ value: Double, unit: MetricUnit) -> String {
         switch unit {

--- a/Sources/MonitorUI/CardExport.swift
+++ b/Sources/MonitorUI/CardExport.swift
@@ -1,0 +1,72 @@
+import AppKit
+import MonitorCore
+import SwiftUI
+
+/// Right-click a card to take it with you.
+///
+/// A chart on screen is a dead end: to put it in a message, or the numbers
+/// behind it in a spreadsheet, the only route was a screenshot. Two items fix
+/// both halves — the picture as a PNG, and the samples as CSV.
+///
+/// This still writes nothing to disk. The pasteboard is somewhere the user
+/// asked for it to go, once, by choosing a menu item; `MonitorStore` stays
+/// unlinked and the ring buffer stays in memory.
+enum CardExport {
+    /// Renders a view and puts it on the pasteboard as an image.
+    ///
+    /// The view is rendered on its own rather than captured from the window, so
+    /// what lands on the pasteboard is the card and nothing around it — no
+    /// insertion indicator left over from a drag, no slice of the panel behind
+    /// it.
+    @MainActor
+    static func copyImage(_ view: some View) {
+        let renderer = ImageRenderer(content: view)
+        // The screen's own scale, so the copy is as sharp as what was on it.
+        // The default of 1 makes a Retina card look like a photograph of one.
+        renderer.scale = NSScreen.main?.backingScaleFactor ?? 2
+        guard let image = renderer.nsImage else {
+            log.error("Could not render card for copying")
+            return
+        }
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.writeObjects([image])
+    }
+
+    static func copyText(_ text: String) {
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(text, forType: .string)
+    }
+}
+
+extension View {
+    /// The context menu shared by both kinds of tile.
+    ///
+    /// `rendered` is passed rather than the tile itself because the two are not
+    /// the same picture: the tile in the panel is sized by the grid and carries
+    /// the drag machinery, and the copy wants a card at its chosen size on the
+    /// panel's own background. A gauge in particular draws no background of its
+    /// own, and copied without one it would arrive as a needle floating on
+    /// whatever the reader pastes it into.
+    ///
+    /// Both closures run when the item is chosen, not when the menu is built,
+    /// so the copy is of the card as it is at that moment.
+    func copyable(
+        csv: @escaping () -> String,
+        @ViewBuilder rendered: @escaping () -> some View
+    ) -> some View {
+        contextMenu {
+            Button {
+                CardExport.copyImage(rendered())
+            } label: {
+                Label("Copy Image", systemImage: "photo")
+            }
+            Button {
+                CardExport.copyText(csv())
+            } label: {
+                Label("Copy Data", systemImage: "tablecells")
+            }
+        }
+    }
+}

--- a/Sources/MonitorUI/DashboardView.swift
+++ b/Sources/MonitorUI/DashboardView.swift
@@ -121,34 +121,18 @@ public struct DashboardView: View {
         ) {
             ForEach(gaugeMetrics, id: \.self) { metric in
                 if let descriptor = model.descriptor(metric) {
-                    VStack(spacing: 2) {
-                        GaugeView(
-                            title: gaugeTitle(descriptor),
-                            value: model.latest(metric),
-                            fullScale: model.scales[metric]?.fullScale ?? 1,
-                            peak: model.scales[metric]?.peak,
-                            unit: descriptor.unit,
-                            // Needle travel matches the sampling interval, so
-                            // it is still moving when the next sample arrives.
-                            travelTime: model.interval
+                    let dial = gaugeTile(metric, descriptor)
+                    dial
+                        .copyable {
+                            CSVExport.text(
+                                for: [(descriptor, model.points(metric))], window: window
+                            )
+                        } rendered: {
+                            copyBackground(dial.frame(width: gaugeSize))
+                        }
+                        .reorderable(
+                            .gauge(metric.rawValue), target: $dropTarget, onDrop: dropGauge
                         )
-                        // The dial's label, not its value. The readout on the
-                        // face already carries the number and its unit, so
-                        // repeating it here was the only thing under the dial
-                        // — and the label had to come off the face, where at
-                        // 130pt across "Network Out" ran into the ticks.
-                        Text(gaugeTitle(descriptor).uppercased())
-                            .font(.system(
-                                size: Theme.Layout.gaugeCaptionSize(forGauge: gaugeSize),
-                                weight: .medium,
-                                design: .rounded
-                            ))
-                            .foregroundStyle(Theme.label)
-                            .lineLimit(1)
-                    }
-                    .reorderable(
-                        .gauge(metric.rawValue), target: $dropTarget, onDrop: dropGauge
-                    )
                 }
             }
         }
@@ -232,6 +216,38 @@ public struct DashboardView: View {
         }
     }
 
+    /// One dial and its caption.
+    ///
+    /// A function rather than written inline because the copy needs the same
+    /// picture a second time — the tile in the wall carries the drag machinery,
+    /// and the copy wants only the dial.
+    private func gaugeTile(_ metric: MetricID, _ descriptor: MetricDescriptor) -> some View {
+        VStack(spacing: 2) {
+            GaugeView(
+                title: gaugeTitle(descriptor),
+                value: model.latest(metric),
+                fullScale: model.scales[metric]?.fullScale ?? 1,
+                peak: model.scales[metric]?.peak,
+                unit: descriptor.unit,
+                // Needle travel matches the sampling interval, so it is still
+                // moving when the next sample arrives.
+                travelTime: model.interval
+            )
+            // The dial's label, not its value. The readout on the face already
+            // carries the number and its unit, so repeating it here was the
+            // only thing under the dial — and the label had to come off the
+            // face, where at 130pt across "Network Out" ran into the ticks.
+            Text(gaugeTitle(descriptor).uppercased())
+                .font(.system(
+                    size: Theme.Layout.gaugeCaptionSize(forGauge: gaugeSize),
+                    weight: .medium,
+                    design: .rounded
+                ))
+                .foregroundStyle(Theme.label)
+                .lineLimit(1)
+        }
+    }
+
     /// "Disk" + "Read" reads better on a dial as "Disk Read" than as either
     /// alone, since two dials on the wall both say "Read".
     private func gaugeTitle(_ descriptor: MetricDescriptor) -> String {
@@ -262,21 +278,51 @@ public struct DashboardView: View {
             spacing: Theme.Layout.gridSpacing
         ) {
             ForEach(groups, id: \.name) { group in
-                ChartCard(
+                // Read once and used three times — the card, its copied
+                // picture and its copied numbers. Reading again for each would
+                // let a tick land in between and hand back a CSV that does not
+                // match the chart it came from.
+                let series = series(of: group)
+                let card = ChartCard(
                     title: group.name,
-                    series: group.metrics.compactMap { metric in
-                        guard let descriptor = model.descriptor(metric) else { return nil }
-                        return (descriptor: descriptor, points: model.points(metric))
-                    },
+                    series: series,
                     window: window,
                     isUnavailable: group.metrics.allSatisfy(model.unavailable.contains),
                     plotHeight: model.arrangement.chartHeight
                 )
-                .reorderable(.chart(group.name), target: $dropTarget) { dragged, on, edge in
-                    dropChart(dragged, on: on, edge: edge, in: section)
-                }
+                card
+                    .copyable {
+                        CSVExport.text(for: series, window: window)
+                    } rendered: {
+                        copyBackground(card.frame(width: model.arrangement.chartWidth))
+                    }
+                    .reorderable(.chart(group.name), target: $dropTarget) { dragged, on, edge in
+                        dropChart(dragged, on: on, edge: edge, in: section)
+                    }
             }
         }
+    }
+
+    /// The series behind one card, in the order the card draws them.
+    private func series(
+        of group: (name: String, metrics: [MetricID])
+    ) -> [(descriptor: MetricDescriptor, points: [Sample])] {
+        group.metrics.compactMap { metric in
+            guard let descriptor = model.descriptor(metric) else { return nil }
+            return (descriptor: descriptor, points: model.points(metric))
+        }
+    }
+
+    /// What a copied tile sits on.
+    ///
+    /// The panel's own background rather than nothing. A card copied
+    /// transparent arrives legible on a white document and invisible on a dark
+    /// one, and a gauge draws no background at all, so the needle would land on
+    /// whatever the reader happened to paste it into.
+    private func copyBackground(_ tile: some View) -> some View {
+        tile
+            .padding(Theme.Layout.pagePadding)
+            .background(Theme.background)
     }
 
     /// What is left of the sensor section once every card has been dragged out

--- a/Tests/MonitorCoreTests/CSVExportTests.swift
+++ b/Tests/MonitorCoreTests/CSVExportTests.swift
@@ -1,0 +1,150 @@
+import Foundation
+@testable import MonitorCore
+import Testing
+
+/// Fixtures at file scope rather than on the suite, so the tests read as the
+/// tables they are checking instead of as `Self.this` and `Self.that`.
+private let read = MetricDescriptor(
+    id: MetricID("disk.bytes.read"), name: "Read", group: "Disk", unit: .bytesPerSecond
+)
+private let written = MetricDescriptor(
+    id: MetricID("disk.bytes.written"), name: "Write", group: "Disk", unit: .bytesPerSecond
+)
+private let cpu = MetricDescriptor(
+    id: MetricID("cpu.total"), name: "Total", group: "CPU", unit: .fraction
+)
+
+/// UTC throughout, so the expected strings do not depend on where the test
+/// runs. The app passes `.current`.
+private let utc = TimeZone(identifier: "UTC")!
+
+private func sample(_ descriptor: MetricDescriptor, _ time: TimeInterval, _ value: Double)
+    -> Sample
+{
+    Sample(metric: descriptor.id, timestamp: time, value: value)
+}
+
+private func lines(_ text: String) -> [String] {
+    text.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+}
+
+@Suite("CSVExport")
+struct CSVExportTests {
+    @Test("Header names every series and its base unit")
+    func header() {
+        let text = CSVExport.text(
+            for: [(read, [sample(read, 100, 1)]), (cpu, [sample(cpu, 100, 0.5)])],
+            window: 60, now: 100, timeZone: utc
+        )
+        #expect(lines(text).first == "Time,Disk Read (B/s),CPU Total (fraction)")
+    }
+
+    @Test("A series whose name repeats its group is not doubled")
+    func headerWithoutRedundantGroup() {
+        let fans = MetricDescriptor(
+            id: MetricID("sensors.Fans"), name: "Fans", group: "Fans", unit: .rpm
+        )
+        let text = CSVExport.text(
+            for: [(fans, [sample(fans, 100, 2000)])], window: 60, now: 100, timeZone: utc
+        )
+        #expect(lines(text).first == "Time,Fans (rpm)")
+    }
+
+    @Test("Timestamps are ISO 8601 with an offset")
+    func timestamps() {
+        let text = CSVExport.text(
+            for: [(cpu, [sample(cpu, 0, 0.25)])], window: 60, now: 0, timeZone: utc
+        )
+        #expect(lines(text)[1].hasPrefix("1970-01-01T00:00:00Z,"))
+    }
+
+    @Test("Values are the stored base units, not what the panel shows")
+    func rawValues() {
+        // 5 MB/s on the dial is 5_000_000 B/s in the buffer, and 50% is 0.5.
+        let text = CSVExport.text(
+            for: [(read, [sample(read, 0, 5_000_000)]), (cpu, [sample(cpu, 0, 0.5)])],
+            window: 60, now: 0, timeZone: utc
+        )
+        #expect(lines(text)[1].hasSuffix(",5000000.0000,0.5000"))
+    }
+
+    @Test("One row per timestamp, with every series on it")
+    func rowsAlign() {
+        let text = CSVExport.text(
+            for: [
+                (read, [sample(read, 10, 1), sample(read, 20, 2)]),
+                (written, [sample(written, 10, 3), sample(written, 20, 4)]),
+            ],
+            window: 60, now: 20, timeZone: utc
+        )
+        let rows = lines(text)
+        #expect(rows.count == 4) // header, two rows, trailing newline
+        #expect(rows[1].hasSuffix(",1.0000,3.0000"))
+        #expect(rows[2].hasSuffix(",2.0000,4.0000"))
+    }
+
+    @Test("A series missing a tick leaves its field empty rather than a zero")
+    func gaps() {
+        // A skipped source is not a source reading zero, and a spreadsheet that
+        // cannot tell them apart draws the same lie the panel refuses to draw.
+        let text = CSVExport.text(
+            for: [
+                (read, [sample(read, 10, 1), sample(read, 20, 2)]),
+                (written, [sample(written, 20, 4)]),
+            ],
+            window: 60, now: 20, timeZone: utc
+        )
+        let rows = lines(text)
+        #expect(rows[1].hasSuffix(",1.0000,"))
+        #expect(rows[2].hasSuffix(",2.0000,4.0000"))
+    }
+
+    @Test("Only the visible window is copied")
+    func windowed() {
+        // The buffer holds ten minutes; the card shows one. Copying the buffer
+        // would hand back data the picture never showed.
+        let points = (0..<10).map { sample(cpu, Double($0) * 10, Double($0)) }
+        let text = CSVExport.text(for: [(cpu, points)], window: 30, now: 90, timeZone: utc)
+        #expect(lines(text).count == 6) // header, 60/70/80/90, trailing newline
+    }
+
+    @Test("Rows are ordered oldest first")
+    func ordered() {
+        let points = [sample(cpu, 30, 3), sample(cpu, 10, 1), sample(cpu, 20, 2)]
+        let text = CSVExport.text(for: [(cpu, points)], window: 60, now: 30, timeZone: utc)
+        let rows = lines(text)
+        #expect(rows[1].hasSuffix(",1.0000"))
+        #expect(rows[3].hasSuffix(",3.0000"))
+    }
+
+    @Test("A card with nothing in the window copies its header alone")
+    func empty() {
+        let text = CSVExport.text(for: [(cpu, [])], window: 60, now: 100, timeZone: utc)
+        #expect(text == "Time,CPU Total (fraction)\n")
+    }
+
+    @Test("A field containing a comma or a quote is quoted")
+    func escaping() {
+        let odd = MetricDescriptor(
+            id: MetricID("x"), name: "In, Out", group: "Net \"work\"", unit: .count
+        )
+        let text = CSVExport.text(
+            for: [(odd, [sample(odd, 0, 1)])], window: 60, now: 0, timeZone: utc
+        )
+        #expect(lines(text)[0] == "Time,\"Net \"\"work\"\" In, Out (count)\"")
+    }
+
+    @Test("Every unit has a base symbol")
+    func baseUnits() {
+        for unit in [
+            MetricUnit.fraction, .bytes, .bytesPerSecond, .bitsPerSecond,
+            .operationsPerSecond, .count, .hertz, .celsius, .watts, .rpm, .seconds,
+        ] {
+            #expect(!Format.baseUnit(unit).isEmpty)
+        }
+        // The stored value, not the pinned display unit: the panel says MB/s
+        // and Mbit/s, and the buffer holds bytes and bits.
+        #expect(Format.baseUnit(.bytesPerSecond) == "B/s")
+        #expect(Format.baseUnit(.bitsPerSecond) == "bit/s")
+    }
+}

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -173,6 +173,66 @@ not — the app still writes no *history* to disk and still does not link
 `MonitorStore`. The argument in `storage.md` is about a sample every half second
 forever, not about a checkbox written when somebody ticks it.
 
+## Copying a card
+
+Right-click any tile — a chart card or a dial — for two items.
+
+**Copy Image** puts the tile on the pasteboard as a PNG. It is rendered on its
+own with `ImageRenderer` rather than captured from the window, so what you get
+is the card and nothing around it: no insertion indicator left over from a drag,
+no slice of the panel behind it. The scale is the screen's own, or a copy of a
+Retina card arrives looking like a photograph of one. It is padded and drawn on
+the panel background, because a dial draws no background of its own and a
+transparent needle lands invisible in half the places you would paste it.
+
+**Copy Data** puts the samples behind the card on the pasteboard as CSV. Two
+rules shape it, both in `CSVExport` in `MonitorCore` — the interesting part is
+the row alignment and the choice of units, and neither needs a window to test.
+
+### Copy what the picture showed
+
+The buffer holds ten minutes and a card usually shows one or two. The export is
+cut to the same window the chart is drawing, so the numbers and the picture
+agree. Copying the whole buffer would hand back data that was never on screen.
+
+### Copy what was stored, not what was drawn
+
+The panel pins disk to MB/s and network to Mbit/s, because the unit under a
+needle must not change while you are reading it. A spreadsheet has no needle,
+and a divided number is a number somebody has to undo. So the CSV carries what
+the buffer holds — bytes per second, bits per second, and a fraction between
+zero and one — and the header names the unit:
+
+```
+Time,Disk Read (B/s),Disk Write (B/s)
+2026-08-18T14:32:10-04:00,5000000.0000,120000.0000
+```
+
+`Format.baseUnit` is that table, and it is deliberately *not* `Format.unitLabel`
+beside it. A column headed `MB/s` carrying bytes is the quiet kind of wrong the
+whole formatting file exists to prevent.
+
+One row per timestamp, oldest first, with every series on it. A series that
+missed a tick leaves its field **empty rather than zero** — a skipped source is
+not a source reading zero, and a spreadsheet that cannot tell them apart draws
+exactly the lie the panel refuses to draw.
+
+Values are written with fixed decimals rather than Swift's shortest round-trip,
+which spells small numbers `1e-05` — a valid double, and text to some
+spreadsheets.
+
+### The gauge gets the same menu
+
+A dial shows one number, but the buffer behind it holds the same history a chart
+has, so **Copy Data** on a gauge gives that one metric over the same window.
+Every tile has the same two items; a menu that changed shape between tile types
+would be one more thing to remember.
+
+### Nothing is written to disk
+
+The pasteboard is somewhere the user asked for it to go, once, by choosing a
+menu item. `MonitorStore` stays unlinked and the ring buffer stays in memory.
+
 ## The auto-ranging dial
 
 A benchmark can pin its dial at a known maximum. A monitor cannot: disk write


### PR DESCRIPTION
## Summary

- **Copy Image** renders the tile on its own with `ImageRenderer` rather than capturing it from the window, so the copy carries no insertion indicator left over from a drag and no slice of the panel behind it. Screen scale, padded, on the panel background — a dial draws no background of its own, and a transparent needle lands invisible in half the places you would paste it.
- **Copy Data** puts the visible window on the pasteboard as CSV. `CSVExport` (`Sources/MonitorCore/CSVExport.swift`) is in `MonitorCore` because the interesting part is the row alignment and the choice of units, and neither needs a window to test.
- Two rules shape the export. It is cut to the window the card is *drawing*, not the whole ten-minute buffer, so the numbers and the picture agree. And it carries what the buffer holds — bytes per second, bits per second, a fraction between zero and one — via the new `Format.baseUnit` (`Sources/MonitorCore/Formatting.swift`), deliberately **not** `Format.unitLabel` beside it. The panel pins disk to MB/s and network to Mbit/s so the unit under a needle cannot move while you read it; a column headed `MB/s` carrying bytes is the quiet kind of wrong.
- A series that missed a tick leaves an **empty field rather than a zero**. A skipped source is not a source reading zero, and a spreadsheet that cannot tell them apart draws exactly the lie the panel refuses to draw.
- Gauges get the same two items. A dial shows one number, but the buffer behind it holds the same history a chart has, so its menu need not be a different shape.
- Nothing new is written to disk. The pasteboard is somewhere the user asked for it to go, once, by choosing a menu item; `MonitorStore` stays unlinked.

Closes #25

## Test plan

- [x] `swift build && swift test` — 139 tests in 16 suites pass, 11 of them new in `Tests/MonitorCoreTests/CSVExportTests.swift`
- [x] `swift build -c release`
- [x] `swiftformat Sources Tests --lint --cache ignore` — clean
- [x] Verified in `swift run monitor`: Copy Image and Copy Data on a chart card and on a dial, and drag-to-reorder still works alongside the context menu

https://claude.ai/code/session_01UPbN2SqYq8t2vcx2YWQTcs