### PR TITLE
Mirror the in/out charts, when you ask for it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,7 @@ Sources/
   MonitorCore/     metric model, ring buffer, downsampling, gauge auto-ranging,
                    seven-segment digit mapping, formatting, the sampling clock,
                    the layout, arrangement, chart and sampling preference
-                   models, CSV export. No macOS APIs — so all of it is testable
+                   models, CSV export, chart axis ticks. No macOS APIs — so all of it is testable
                    without a machine to read.
   MonitorSources/  the readers: CPU, memory, disk, network, GPU, SMC sensors
                    (temperature, fans, power), and the registry that lists them.
@@ -148,22 +148,39 @@ are no component-level AGENTS.md files.
   freely during a gesture, then call `commitArrangement()`. Adding a `didSet`
   that saves would turn one decision into hundreds of writes — the thing
   `docs/storage.md` exists to prevent.
-- **Paired charts can be mirrored, and only the picture flips.** Network in
-  and disk read draw above the baseline, out and written below it, when
-  **Mirror paired charts** is on in the Charts tab. The stored sample stays
-  positive — a rate is never negative — so `ChartCard.plotted` negates at draw
-  time and the legend, the formatter, the gauges and the CSV export are
-  untouched. Axis labels are magnitudes on both sides. One symmetric scale, not
-  one per direction: the two share a card in order to be read against each
-  other. `ChartMirror.pairs` (in `MonitorCore`) is the table, deliberately not a
-  field on `MetricDescriptor` — a descriptor says what a metric *is* and is
-  declared by the source that reads it, and "this one points down" is a
-  statement about a picture. A card mirrors only when it draws **both halves**,
-  so switching one direction off returns it to drawing upward rather than
-  leaving a trace under an empty top half. `ChartPreferences` is its own type
-  and key beside `LayoutPreferences`: **which cards exist** versus **how one is
-  drawn**. Off by default, because a chart that changes shape on upgrade is
-  worse than one somebody switches on.
+- **A metric declares which way it runs.** `MetricDescriptor.direction` is
+  `.inbound`, `.outbound`, or nil for everything that is not one direction of a
+  flow. Five groups pair up: Network, Network Packets, Disk, Disk Ops, Memory
+  Paging. Read and write *latency* deliberately declare nothing — two
+  measurements of the same kind are not two directions of one flow. A group
+  that declares a direction must declare its opposite too, checked against the
+  real registry in `MonitorSourcesTests`.
+- **Paired charts can be mirrored, and only the picture flips.** Inbound draws
+  above the baseline and outbound below it when **Mirror paired charts** is on
+  in the Charts tab. The stored sample stays positive — a rate is never
+  negative — so `ChartCard.plotted` negates at draw time and the legend, the
+  formatter, the gauges and the CSV export are untouched. Axis labels are
+  magnitudes on both sides. One symmetric scale, not one per direction: the two
+  share a card in order to be read against each other. A card mirrors only when
+  it draws **both halves**, so switching one direction off returns it to drawing
+  upward rather than leaving a trace under an empty top half. `ChartPreferences`
+  is its own type and key beside `LayoutPreferences`: **which cards exist**
+  versus **how one is drawn**. Off by default, because a chart that changes
+  shape on upgrade is worse than one somebody switches on.
+- **The time axis is computed, not automatic.** `ChartAxis` in `MonitorCore`.
+  Three rules, and the first two versions traded one for another: a tick is an
+  **instant** (10:42:00 sits at 10:42:00 and scrolls left keeping its label —
+  ticks at fractions of the window stand still while their labels count up in
+  real time); never more labels than fit; and **never fewer than two**, which
+  wins where it conflicts with the second. The interval is chosen from the
+  window's **length alone, never its position** — the count drifts by one as a
+  tick scrolls off, but an interval chosen by counting actual ticks flips
+  between rungs as the window slides and the axis restyles itself every few
+  seconds. No AM/PM; seconds only when the interval is under a minute.
+- **A card's header fits, it does not count.** Title beside legend when it fits,
+  stacked when it does not, decided by `ViewThatFits`. A count of series cannot
+  know how wide the words are, and since the title is `fixedSize` a header that
+  did not fit pushed the card past its grid column and stretched the row.
 - **A card can be copied, and the copy is not what the panel shows.**
   Right-click any tile for **Copy Image** (the tile rendered on its own with
   `ImageRenderer`, not captured from the window) and **Copy Data** (the visible

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,8 +64,8 @@ look at it in the app.
 Sources/
   MonitorCore/     metric model, ring buffer, downsampling, gauge auto-ranging,
                    seven-segment digit mapping, formatting, the sampling clock,
-                   the layout, arrangement and sampling preference models,
-                   CSV export. No macOS APIs — so all of it is testable
+                   the layout, arrangement, chart and sampling preference
+                   models, CSV export. No macOS APIs — so all of it is testable
                    without a machine to read.
   MonitorSources/  the readers: CPU, memory, disk, network, GPU, SMC sensors
                    (temperature, fans, power), and the registry that lists them.
@@ -148,6 +148,22 @@ are no component-level AGENTS.md files.
   freely during a gesture, then call `commitArrangement()`. Adding a `didSet`
   that saves would turn one decision into hundreds of writes — the thing
   `docs/storage.md` exists to prevent.
+- **Paired charts can be mirrored, and only the picture flips.** Network in
+  and disk read draw above the baseline, out and written below it, when
+  **Mirror paired charts** is on in the Charts tab. The stored sample stays
+  positive — a rate is never negative — so `ChartCard.plotted` negates at draw
+  time and the legend, the formatter, the gauges and the CSV export are
+  untouched. Axis labels are magnitudes on both sides. One symmetric scale, not
+  one per direction: the two share a card in order to be read against each
+  other. `ChartMirror.pairs` (in `MonitorCore`) is the table, deliberately not a
+  field on `MetricDescriptor` — a descriptor says what a metric *is* and is
+  declared by the source that reads it, and "this one points down" is a
+  statement about a picture. A card mirrors only when it draws **both halves**,
+  so switching one direction off returns it to drawing upward rather than
+  leaving a trace under an empty top half. `ChartPreferences` is its own type
+  and key beside `LayoutPreferences`: **which cards exist** versus **how one is
+  drawn**. Off by default, because a chart that changes shape on upgrade is
+  worse than one somebody switches on.
 - **A card can be copied, and the copy is not what the panel shows.**
   Right-click any tile for **Copy Image** (the tile rendered on its own with
   `ImageRenderer`, not captured from the window) and **Copy Data** (the visible
@@ -161,7 +177,9 @@ are no component-level AGENTS.md files.
   field, never a zero** — same reason a failed source greys a card out instead
   of drawing a flat line.
 - **The layout is chosen per metric, in preferences.** Cmd-, opens a tabbed
-  window. Its **Layout** tab lists every metric with a Gauge checkbox and a
+  window. Its **Charts** tab holds how cards are *drawn* (mirroring), which is
+  a different question from which cards there are. Its **Layout** tab lists
+  every metric with a Gauge checkbox and a
   Chart checkbox, grouped into collapsible sections whose headings carry the
   same two checkboxes for the whole group. The two columns are not symmetrical:
   **a gauge is per metric, a chart is per group.** Ticking Network In and Network Out gives two dials and *one*

--- a/Sources/MonitorCore/ChartAxis.swift
+++ b/Sources/MonitorCore/ChartAxis.swift
@@ -1,0 +1,121 @@
+import Foundation
+
+/// Where the time labels go along the bottom of a chart.
+///
+/// Here rather than in the view because it is arithmetic, and arithmetic that
+/// has been wrong on screen three times.
+///
+/// **A tick is an instant, not a position.** 10:42:00 belongs at 10:42:00, and
+/// as the window scrolls it must travel left and eventually off the edge with
+/// its label unchanged. Ticks placed at fixed fractions of the window do the
+/// opposite: the gridline stands still and the time under it counts up in real
+/// time, which is a clock, not an axis.
+///
+/// Swift Charts will place instants itself with `.automatic`, and that was the
+/// first version. It treats `desiredCount` as a hint and picks its own
+/// boundaries, so on a narrow card the labels crowded into each other and ran
+/// off the right edge. Choosing the interval here keeps both properties: real
+/// instants, and never more of them than fit.
+public enum ChartAxis {
+    /// The intervals worth labelling, in seconds, finest first. Each divides a
+    /// minute or is a whole number of minutes, so a tick lands on a time
+    /// somebody would write down.
+    static let strides: [TimeInterval] = [1, 2, 5, 10, 15, 30, 60, 120, 300, 600]
+
+    /// Points of card per label, measured off the narrowest column the grid
+    /// makes. Two is the fewest that says anything; past five they are closer
+    /// together than the eye needs on a chart this size.
+    static let spacing = 78.0
+    static let fewest = 2
+    static let most = 5
+
+    /// The y-axis and its labels, which the measured width includes and the
+    /// time labels cannot use.
+    static let axisAllowance = 50.0
+
+    /// How many labels this card has room for.
+    public static func maximumTicks(width: Double) -> Int {
+        guard width.isFinite else { return fewest }
+        return max(fewest, min(most, Int((width - axisAllowance) / spacing)))
+    }
+
+    /// Ticks are held this far in from each edge of the window.
+    ///
+    /// A label is centred on its tick, so one sitting hard against an edge is
+    /// half cut off — which is what truncated the last label to "10:34…". A
+    /// tick inside the band is dropped rather than moved: moving it would put
+    /// it somewhere that is not the time it claims.
+    static let edgeFraction = 0.06
+
+    /// The labelled instants for one window, and how far apart they are.
+    public struct Marks: Equatable, Sendable {
+        public let times: [TimeInterval]
+        public let stride: TimeInterval
+    }
+
+    /// The interval to label at: as many labels as the card has room for, and
+    /// never fewer than two.
+    ///
+    /// Chosen from the *length* of the window, not from where it happens to
+    /// sit. The ticks themselves are absolute instants, so the exact count
+    /// drifts by one as the window slides — but the interval must not, or the
+    /// axis restyles itself every few seconds. Picking the interval by counting
+    /// the ticks it actually produced was the previous version, and on a narrow
+    /// ten-minute card it flipped between 300 s and 120 s as the window moved,
+    /// so the labels jumped between two and five.
+    ///
+    /// Two rules, in this order:
+    ///
+    /// 1. **Never fewer than two labels.** One lonely label says nothing about
+    ///    the span you are looking at.
+    /// 2. **Never more than the card has room for**, where that is compatible
+    ///    with the first. On a narrow card showing ten minutes it is not, and
+    ///    slightly tight labels beat a bare axis.
+    public static func marks(
+        from start: TimeInterval, to end: TimeInterval, maximumTicks: Int
+    ) -> Marks {
+        guard end > start else { return Marks(times: [], stride: strides[0]) }
+        let usable = (end - start) * (1 - 2 * edgeFraction)
+
+        // The coarsest interval that still fits `fewest` of itself in the
+        // window, whatever the window's phase.
+        let guaranteeing = strides.last { (usable / $0).rounded(.down) >= Double(fewest) }
+            ?? strides[0]
+        // The finest interval that cannot produce more labels than fit. A
+        // window of length L holds either floor(L / stride) boundaries or one
+        // more, depending on its phase, so the worst case is that floor plus
+        // one.
+        let capping = strides.first {
+            (usable / $0).rounded(.down) + 1 <= Double(maximumTicks)
+        } ?? strides[strides.count - 1]
+
+        // The finer of the two. Finer than `guaranteeing` still guarantees two,
+        // so this respects the room whenever the room allows two, and gives up
+        // on the room rather than on the two when it does not.
+        let stride = Swift.min(guaranteeing, capping)
+        return Marks(times: times(from: start, to: end, stride: stride), stride: stride)
+    }
+
+    /// Every multiple of `stride` inside the window, less the edge bands.
+    ///
+    /// Multiples counted from the epoch. Time zone offsets are whole minutes,
+    /// so a multiple of 30 s is on a local half-minute too.
+    public static func times(
+        from start: TimeInterval, to end: TimeInterval, stride: TimeInterval
+    ) -> [TimeInterval] {
+        guard stride > 0, end > start else { return [] }
+        let band = (end - start) * edgeFraction
+        let last = end - band
+        var tick = ((start + band) / stride).rounded(.up) * stride
+        var times: [TimeInterval] = []
+        while tick <= last {
+            times.append(tick)
+            tick += stride
+        }
+        return times
+    }
+
+    /// Whether the labels need seconds to stay distinct. An interval under a
+    /// minute lands two labels inside the same minute.
+    public static func showsSeconds(stride: TimeInterval) -> Bool { stride < 60 }
+}

--- a/Sources/MonitorCore/ChartPreferences.swift
+++ b/Sources/MonitorCore/ChartPreferences.swift
@@ -19,31 +19,29 @@ public struct MetricPair: Equatable, Sendable {
 
 /// Which cards are two directions of one thing, and which way round.
 ///
-/// A table here rather than a field on `MetricDescriptor`. A descriptor says
-/// what a metric *is* — name, group, unit, kind — and it is declared by the
-/// source that reads it. "This one points down" is a statement about a picture,
-/// and a disk reader has no business making it. Keeping the table separate also
-/// means a source can be added without deciding whether it has an opposite.
-///
-/// In and out rather than out and in, read above written: the first is the one
-/// that arrives, and download above upload is the way every meter of this kind
-/// has drawn it since modem lights.
+/// No table of metric ids here. A metric declares its own `direction` in
+/// `MetricDescriptor`, so a card is a pair when it draws exactly one inbound
+/// series and one outbound one — and a source added later gets mirroring
+/// without this file being told it exists.
 public enum ChartMirror {
-    public static let pairs = [
-        MetricPair(up: MetricID("net.bits.in"), down: MetricID("net.bits.out")),
-        MetricPair(up: MetricID("disk.bytes.read"), down: MetricID("disk.bytes.written")),
-    ]
-
     /// The pair a card draws, or nil if it does not draw exactly one.
     ///
     /// **Both halves or neither.** A card showing only the download half would
     /// mirror into a single trace hanging below an empty top half, which reads
     /// as a bug rather than as a choice. Switch one direction off in
     /// preferences and the card goes back to drawing upward from zero.
-    public static func pair(for metrics: [MetricID]) -> MetricPair? {
-        let drawn = Set(metrics)
-        guard drawn.count == 2 else { return nil }
-        return pairs.first { drawn == [$0.up, $0.down] }
+    ///
+    /// Inbound above outbound: the first is the one that arrives, and download
+    /// above upload is how every meter of this kind has drawn it since modem
+    /// lights.
+    public static func pair(for descriptors: [MetricDescriptor]) -> MetricPair? {
+        guard descriptors.count == 2 else { return nil }
+        let inbound = descriptors.filter { $0.direction == .inbound }
+        let outbound = descriptors.filter { $0.direction == .outbound }
+        guard inbound.count == 1, let up = inbound.first,
+              outbound.count == 1, let down = outbound.first
+        else { return nil }
+        return MetricPair(up: up.id, down: down.id)
     }
 }
 
@@ -70,9 +68,9 @@ public struct ChartPreferences: Codable, Equatable, Sendable {
 
     /// The pair this card should mirror, given the setting: nil when mirroring
     /// is off, and nil when the card is not a pair.
-    public func mirror(for metrics: [MetricID]) -> MetricPair? {
+    public func mirror(for descriptors: [MetricDescriptor]) -> MetricPair? {
         guard mirrorsPairs else { return nil }
-        return ChartMirror.pair(for: metrics)
+        return ChartMirror.pair(for: descriptors)
     }
 
     private enum CodingKeys: String, CodingKey {

--- a/Sources/MonitorCore/ChartPreferences.swift
+++ b/Sources/MonitorCore/ChartPreferences.swift
@@ -1,0 +1,89 @@
+import Foundation
+
+/// Two metrics that are opposite directions of one thing.
+///
+/// Network in and out, disk read and written. Not any two metrics that share a
+/// card: temperature sensors share one, and neither of them is the opposite of
+/// the other.
+public struct MetricPair: Equatable, Sendable {
+    /// Drawn above the baseline.
+    public let up: MetricID
+    /// Drawn below it.
+    public let down: MetricID
+
+    public init(up: MetricID, down: MetricID) {
+        self.up = up
+        self.down = down
+    }
+}
+
+/// Which cards are two directions of one thing, and which way round.
+///
+/// A table here rather than a field on `MetricDescriptor`. A descriptor says
+/// what a metric *is* — name, group, unit, kind — and it is declared by the
+/// source that reads it. "This one points down" is a statement about a picture,
+/// and a disk reader has no business making it. Keeping the table separate also
+/// means a source can be added without deciding whether it has an opposite.
+///
+/// In and out rather than out and in, read above written: the first is the one
+/// that arrives, and download above upload is the way every meter of this kind
+/// has drawn it since modem lights.
+public enum ChartMirror {
+    public static let pairs = [
+        MetricPair(up: MetricID("net.bits.in"), down: MetricID("net.bits.out")),
+        MetricPair(up: MetricID("disk.bytes.read"), down: MetricID("disk.bytes.written")),
+    ]
+
+    /// The pair a card draws, or nil if it does not draw exactly one.
+    ///
+    /// **Both halves or neither.** A card showing only the download half would
+    /// mirror into a single trace hanging below an empty top half, which reads
+    /// as a bug rather than as a choice. Switch one direction off in
+    /// preferences and the card goes back to drawing upward from zero.
+    public static func pair(for metrics: [MetricID]) -> MetricPair? {
+        let drawn = Set(metrics)
+        guard drawn.count == 2 else { return nil }
+        return pairs.first { drawn == [$0.up, $0.down] }
+    }
+}
+
+/// How the charts are drawn, as opposed to which ones there are.
+///
+/// Its own type beside `LayoutPreferences` rather than a field on it, because
+/// the two answer different questions. `LayoutPreferences` is *which cards
+/// exist*; this is *how one of them is drawn*. They are chosen on different
+/// tabs and stored under different keys, so a value a later version writes
+/// costs one of them and not both.
+public struct ChartPreferences: Codable, Equatable, Sendable {
+    /// Draw a paired card as one trace above the baseline and the other below.
+    ///
+    /// Off by default. Mirroring is the clearer way to read throughput, but a
+    /// chart that changes shape under somebody on upgrade is worse than one
+    /// they have to switch on.
+    public var mirrorsPairs: Bool
+
+    public init(mirrorsPairs: Bool = false) {
+        self.mirrorsPairs = mirrorsPairs
+    }
+
+    public static let `default` = ChartPreferences()
+
+    /// The pair this card should mirror, given the setting: nil when mirroring
+    /// is off, and nil when the card is not a pair.
+    public func mirror(for metrics: [MetricID]) -> MetricPair? {
+        guard mirrorsPairs else { return nil }
+        return ChartMirror.pair(for: metrics)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case mirrorsPairs
+    }
+
+    /// `decodeIfPresent`, so a value written before a setting existed still
+    /// decodes rather than resetting the whole struct to its defaults.
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let stored = try container.decodeIfPresent(Bool.self, forKey: .mirrorsPairs)
+        self.init(mirrorsPairs: stored ?? ChartPreferences.default.mirrorsPairs)
+    }
+}

--- a/Sources/MonitorCore/Metric.swift
+++ b/Sources/MonitorCore/Metric.swift
@@ -42,6 +42,27 @@ public enum MetricKind: String, Sendable, Codable {
     case counter
 }
 
+/// Which way a flow runs, for the metrics that are one direction of one.
+///
+/// Disk bytes read and written, network bits and packets in and out, pages in
+/// and out of memory. A metric with a direction has an opposite in its group,
+/// and the two are only meaningful against each other.
+///
+/// A fact about the metric, not about the picture: whether the pair is then
+/// *drawn* mirrored is a preference, and lives in `ChartPreferences`. Declaring
+/// it here means a source added later gets the option without anything else
+/// being told about it.
+///
+/// Most metrics have none. Read and write *latency* are the instructive case:
+/// two measurements of the same kind, not two directions of one flow, so
+/// neither carries a direction and their card never mirrors.
+public enum MetricDirection: String, Sendable, Codable {
+    /// Arriving: bytes read, packets in, pages in.
+    case inbound
+    /// Leaving: bytes written, packets out, pages out.
+    case outbound
+}
+
 /// Everything the UI needs to draw a series without knowing where it came from.
 public struct MetricDescriptor: Hashable, Sendable, Codable {
     public let id: MetricID
@@ -54,6 +75,9 @@ public struct MetricDescriptor: Hashable, Sendable, Codable {
     /// Upper bound for the y-axis when the unit does not imply one. Nil means
     /// the chart scales to the data.
     public let nominalMaximum: Double?
+    /// Which way this one runs, when it is one direction of a flow. Nil for
+    /// everything that is not.
+    public let direction: MetricDirection?
 
     public init(
         id: MetricID,
@@ -61,7 +85,8 @@ public struct MetricDescriptor: Hashable, Sendable, Codable {
         group: String,
         unit: MetricUnit,
         kind: MetricKind = .gauge,
-        nominalMaximum: Double? = nil
+        nominalMaximum: Double? = nil,
+        direction: MetricDirection? = nil
     ) {
         self.id = id
         self.name = name
@@ -69,5 +94,6 @@ public struct MetricDescriptor: Hashable, Sendable, Codable {
         self.unit = unit
         self.kind = kind
         self.nominalMaximum = nominalMaximum
+        self.direction = direction
     }
 }

--- a/Sources/MonitorSources/DiskSource.swift
+++ b/Sources/MonitorSources/DiskSource.swift
@@ -30,18 +30,20 @@ public final class DiskSource: MetricSource, @unchecked Sendable {
     public var descriptors: [MetricDescriptor] {
         [
             MetricDescriptor(
-                id: Self.bytesRead, name: "Read", group: "Disk", unit: .bytesPerSecond
+                id: Self.bytesRead, name: "Read", group: "Disk", unit: .bytesPerSecond,
+                direction: .inbound
             ),
             MetricDescriptor(
-                id: Self.bytesWritten, name: "Write", group: "Disk", unit: .bytesPerSecond
+                id: Self.bytesWritten, name: "Write", group: "Disk", unit: .bytesPerSecond,
+                direction: .outbound
             ),
             MetricDescriptor(
                 id: Self.readsPerSecond, name: "Reads", group: "Disk Ops",
-                unit: .operationsPerSecond
+                unit: .operationsPerSecond, direction: .inbound
             ),
             MetricDescriptor(
                 id: Self.writesPerSecond, name: "Writes", group: "Disk Ops",
-                unit: .operationsPerSecond
+                unit: .operationsPerSecond, direction: .outbound
             ),
             MetricDescriptor(
                 id: Self.readLatency, name: "Read", group: "Disk Latency",

--- a/Sources/MonitorSources/MemorySource.swift
+++ b/Sources/MonitorSources/MemorySource.swift
@@ -59,11 +59,11 @@ public final class MemorySource: MetricSource, @unchecked Sendable {
             MetricDescriptor(id: Self.swapUsed, name: "Swap", group: "Memory", unit: .bytes),
             MetricDescriptor(
                 id: Self.pageIn, name: "Page in", group: "Memory Paging",
-                unit: .operationsPerSecond
+                unit: .operationsPerSecond, direction: .inbound
             ),
             MetricDescriptor(
                 id: Self.pageOut, name: "Page out", group: "Memory Paging",
-                unit: .operationsPerSecond
+                unit: .operationsPerSecond, direction: .outbound
             ),
         ]
     }

--- a/Sources/MonitorSources/NetworkSource.swift
+++ b/Sources/MonitorSources/NetworkSource.swift
@@ -54,18 +54,20 @@ public final class NetworkSource: MetricSource, @unchecked Sendable {
     public var descriptors: [MetricDescriptor] {
         [
             MetricDescriptor(
-                id: Self.bitsIn, name: "In", group: "Network", unit: .bitsPerSecond
+                id: Self.bitsIn, name: "In", group: "Network", unit: .bitsPerSecond,
+                direction: .inbound
             ),
             MetricDescriptor(
-                id: Self.bitsOut, name: "Out", group: "Network", unit: .bitsPerSecond
+                id: Self.bitsOut, name: "Out", group: "Network", unit: .bitsPerSecond,
+                direction: .outbound
             ),
             MetricDescriptor(
                 id: Self.packetsIn, name: "Packets in", group: "Network Packets",
-                unit: .operationsPerSecond
+                unit: .operationsPerSecond, direction: .inbound
             ),
             MetricDescriptor(
                 id: Self.packetsOut, name: "Packets out", group: "Network Packets",
-                unit: .operationsPerSecond
+                unit: .operationsPerSecond, direction: .outbound
             ),
         ]
     }

--- a/Sources/MonitorUI/AppModel.swift
+++ b/Sources/MonitorUI/AppModel.swift
@@ -30,6 +30,17 @@ public final class AppModel {
         }
     }
 
+    /// How the charts are drawn, as opposed to which ones there are.
+    ///
+    /// Saved on change like `layout` and unlike `arrangement`: it is a
+    /// checkbox, so it changes once when somebody clicks it.
+    public var charts: ChartPreferences {
+        didSet {
+            guard charts != oldValue else { return }
+            ChartPreferencesStore.save(charts, to: defaults)
+        }
+    }
+
     /// Where every tile sits and how big the tiles are.
     ///
     /// Separate from `layout` because the two answer different questions: that
@@ -116,6 +127,7 @@ public final class AppModel {
         sampler = Sampler(sources: sources, sinks: [], interval: stored.performance)
         layout = LayoutPreferencesStore.load(for: all, from: defaults)
         arrangement = PanelArrangementStore.load(for: all, from: defaults)
+        charts = ChartPreferencesStore.load(from: defaults)
 
         // A scale for every metric, not only the ones a dial shows today. Any
         // metric can be given a dial in preferences, and auto-ranging needs

--- a/Sources/MonitorUI/ChartCard.swift
+++ b/Sources/MonitorUI/ChartCard.swift
@@ -17,19 +17,27 @@ public struct ChartCard: View {
     /// card whose legend wraps to three lines grows rather than squeezing the
     /// chart out of it.
     public var plotHeight: Double = Theme.Layout.chartMinHeight
+    /// The two opposite directions this card draws, when it is drawing them
+    /// mirrored. Nil is the ordinary card: every series upward from zero.
+    ///
+    /// Passed in rather than worked out here, because whether to mirror is a
+    /// preference and a card does not read preferences.
+    public var mirror: MetricPair?
 
     public init(
         title: String,
         series: [(descriptor: MetricDescriptor, points: [Sample])],
         window: TimeInterval,
         isUnavailable: Bool = false,
-        plotHeight: Double = Theme.Layout.chartMinHeight
+        plotHeight: Double = Theme.Layout.chartMinHeight,
+        mirror: MetricPair? = nil
     ) {
         self.title = title
         self.series = series
         self.window = window
         self.isUnavailable = isUnavailable
         self.plotHeight = plotHeight
+        self.mirror = mirror
     }
 
     public var body: some View {
@@ -177,11 +185,21 @@ public struct ChartCard: View {
         // that the compiler warns about it.
         let entries = visible
         return Chart {
+            // The baseline, drawn only when there is one to draw. On an
+            // ordinary card zero is the bottom of the plot and the axis already
+            // marks it; on a mirrored card it is the line the two directions
+            // are read against, and it has to be visible as more than one grid
+            // line among several.
+            if mirror != nil {
+                RuleMark(y: .value("Zero", 0))
+                    .foregroundStyle(Theme.panelEdge)
+                    .lineStyle(StrokeStyle(lineWidth: 1))
+            }
             ForEach(Array(entries.enumerated()), id: \.offset) { index, entry in
                 ForEach(entry.points, id: \.timestamp) { sample in
                     LineMark(
                         x: .value("Time", Date(timeIntervalSince1970: sample.timestamp)),
-                        y: .value("Value", sample.value)
+                        y: .value("Value", plotted(sample.value, of: entry.descriptor))
                     )
                     .foregroundStyle(Theme.seriesColor(index))
                     .interpolationMethod(.monotone)
@@ -205,7 +223,10 @@ public struct ChartCard: View {
                     if let value = mark.as(Double.self),
                        let unit = series.first?.descriptor.unit
                     {
-                        Text(Format.axisLabel(value, unit: unit))
+                        // The magnitude, on both sides of the baseline. Below
+                        // the line is a direction, not a negative quantity, and
+                        // "-50 MB/s" is not a rate anything can achieve.
+                        Text(Format.axisLabel(abs(value), unit: unit))
                             .font(.system(size: Theme.Layout.axisLabel, design: .rounded))
                             .foregroundStyle(Theme.label)
                     }
@@ -238,15 +259,34 @@ public struct ChartCard: View {
     /// A fraction metric is pinned to 0...1 so a quiet CPU draws a flat line at
     /// the bottom. Auto-scaling it would magnify 2% noise into a dramatic chart
     /// — the single most common way a system monitor misleads.
+    /// Where a sample is drawn, which is not what it is worth.
+    ///
+    /// Only the picture flips. The sample in the buffer stays positive — a rate
+    /// is never negative — so the legend, the formatter, the gauges and the CSV
+    /// export all keep reading the number the source produced.
+    private func plotted(_ value: Double, of descriptor: MetricDescriptor) -> Double {
+        descriptor.id == mirror?.down ? -value : value
+    }
+
     private var yDomain: ClosedRange<Double> {
+        let top = upperBound
+        // Symmetric about zero, so a rate reads the same distance from the
+        // baseline whichever way it points. One shared scale, not one per
+        // direction: the whole reason the two share a card is to be read
+        // against each other, and a card where download dwarfs upload will look
+        // nearly flat on the quiet side. That is the honest picture.
+        return mirror == nil ? 0...top : -top...top
+    }
+
+    private var upperBound: Double {
         if let descriptor = series.first?.descriptor {
-            if descriptor.unit == .fraction { return 0...1 }
-            if let maximum = descriptor.nominalMaximum { return 0...maximum }
+            if descriptor.unit == .fraction { return 1 }
+            if let maximum = descriptor.nominalMaximum { return maximum }
         }
         // Scaled to what is on screen, not to the whole buffer. Otherwise a
         // spike eight minutes off the left of a two-minute window flattens
         // everything you can actually see.
         let peak = visible.flatMap { $0.points.map(\.value) }.max() ?? 1
-        return 0...max(peak * 1.15, .leastNonzeroMagnitude)
+        return max(peak * 1.15, .leastNonzeroMagnitude)
     }
 }

--- a/Sources/MonitorUI/ChartCard.swift
+++ b/Sources/MonitorUI/ChartCard.swift
@@ -57,29 +57,29 @@ public struct ChartCard: View {
         )
     }
 
-    /// Above this many series the legend gets its own line rather than sharing
-    /// one with the title.
+    /// Title and legend on one line when they fit, and on two when they do not.
     ///
-    /// Three is what fits beside a title at the narrowest column the grid
-    /// makes. Memory has seven, and squeezed into the space left over they
-    /// wrapped four rows deep — or, before the legend could wrap at all,
-    /// compressed into a row of ellipses, which is what this fixes.
-    private static let inlineLegendLimit = 3
-
+    /// Decided by fit rather than by counting series, which is what it used to
+    /// do. A count cannot know how wide the words are: "Memory Paging" beside
+    /// "Page in 19/s  Page out 4.0/s" is two series and does not fit, while
+    /// "GPU" beside "GPU 0%  VRAM 1.9 GB" is two series and does. With the
+    /// title `fixedSize` — it must not truncate — a header that did not fit
+    /// pushed the whole card wider than its grid column, which stretched the
+    /// row and left the legend running out through the card's edge.
+    ///
+    /// `ViewThatFits` proposes the column's width to the first arrangement and
+    /// falls back to the second, so the compact line survives wherever there is
+    /// room for it.
     private var header: some View {
-        // Two arrangements, not one that adapts: a card with two series should
-        // keep the compact single line, and only the crowded card should spend
-        // a second line on chrome.
-        VStack(alignment: .leading, spacing: 4) {
-            if series.count > Self.inlineLegendLimit {
+        ViewThatFits(in: .horizontal) {
+            HStack(alignment: .top, spacing: 8) {
+                titleText
+                Spacer(minLength: 0)
+                legend
+            }
+            VStack(alignment: .leading, spacing: 4) {
                 titleText
                 legend
-            } else {
-                HStack(alignment: .top, spacing: 8) {
-                    titleText
-                    Spacer(minLength: 0)
-                    legend
-                }
             }
         }
     }
@@ -234,14 +234,58 @@ public struct ChartCard: View {
             }
         }
         .chartXAxis {
-            AxisMarks(values: .automatic(desiredCount: 3)) { _ in
+            AxisMarks(values: xTicks) { _ in
                 AxisGridLine().foregroundStyle(Theme.panelEdge.opacity(0.3))
-                AxisValueLabel(format: .dateTime.hour().minute(), centered: false)
+                AxisValueLabel(format: timeFormat, centered: true)
                     .font(.system(size: Theme.Layout.axisLabel, design: .rounded))
                     .foregroundStyle(Theme.label)
             }
         }
+        .background(
+            GeometryReader { proxy in
+                Color.clear.preference(key: PlotWidthKey.self, value: proxy.size.width)
+            }
+        )
+        .onPreferenceChange(PlotWidthKey.self) { plotWidth = $0 }
         .frame(minHeight: plotHeight)
+    }
+
+    /// How wide the card is, which decides how many time labels fit.
+    ///
+    /// Measured rather than assumed: the width comes from the grid, and the
+    /// grid's column width is a slider in the toolbar. A count fixed in the
+    /// source is right at exactly one card size.
+    @State private var plotWidth = 0.0
+
+    private struct PlotWidthKey: PreferenceKey {
+        static let defaultValue = 0.0
+        static func reduce(value: inout Double, nextValue: () -> Double) {
+            value = max(value, nextValue())
+        }
+    }
+
+    /// The labelled instants and their spacing — see `ChartAxis`, which is
+    /// where the arithmetic lives and where it is tested.
+    private var marks: ChartAxis.Marks {
+        let range = xRange
+        return ChartAxis.marks(
+            from: range.start, to: range.end,
+            maximumTicks: ChartAxis.maximumTicks(width: plotWidth)
+        )
+    }
+
+    private var xTicks: [Date] {
+        marks.times.map { Date(timeIntervalSince1970: $0) }
+    }
+
+    /// No AM/PM. A card shows at most ten minutes of history, so which half of
+    /// the day it is was never in question, and those two characters were most
+    /// of what made the labels collide.
+    private var timeFormat: Date.FormatStyle {
+        let base = Date.FormatStyle.dateTime
+            .hour(.twoDigits(amPM: .omitted))
+            .minute(.twoDigits)
+        return ChartAxis.showsSeconds(stride: marks.stride) ? base.second(.twoDigits) : base
     }
 
     /// The visible time span, as raw timestamps.

--- a/Sources/MonitorUI/DashboardView.swift
+++ b/Sources/MonitorUI/DashboardView.swift
@@ -292,7 +292,7 @@ public struct DashboardView: View {
                     // The metrics the card is *drawing*, not the group's whole
                     // membership: switch one direction off and the card stops
                     // being a pair.
-                    mirror: model.charts.mirror(for: series.map(\.descriptor.id))
+                    mirror: model.charts.mirror(for: series.map(\.descriptor))
                 )
                 card
                     .copyable {

--- a/Sources/MonitorUI/DashboardView.swift
+++ b/Sources/MonitorUI/DashboardView.swift
@@ -288,7 +288,11 @@ public struct DashboardView: View {
                     series: series,
                     window: window,
                     isUnavailable: group.metrics.allSatisfy(model.unavailable.contains),
-                    plotHeight: model.arrangement.chartHeight
+                    plotHeight: model.arrangement.chartHeight,
+                    // The metrics the card is *drawing*, not the group's whole
+                    // membership: switch one direction off and the card stops
+                    // being a pair.
+                    mirror: model.charts.mirror(for: series.map(\.descriptor.id))
                 )
                 card
                     .copyable {

--- a/Sources/MonitorUI/LayoutPreferencesStore.swift
+++ b/Sources/MonitorUI/LayoutPreferencesStore.swift
@@ -116,3 +116,34 @@ enum PanelArrangementStore {
         defaults.set(data, forKey: key)
     }
 }
+
+/// How the charts are drawn, kept beside the layout in the same domain.
+///
+/// Its own key, for the same reason the arrangement has one: `LayoutPreferences`
+/// is which cards exist and this is how one of them is drawn. A value a later
+/// version writes costs one of them and not both.
+enum ChartPreferencesStore {
+    static let key = "chart.preferences"
+
+    static func load(from defaults: UserDefaults = LayoutPreferencesStore.suite)
+        -> ChartPreferences
+    {
+        guard let data = defaults.data(forKey: key),
+              let stored = try? JSONDecoder().decode(ChartPreferences.self, from: data)
+        else {
+            return .default
+        }
+        return stored
+    }
+
+    static func save(
+        _ preferences: ChartPreferences,
+        to defaults: UserDefaults = LayoutPreferencesStore.suite
+    ) {
+        guard let data = try? JSONEncoder().encode(preferences) else {
+            log.error("Could not encode chart preferences")
+            return
+        }
+        defaults.set(data, forKey: key)
+    }
+}

--- a/Sources/MonitorUI/PreferencesView.swift
+++ b/Sources/MonitorUI/PreferencesView.swift
@@ -3,11 +3,12 @@ import SwiftUI
 
 /// The preferences window, opened with Cmd-, from the app menu.
 ///
-/// Two tabs: what the panel draws, and how often it is read. The tab bar was
-/// there when there was only one, because a `TabView` added later moves every
-/// control down by its height, and a preferences window that changes shape
-/// between versions is one people have to re-learn. The frame is fixed for the
-/// same reason: a settings window is not a document window.
+/// Three tabs: which cards there are, how they are drawn, and how often they
+/// are read. The tab bar was there when there was only one, because a `TabView`
+/// added later moves every control down by its height, and a preferences window
+/// that changes shape between versions is one people have to re-learn. The
+/// frame is fixed for the same reason: a settings window is not a document
+/// window.
 public struct PreferencesView: View {
     @Bindable private var model: AppModel
 
@@ -19,6 +20,8 @@ public struct PreferencesView: View {
         TabView {
             LayoutTab(model: model)
                 .tabItem { Label("Layout", systemImage: "square.grid.2x2") }
+            ChartsTab(model: model)
+                .tabItem { Label("Charts", systemImage: "chart.xyaxis.line") }
             SamplingTab(model: model)
                 .tabItem { Label("Sampling", systemImage: "timer") }
         }
@@ -172,6 +175,37 @@ struct LayoutTab: View {
             Spacer()
         }
         .padding(16)
+    }
+}
+
+/// How the charts are drawn, as opposed to which ones there are.
+///
+/// A separate tab from Layout because it is a different question. Layout is
+/// which cards exist; this is how one of them is drawn, and putting the two on
+/// one screen means reading a grid of checkboxes to find a switch that is not
+/// about any single row of it.
+struct ChartsTab: View {
+    @Bindable var model: AppModel
+
+    var body: some View {
+        Form {
+            Section {
+                Toggle("Mirror paired charts", isOn: $model.charts.mirrorsPairs)
+            } footer: {
+                Text(
+                    "Network in and disk read are drawn above the baseline, out "
+                        + "and written below it. Two directions of one thing "
+                        + "overlap when they both climb from zero, and the shape "
+                        + "of a transfer is easier to read when they cannot. "
+                        + "Both sides share one scale, so a busy download makes "
+                        + "a quiet upload look small — which is what it is."
+                )
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .formStyle(.grouped)
     }
 }
 

--- a/Tests/MonitorCoreTests/ChartAxisTests.swift
+++ b/Tests/MonitorCoreTests/ChartAxisTests.swift
@@ -1,0 +1,142 @@
+import Foundation
+@testable import MonitorCore
+import Testing
+
+@Suite("ChartAxis")
+struct ChartAxisTests {
+    /// The four windows the toolbar offers.
+    static let windows: [TimeInterval] = [60, 120, 300, 600]
+
+    @Test("A narrow card gets fewer labels than a wide one")
+    func countFollowsWidth() {
+        #expect(ChartAxis.maximumTicks(width: 260) < ChartAxis.maximumTicks(width: 600))
+    }
+
+    @Test("Never fewer than two labels, never more than five")
+    func countIsBounded() {
+        #expect(ChartAxis.maximumTicks(width: 0) == ChartAxis.fewest)
+        #expect(ChartAxis.maximumTicks(width: 10000) == ChartAxis.most)
+        #expect(ChartAxis.maximumTicks(width: .nan) == ChartAxis.fewest)
+    }
+
+    @Test("Every window on every card width gets at least two labels")
+    func neverFewerThanTwo() {
+        // The bug this pins: at five minutes on a narrow card the interval
+        // chosen was 300 s for a 300 s window, and a 300 s window inset at both
+        // ends contains a multiple of 300 only sometimes. The axis emptied
+        // itself. Swept across a whole window's worth of start offsets, because
+        // whether an absolute boundary falls inside depends on where the window
+        // happens to sit.
+        for span in Self.windows {
+            for width in [200.0, 260, 400, 600, 900] {
+                let maximum = ChartAxis.maximumTicks(width: width)
+                for offset in stride(from: 0.0, to: span, by: span / 20) {
+                    let marks = ChartAxis.marks(
+                        from: 1_700_000_000 + offset,
+                        to: 1_700_000_000 + offset + span,
+                        maximumTicks: maximum
+                    )
+                    #expect(marks.times.count >= ChartAxis.fewest)
+                }
+            }
+        }
+    }
+
+    @Test("The card's room is respected wherever two labels fit inside it")
+    func staysWithinTheRoom() {
+        // Not an absolute cap: two labels beat a tidy count, so a window that
+        // cannot show two within the room is allowed to go over. It must not go
+        // far over.
+        for span in Self.windows {
+            for width in [200.0, 260, 400, 600, 900] {
+                let maximum = ChartAxis.maximumTicks(width: width)
+                for offset in stride(from: 0.0, to: span, by: span / 20) {
+                    let marks = ChartAxis.marks(
+                        from: 1_700_000_000 + offset,
+                        to: 1_700_000_000 + offset + span,
+                        maximumTicks: maximum
+                    )
+                    #expect(marks.times.count <= max(maximum, ChartAxis.fewest) + 3)
+                }
+            }
+        }
+    }
+
+    @Test("The interval does not change as the window slides")
+    func strideIsStable() {
+        // The flicker this replaces: choosing the interval by counting the
+        // ticks it produced made a narrow ten-minute card flip between 300 s
+        // and 120 s as the window moved, so the labels jumped between two and
+        // five every few seconds.
+        for span in Self.windows {
+            for width in [200.0, 260, 400, 600, 900] {
+                let maximum = ChartAxis.maximumTicks(width: width)
+                let strides = Set(
+                    stride(from: 0.0, to: span, by: 1).map { offset in
+                        ChartAxis.marks(
+                            from: 1_700_000_000 + offset,
+                            to: 1_700_000_000 + offset + span,
+                            maximumTicks: maximum
+                        ).stride
+                    }
+                )
+                #expect(strides.count == 1)
+            }
+        }
+    }
+
+    @Test("Ticks land on round clock boundaries")
+    func onBoundaries() {
+        let marks = ChartAxis.marks(from: 1_000_007, to: 1_000_127, maximumTicks: 3)
+        #expect(!marks.times.isEmpty)
+        #expect(marks.times.allSatisfy {
+            $0.truncatingRemainder(dividingBy: marks.stride) == 0
+        })
+        #expect(ChartAxis.strides.contains(marks.stride))
+    }
+
+    @Test("A tick is an instant: the window slides, the tick does not")
+    func ticksAreInstants() {
+        // Ticks placed at fractions of the window keep still while their labels
+        // count up in real time. A gridline has to travel left with the data it
+        // marks and keep the time it names.
+        let early = ChartAxis.times(from: 0, to: 120, stride: 30)
+        let later = ChartAxis.times(from: 10, to: 130, stride: 30)
+        let shared = Set(early).intersection(later)
+        #expect(!shared.isEmpty)
+        #expect(shared.allSatisfy { $0.truncatingRemainder(dividingBy: 30) == 0 })
+        // And the window having moved on drops the tick that scrolled off.
+        #expect(!later.contains(where: { $0 < 10 }))
+    }
+
+    @Test("No tick sits against either edge of the window")
+    func insetFromTheEdges() {
+        // A label is centred on its tick, so one on the edge is half cut off.
+        let times = ChartAxis.times(from: 0, to: 600, stride: 60)
+        #expect(times.allSatisfy { $0 > 0 && $0 < 600 })
+    }
+
+    @Test("An empty or backwards window has no ticks")
+    func degenerateWindow() {
+        #expect(ChartAxis.times(from: 100, to: 100, stride: 30).isEmpty)
+        #expect(ChartAxis.times(from: 200, to: 100, stride: 30).isEmpty)
+        #expect(ChartAxis.times(from: 0, to: 120, stride: 0).isEmpty)
+        #expect(ChartAxis.marks(from: 100, to: 100, maximumTicks: 3).times.isEmpty)
+    }
+
+    @Test("The roundest interval that fits is the one chosen")
+    func prefersCoarse() {
+        // Ten minutes across five labels could be 15 s; it should be 120 s.
+        let marks = ChartAxis.marks(
+            from: 1_700_000_000, to: 1_700_000_600, maximumTicks: 5
+        )
+        #expect(marks.stride >= 120)
+    }
+
+    @Test("Seconds appear only when a stride lands twice inside one minute")
+    func secondsWhenNeeded() {
+        #expect(ChartAxis.showsSeconds(stride: 30))
+        #expect(!ChartAxis.showsSeconds(stride: 60))
+        #expect(!ChartAxis.showsSeconds(stride: 300))
+    }
+}

--- a/Tests/MonitorCoreTests/ChartPreferencesTests.swift
+++ b/Tests/MonitorCoreTests/ChartPreferencesTests.swift
@@ -2,24 +2,35 @@ import Foundation
 @testable import MonitorCore
 import Testing
 
-private let netIn = MetricID("net.bits.in")
-private let netOut = MetricID("net.bits.out")
-private let diskRead = MetricID("disk.bytes.read")
-private let diskWritten = MetricID("disk.bytes.written")
+private func metric(
+    _ id: String, _ name: String, group: String, direction: MetricDirection? = nil
+) -> MetricDescriptor {
+    MetricDescriptor(
+        id: MetricID(id), name: name, group: group, unit: .bitsPerSecond,
+        direction: direction
+    )
+}
+
+private let netIn = metric("net.bits.in", "In", group: "Network", direction: .inbound)
+private let netOut = metric("net.bits.out", "Out", group: "Network", direction: .outbound)
+private let diskRead = metric("disk.bytes.read", "Read", group: "Disk", direction: .inbound)
+private let diskWritten = metric(
+    "disk.bytes.written", "Write", group: "Disk", direction: .outbound
+)
 
 @Suite("ChartMirror")
 struct ChartMirrorTests {
     @Test("A card drawing both directions is a pair")
     func recognisesPairs() {
-        #expect(ChartMirror.pair(for: [netIn, netOut])?.up == netIn)
-        #expect(ChartMirror.pair(for: [diskRead, diskWritten])?.down == diskWritten)
+        #expect(ChartMirror.pair(for: [netIn, netOut])?.up == netIn.id)
+        #expect(ChartMirror.pair(for: [diskRead, diskWritten])?.down == diskWritten.id)
     }
 
-    @Test("Order on the card does not decide which way is up")
+    @Test("Inbound is up whichever order the card lists them in")
     func orderIndependent() {
         // The card lists its series in layout order, which the reader can
         // change. Which one points down is not that list's business.
-        #expect(ChartMirror.pair(for: [netOut, netIn])?.up == netIn)
+        #expect(ChartMirror.pair(for: [netOut, netIn])?.up == netIn.id)
     }
 
     @Test("One direction on its own is not a pair")
@@ -28,26 +39,41 @@ struct ChartMirrorTests {
         // empty top half, which reads as a bug rather than as a choice.
         #expect(ChartMirror.pair(for: [netIn]) == nil)
         #expect(ChartMirror.pair(for: [netOut]) == nil)
-    }
-
-    @Test("A card that is not two opposite directions is not a pair")
-    func notAPair() {
-        let cpu = MetricID("cpu.total")
-        let user = MetricID("cpu.user")
-        #expect(ChartMirror.pair(for: [cpu, user]) == nil)
-        // Two sensors sharing a card are two readings, not two directions.
         #expect(ChartMirror.pair(for: []) == nil)
     }
 
-    @Test("Halves of different pairs are not a pair")
-    func crossedPair() {
-        #expect(ChartMirror.pair(for: [netIn, diskWritten]) == nil)
+    @Test("Metrics without a declared direction never pair")
+    func noDirection() {
+        // Read and write latency are the case this protects: two measurements
+        // of the same kind, not two directions of one flow.
+        let readLatency = metric("disk.latency.read", "Read", group: "Disk Latency")
+        let writeLatency = metric("disk.latency.write", "Write", group: "Disk Latency")
+        #expect(ChartMirror.pair(for: [readLatency, writeLatency]) == nil)
+    }
+
+    @Test("Two of the same direction are not a pair")
+    func sameDirectionTwice() {
+        #expect(ChartMirror.pair(for: [netIn, diskRead]) == nil)
     }
 
     @Test("A card carrying a pair and something else is not mirrored")
     func pairPlusExtra() {
         // Three traces and only two of them opposite has no honest baseline.
         #expect(ChartMirror.pair(for: [netIn, netOut, diskRead]) == nil)
+    }
+
+    @Test("Every source that declares one direction declares the other")
+    func directionsComeInPairs() {
+        // A group with an inbound metric and no outbound one can never mirror,
+        // which is a declaration somebody half finished rather than a choice.
+        let all = SourceRegistryFixture.descriptors
+        let directed = all.filter { $0.direction != nil }
+        #expect(!directed.isEmpty)
+        for group in Set(directed.map(\.group)) {
+            let members = directed.filter { $0.group == group }
+            #expect(members.count(where: { $0.direction == .inbound }) == 1)
+            #expect(members.count(where: { $0.direction == .outbound }) == 1)
+        }
     }
 }
 
@@ -63,7 +89,7 @@ struct ChartPreferencesTests {
     func onlyPairsMirror() {
         let preferences = ChartPreferences(mirrorsPairs: true)
         #expect(preferences.mirror(for: [netIn, netOut]) != nil)
-        #expect(preferences.mirror(for: [MetricID("cpu.total")]) == nil)
+        #expect(preferences.mirror(for: [netIn]) == nil)
     }
 
     @Test("Round-trips through Codable")
@@ -78,4 +104,26 @@ struct ChartPreferencesTests {
         let data = Data("{}".utf8)
         #expect(try JSONDecoder().decode(ChartPreferences.self, from: data) == .default)
     }
+}
+
+/// The directions the real sources declare, written out here because
+/// `MonitorCore` cannot see `MonitorSources` — it is the layer below it.
+///
+/// A copy, so it can go stale. `MonitorSourcesTests` checks the real registry
+/// against the same rule, which is the test that cannot.
+enum SourceRegistryFixture {
+    static let descriptors = [
+        netIn, netOut, diskRead, diskWritten,
+        metric("disk.ops.read", "Reads", group: "Disk Ops", direction: .inbound),
+        metric("disk.ops.write", "Writes", group: "Disk Ops", direction: .outbound),
+        metric("net.packets.in", "Packets in", group: "Network Packets", direction: .inbound),
+        metric(
+            "net.packets.out", "Packets out", group: "Network Packets", direction: .outbound
+        ),
+        metric("memory.pagein.rate", "Page in", group: "Memory Paging", direction: .inbound),
+        metric(
+            "memory.pageout.rate", "Page out", group: "Memory Paging", direction: .outbound
+        ),
+        metric("cpu.total", "Total", group: "CPU"),
+    ]
 }

--- a/Tests/MonitorCoreTests/ChartPreferencesTests.swift
+++ b/Tests/MonitorCoreTests/ChartPreferencesTests.swift
@@ -1,0 +1,81 @@
+import Foundation
+@testable import MonitorCore
+import Testing
+
+private let netIn = MetricID("net.bits.in")
+private let netOut = MetricID("net.bits.out")
+private let diskRead = MetricID("disk.bytes.read")
+private let diskWritten = MetricID("disk.bytes.written")
+
+@Suite("ChartMirror")
+struct ChartMirrorTests {
+    @Test("A card drawing both directions is a pair")
+    func recognisesPairs() {
+        #expect(ChartMirror.pair(for: [netIn, netOut])?.up == netIn)
+        #expect(ChartMirror.pair(for: [diskRead, diskWritten])?.down == diskWritten)
+    }
+
+    @Test("Order on the card does not decide which way is up")
+    func orderIndependent() {
+        // The card lists its series in layout order, which the reader can
+        // change. Which one points down is not that list's business.
+        #expect(ChartMirror.pair(for: [netOut, netIn])?.up == netIn)
+    }
+
+    @Test("One direction on its own is not a pair")
+    func halfPair() {
+        // Otherwise switching Network Out off leaves a trace hanging below an
+        // empty top half, which reads as a bug rather than as a choice.
+        #expect(ChartMirror.pair(for: [netIn]) == nil)
+        #expect(ChartMirror.pair(for: [netOut]) == nil)
+    }
+
+    @Test("A card that is not two opposite directions is not a pair")
+    func notAPair() {
+        let cpu = MetricID("cpu.total")
+        let user = MetricID("cpu.user")
+        #expect(ChartMirror.pair(for: [cpu, user]) == nil)
+        // Two sensors sharing a card are two readings, not two directions.
+        #expect(ChartMirror.pair(for: []) == nil)
+    }
+
+    @Test("Halves of different pairs are not a pair")
+    func crossedPair() {
+        #expect(ChartMirror.pair(for: [netIn, diskWritten]) == nil)
+    }
+
+    @Test("A card carrying a pair and something else is not mirrored")
+    func pairPlusExtra() {
+        // Three traces and only two of them opposite has no honest baseline.
+        #expect(ChartMirror.pair(for: [netIn, netOut, diskRead]) == nil)
+    }
+}
+
+@Suite("ChartPreferences")
+struct ChartPreferencesTests {
+    @Test("Mirroring is off until it is switched on")
+    func offByDefault() {
+        #expect(ChartPreferences.default.mirrorsPairs == false)
+        #expect(ChartPreferences.default.mirror(for: [netIn, netOut]) == nil)
+    }
+
+    @Test("Switched on, a pair mirrors and everything else does not")
+    func onlyPairsMirror() {
+        let preferences = ChartPreferences(mirrorsPairs: true)
+        #expect(preferences.mirror(for: [netIn, netOut]) != nil)
+        #expect(preferences.mirror(for: [MetricID("cpu.total")]) == nil)
+    }
+
+    @Test("Round-trips through Codable")
+    func codable() throws {
+        let preferences = ChartPreferences(mirrorsPairs: true)
+        let data = try JSONEncoder().encode(preferences)
+        #expect(try JSONDecoder().decode(ChartPreferences.self, from: data) == preferences)
+    }
+
+    @Test("A stored value written before a setting existed still decodes")
+    func decodesMissingKeys() throws {
+        let data = Data("{}".utf8)
+        #expect(try JSONDecoder().decode(ChartPreferences.self, from: data) == .default)
+    }
+}

--- a/Tests/MonitorSourcesTests/SourceTests.swift
+++ b/Tests/MonitorSourcesTests/SourceTests.swift
@@ -15,6 +15,31 @@ struct SourceTests {
         #expect(all.count == Set(all).count, "two metrics share an id; history would collide")
     }
 
+    @Test("a declared direction always has its opposite in the same group")
+    func directionsComeInPairs() {
+        // A group with an inbound metric and no outbound one can never mirror,
+        // which is a declaration somebody half finished rather than a choice.
+        // Checked against the real registry, which `MonitorCoreTests` cannot
+        // see — it is the layer below this one.
+        let directed = SourceRegistry.allDescriptors.filter { $0.direction != nil }
+        #expect(!directed.isEmpty)
+        for group in Set(directed.map(\.group)) {
+            let members = directed.filter { $0.group == group }
+            #expect(
+                members.count(where: { $0.direction == .inbound }) == 1,
+                "\(group) needs exactly one inbound metric"
+            )
+            #expect(
+                members.count(where: { $0.direction == .outbound }) == 1,
+                "\(group) needs exactly one outbound metric"
+            )
+            #expect(
+                ChartMirror.pair(for: members) != nil,
+                "\(group) declares directions but does not form a pair"
+            )
+        }
+    }
+
     @Test("CPU load is a fraction, and the first read is only a baseline")
     func cpu() throws {
         let source = CPUSource()

--- a/Tests/MonitorUITests/AppModelTests.swift
+++ b/Tests/MonitorUITests/AppModelTests.swift
@@ -217,6 +217,22 @@ struct AppModelTests {
         #expect(second.arrangement.gaugeSize == PanelSize.gauge.initial)
     }
 
+    /// Unlike the arrangement, this one saves on change: it is a checkbox, so
+    /// there is no gesture to end.
+    @Test("the chart setting is written the moment it changes")
+    func chartPreferencesPersist() throws {
+        let defaults = try #require(UserDefaults(suiteName: Self.domain))
+        defaults.removePersistentDomain(forName: Self.domain)
+        let sources = [StubSource(id: "disk", group: "Disk", names: ["Read"])]
+
+        let first = AppModel(sources: sources, defaults: defaults)
+        #expect(first.charts.mirrorsPairs == false)
+        first.charts.mirrorsPairs = true
+
+        let second = AppModel(sources: sources, defaults: defaults)
+        #expect(second.charts.mirrorsPairs)
+    }
+
     @Test("restoring the arrangement puts everything back and writes it")
     func restoreArrangement() throws {
         let defaults = try #require(UserDefaults(suiteName: Self.domain))

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -184,10 +184,10 @@ above the baseline, the other below. Zero moves to the middle of the plot.
 Upload and download become two shapes that cannot be confused, and the shape of
 a transfer — a burst up, a long tail down — is readable without reading the key.
 
-Two cards are pairs: Network (in up, out down) and Disk (read up, written down).
-In above out and read above written, because the first is the one that arrives,
-and download above upload is how every meter of this kind has drawn it since
-modem lights.
+Five cards are pairs: Network, Network Packets, Disk, Disk Ops and Memory
+Paging. Inbound above outbound in every case — in above out, read above written,
+page in above page out — because the first is the one that arrives, and download
+above upload is how every meter of this kind has drawn it since modem lights.
 
 ### Only the picture flips
 
@@ -212,13 +212,31 @@ metrics of one. Switch Network Out off in the Layout tab and the card stops
 mirroring rather than leaving a single trace hanging below an empty top half,
 which reads as a bug rather than as a choice.
 
-### Where the table lives
+### Pairing is declared, not tabulated
 
-`ChartMirror.pairs` in `MonitorCore`, not a field on `MetricDescriptor`. A
-descriptor says what a metric *is*, and it is declared by the source that reads
-it; "this one points down" is a statement about a picture, and a disk reader has
-no business making it. A separate table also means a source can be added without
-deciding whether it has an opposite.
+A metric says which way it runs. `MetricDescriptor.direction` is `.inbound`,
+`.outbound`, or nil for the great majority that are not one direction of
+anything. A card is a pair when it draws exactly one inbound series and one
+outbound one, so there is no table of metric ids anywhere and a source added
+later gets mirroring without this being told it exists.
+
+The first version *was* a table, on the reasoning that "this one points down" is
+a statement about a picture and a disk reader has no business making it. That
+reasoning was right about the wrong thing: which way a byte is travelling is a
+fact about the metric, and only the decision to draw one below a line is about
+the picture. The fact belongs on the descriptor; the picture stays in
+`ChartPreferences`.
+
+Read and write *latency* are the instructive case. They share a card and look
+like a pair, and neither declares a direction, so the card never mirrors — two
+measurements of the same kind are not two directions of one flow, and drawing a
+slow write below the line would say a slow write is the opposite of a slow read.
+
+Two tests hold the declaration together: every group that declares a direction
+must have exactly one metric of each, checked against the real registry in
+`MonitorSourcesTests`. A group with an inbound metric and no outbound one can
+never mirror, which is a declaration somebody half finished rather than a
+choice.
 
 `ChartPreferences` is its own type beside `LayoutPreferences` for the matching
 reason: **`LayoutPreferences` is which cards exist, `ChartPreferences` is how one
@@ -228,6 +246,70 @@ checkbox has no gesture to end.
 
 Off by default. Mirroring is the clearer way to read throughput, but a chart
 that changes shape under somebody on upgrade is worse than one they switch on.
+
+## The time axis
+
+Three things have to be true of the labels along the bottom, and the first two
+versions of this got one of them at the expense of another.
+
+**A tick is an instant, not a position.** 10:42:00 belongs at 10:42:00. As the
+window scrolls that gridline travels left, keeps its label, and eventually
+leaves. Ticks placed at fractions of the window do the opposite: the gridline
+stands still while the time under it counts up in real time, which is a clock,
+not an axis.
+
+**Never more labels than fit.** `.automatic(desiredCount:)` treats the count as
+a hint and chooses its own boundaries, so on the narrowest column the grid makes
+the labels collided and the last one ran off the edge as `10:34…`.
+
+**Never fewer than two.** One lonely label says nothing about the span you are
+looking at, and none says less.
+
+`ChartAxis` in `MonitorCore` holds the arithmetic, which is why it is testable
+without a window.
+
+### The interval comes from the window's length, never its position
+
+The ticks are absolute instants, so how many land inside the window depends on
+where the window happens to sit — the same interval yields three, two, one or
+none as it slides. An early version chose the interval by counting what it
+actually produced, which meant a narrow ten-minute card flipped between 300 s
+and 120 s every few seconds and the labels jumped between two and five.
+
+So the interval is chosen from the length alone: the coarsest rung of the ladder
+(1, 2, 5, 10, 15, 30 s, then 1, 2, 5, 10 min) that fits two of itself in the
+window, or a finer one where the card has room for more. The count still drifts
+by one as a tick scrolls off the edge, which is correct and invisible. The
+interval does not move.
+
+Where the two rules conflict — a narrow card showing five minutes cannot have
+both two labels and no more than two — **two labels win**. A bare axis is worse
+than a tight one.
+
+### Details
+
+Ticks are held 6% in from each edge, because a label is centred on its tick and
+one against the edge is half cut off. A tick inside that band is dropped rather
+than nudged: moving it would put it somewhere that is not the time it claims.
+
+Seconds appear only when the interval is under a minute, where two labels would
+otherwise land inside the same minute and read as the same time twice.
+
+No AM/PM at any width. A card shows ten minutes of history at most, so which
+half of the day it is was never in question, and those two characters were most
+of what made the labels collide.
+
+## Title and legend: fit, not count
+
+A card puts its legend beside the title when it fits and underneath when it does
+not, and `ViewThatFits` decides by proposing the column's width.
+
+It used to decide by counting series, which cannot work: a count does not know
+how wide the words are. "Memory Paging" beside "Page in 19/s  Page out 4.0/s" is
+two series and does not fit; "GPU" beside "GPU 0%  VRAM 1.9 GB" is two series
+and does. The title is `fixedSize` — it must not truncate — so a header that did
+not fit pushed the card wider than its grid column, which stretched the whole
+row and ran the legend out through the card's edge.
 
 ## Copying a card
 

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -173,6 +173,62 @@ not — the app still writes no *history* to disk and still does not link
 `MonitorStore`. The argument in `storage.md` is about a sample every half second
 forever, not about a checkbox written when somebody ticks it.
 
+## Mirrored in/out charts
+
+Network In and Network Out share a card so they can be read against each other,
+and drawn both upward from zero they overlap: at a glance you cannot tell which
+trace is which without reading the legend.
+
+Switch **Mirror paired charts** on in the Charts tab and one direction goes
+above the baseline, the other below. Zero moves to the middle of the plot.
+Upload and download become two shapes that cannot be confused, and the shape of
+a transfer — a burst up, a long tail down — is readable without reading the key.
+
+Two cards are pairs: Network (in up, out down) and Disk (read up, written down).
+In above out and read above written, because the first is the one that arrives,
+and download above upload is how every meter of this kind has drawn it since
+modem lights.
+
+### Only the picture flips
+
+The sample in the buffer stays positive. A rate is never negative, and a
+negative must not reach the formatter, the gauges, or the CSV export — `plotted`
+in `ChartCard` negates at draw time and nothing else knows. The axis labels read
+as magnitudes on both sides too: below the line is a *direction*, not a negative
+quantity, and `-50 MB/s` is not a rate anything can achieve.
+
+### One shared scale
+
+The domain is symmetric about zero, and its half-range is the larger of the two
+peaks. So a card where download dwarfs upload looks nearly flat on the quiet
+side. That is honest, and it is the whole reason the two share a card: a scale
+per direction would make a 30 kbit/s upload and a 300 Mbit/s download draw the
+same shape.
+
+### Both halves or neither
+
+`ChartMirror.pair(for:)` returns a pair only when the card draws exactly the two
+metrics of one. Switch Network Out off in the Layout tab and the card stops
+mirroring rather than leaving a single trace hanging below an empty top half,
+which reads as a bug rather than as a choice.
+
+### Where the table lives
+
+`ChartMirror.pairs` in `MonitorCore`, not a field on `MetricDescriptor`. A
+descriptor says what a metric *is*, and it is declared by the source that reads
+it; "this one points down" is a statement about a picture, and a disk reader has
+no business making it. A separate table also means a source can be added without
+deciding whether it has an opposite.
+
+`ChartPreferences` is its own type beside `LayoutPreferences` for the matching
+reason: **`LayoutPreferences` is which cards exist, `ChartPreferences` is how one
+is drawn.** Separate keys, so a value a later version writes costs one and not
+both. It saves on change, like the layout and unlike the arrangement — a
+checkbox has no gesture to end.
+
+Off by default. Mirroring is the clearer way to read throughput, but a chart
+that changes shape under somebody on upgrade is worse than one they switch on.
+
 ## Copying a card
 
 Right-click any tile — a chart card or a dial — for two items.


### PR DESCRIPTION
## Summary

- **Mirror paired charts**, a new checkbox on a new **Charts** tab in preferences. On, inbound draws above the baseline and outbound below it. Off by default — a chart that changes shape under somebody on upgrade is worse than one they switch on.
- **A metric declares which way it runs.** `MetricDescriptor.direction` is `.inbound`, `.outbound`, or nil for the great majority that are not one direction of anything. A card is a pair when it draws exactly one of each, so five groups mirror — Network, Network Packets, Disk, Disk Ops, Memory Paging — and a source added later gets it for free. Read and write *latency* deliberately declare nothing: two measurements of the same kind are not two directions of one flow.
- **Only the picture flips.** The stored sample stays positive, so `ChartCard.plotted` negates at draw time and the legend, `Format`, the gauges and the CSV export from #25 never see a negative. Axis labels are magnitudes on both sides.
- **One symmetric scale**, half-range set by the larger of the two peaks. A card where download dwarfs upload looks nearly flat on the quiet side; that is the honest picture, and the reason the two share a card at all.
- **Both halves or neither** — switching one direction off in Layout returns the card to drawing upward instead of leaving a trace under an empty top half.

### Also here: the time axis, found while checking the above

- **A tick is an instant.** 10:42:00 sits at 10:42:00 and scrolls left keeping its label. Ticks at fractions of the window do the opposite — the gridline stands still while the time under it counts up in real time.
- **Never more labels than fit, and never fewer than two**, the second winning where they conflict. `.automatic(desiredCount:)` treated the count as a hint and chose boundaries that collided and ran off the edge as `10:34…`.
- **The interval comes from the window's length alone, never its position.** The ticks are absolute instants, so how many land inside depends on where the window sits; choosing the interval by counting what it produced made a narrow ten-minute card flip between 300 s and 120 s as it slid, jumping the labels between two and five. `ChartAxis` in `MonitorCore` holds the arithmetic so it is testable without a window.
- No AM/PM at any width; seconds only when the interval is under a minute.
- **A card's header fits rather than counts.** `ViewThatFits` puts the legend beside the title where there is room and under it where there is not. A count of series cannot know how wide the words are, and since the title is `fixedSize` a header that did not fit pushed the card past its grid column, stretched the row, and ran the legend out through the card's edge.

Closes #27

## Test plan

- [x] `swift build && swift test` — 163 tests in 19 suites
- [x] `swift build -c release`
- [x] `swiftformat Sources Tests --lint --cache ignore` — clean
- [x] **Checked on screen** in `swift run monitor`: all five pairs mirror; unticking one direction returns the card to drawing upward; axis labels read as magnitudes on both sides; the time labels are legible, evenly spaced and move with the data at every window and card width; the previously stretched cards size correctly
- [x] Axis behaviour swept in tests across all four windows × five card widths × a full window of start offsets: at least two labels always, and exactly one interval per window (no flicker)

https://claude.ai/code/session_01UPbN2SqYq8t2vcx2YWQTcs