### PR TITLE
Double-click a tile to zoom it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,6 +207,17 @@ are no component-level AGENTS.md files.
   is the quiet kind of wrong. A series that missed a tick leaves an **empty
   field, never a zero** — same reason a failed source greys a card out instead
   of drawing a flat line.
+- **A tile zooms in a sheet, and the zoom is view state.** Double-click any card
+  or dial for a temporary window over the panel; Escape, Done or another
+  double-click closes it. One `@State` value on `DashboardView` holds it, so
+  opening a second tile closes the first by construction. It must **never** go
+  into `PanelArrangement` — a zoom does not survive a relaunch and does not
+  resize anything stored. Sizes come from `ZoomLayout`, a fraction of the
+  measured panel, bounded at both ends. Sampling does not stop while it is open;
+  the buffer is shared, so the panel underneath comes back without a gap. A tile
+  now carries three gestures — drag to reorder, right-click to copy,
+  double-click to zoom — and that they do not fight is checked by running
+  `swift run monitor`, never by a test.
 - **The layout is chosen per metric, in preferences.** Cmd-, opens a tabbed
   window. Its **Charts** tab holds how cards are *drawn* (mirroring), which is
   a different question from which cards there are. Its **Layout** tab lists

--- a/Sources/MonitorUI/DashboardView.swift
+++ b/Sources/MonitorUI/DashboardView.swift
@@ -25,6 +25,15 @@ public struct DashboardView: View {
     /// Which gap is currently showing an insertion line, if any. One value for
     /// the whole panel: exactly one gap can be the target at a time.
     @State private var dropTarget: DropTarget?
+    /// Which tile is zoomed, if any. One value for the whole panel: zoom is a
+    /// mode the panel is in, not a property a tile carries, so opening a second
+    /// tile closes the first without anybody having to close it.
+    ///
+    /// `@State`, deliberately. A zoom is a view state and must not outlive the
+    /// session or resize anything stored — the tile comes back the size it was.
+    @State private var zoomed: PanelTile?
+    /// The panel's own size, which is what the zoom is a fraction of.
+    @State private var panelSize = CGSize.zero
 
     /// Edge length of one dial, and so the height of the gauge wall.
     ///
@@ -80,9 +89,69 @@ public struct DashboardView: View {
             .padding(Theme.Layout.pagePadding)
         }
         .background(Theme.background)
+        .background(
+            GeometryReader { proxy in
+                Color.clear.preference(key: PanelSizeKey.self, value: proxy.size)
+            }
+        )
+        .onPreferenceChange(PanelSizeKey.self) { panelSize = $0 }
         .toolbar { toolbar }
         .onAppear { model.start() }
         .onDisappear { model.stop() }
+        // A sheet rather than a second window: it is temporary, Escape already
+        // means dismiss, and nothing has to decide what a stray window does on
+        // relaunch. The sampler keeps running underneath.
+        .sheet(item: $zoomed) { tile in
+            zoom(tile)
+        }
+    }
+
+    /// Carries the panel's size up so the zoom can be a fraction of it.
+    private struct PanelSizeKey: PreferenceKey {
+        static let defaultValue = CGSize.zero
+        static func reduce(value: inout CGSize, nextValue: () -> CGSize) {
+            let next = nextValue()
+            value = next == .zero ? value : next
+        }
+    }
+
+    // MARK: - Zoom
+
+    /// The zoomed tile, drawn from the model rather than handed over at
+    /// double-click time. A card frozen at the moment it was opened would stop
+    /// updating, which is the opposite of what a bigger chart is for.
+    @ViewBuilder
+    private func zoom(_ tile: PanelTile) -> some View {
+        let size = ZoomLayout.size(panel: panelSize)
+        ZoomFrame(title: zoomTitle(tile), size: size, close: { zoomed = nil }) {
+            switch tile {
+            case let .chart(name):
+                if let group = zoomedGroup(named: name) {
+                    chartCard(group, plotHeight: ZoomLayout.plotHeight(in: size))
+                }
+            case let .gauge(id):
+                let metric = MetricID(id)
+                if let descriptor = model.descriptor(metric) {
+                    let edge = ZoomLayout.dialEdge(in: size)
+                    gaugeTile(metric, descriptor, size: edge)
+                        .frame(width: edge)
+                        .frame(maxWidth: .infinity)
+                }
+            }
+        }
+    }
+
+    private func zoomTitle(_ tile: PanelTile) -> String {
+        switch tile {
+        case let .chart(name): name
+        case let .gauge(id):
+            model.descriptor(MetricID(id)).map(gaugeTitle) ?? id
+        }
+    }
+
+    /// The group behind a zoomed card, from either section.
+    private func zoomedGroup(named name: String) -> (name: String, metrics: [MetricID])? {
+        (model.performanceGroups + model.sensorGroups).first { $0.name == name }
     }
 
     // MARK: - Gauges
@@ -121,7 +190,7 @@ public struct DashboardView: View {
         ) {
             ForEach(gaugeMetrics, id: \.self) { metric in
                 if let descriptor = model.descriptor(metric) {
-                    let dial = gaugeTile(metric, descriptor)
+                    let dial = gaugeTile(metric, descriptor, size: gaugeSize)
                     dial
                         .copyable {
                             CSVExport.text(
@@ -133,6 +202,7 @@ public struct DashboardView: View {
                         .reorderable(
                             .gauge(metric.rawValue), target: $dropTarget, onDrop: dropGauge
                         )
+                        .zoomable(.gauge(metric.rawValue), zoomed: $zoomed)
                 }
             }
         }
@@ -221,7 +291,9 @@ public struct DashboardView: View {
     /// A function rather than written inline because the copy needs the same
     /// picture a second time — the tile in the wall carries the drag machinery,
     /// and the copy wants only the dial.
-    private func gaugeTile(_ metric: MetricID, _ descriptor: MetricDescriptor) -> some View {
+    private func gaugeTile(
+        _ metric: MetricID, _ descriptor: MetricDescriptor, size: Double
+    ) -> some View {
         VStack(spacing: 2) {
             GaugeView(
                 title: gaugeTitle(descriptor),
@@ -239,7 +311,7 @@ public struct DashboardView: View {
             // face, where at 130pt across "Network Out" ran into the ticks.
             Text(gaugeTitle(descriptor).uppercased())
                 .font(.system(
-                    size: Theme.Layout.gaugeCaptionSize(forGauge: gaugeSize),
+                    size: Theme.Layout.gaugeCaptionSize(forGauge: size),
                     weight: .medium,
                     design: .rounded
                 ))
@@ -283,17 +355,8 @@ public struct DashboardView: View {
                 // let a tick land in between and hand back a CSV that does not
                 // match the chart it came from.
                 let series = series(of: group)
-                let card = ChartCard(
-                    title: group.name,
-                    series: series,
-                    window: window,
-                    isUnavailable: group.metrics.allSatisfy(model.unavailable.contains),
-                    plotHeight: model.arrangement.chartHeight,
-                    // The metrics the card is *drawing*, not the group's whole
-                    // membership: switch one direction off and the card stops
-                    // being a pair.
-                    mirror: model.charts.mirror(for: series.map(\.descriptor)),
-                    stacked: model.charts.stack(for: series.map(\.descriptor))
+                let card = chartCard(
+                    group, series: series, plotHeight: model.arrangement.chartHeight
                 )
                 card
                     .copyable {
@@ -304,8 +367,31 @@ public struct DashboardView: View {
                     .reorderable(.chart(group.name), target: $dropTarget) { dragged, on, edge in
                         dropChart(dragged, on: on, edge: edge, in: section)
                     }
+                    .zoomable(.chart(group.name), zoomed: $zoomed)
             }
         }
+    }
+
+    /// One card, at whichever plot height the caller wants — the panel's stored
+    /// height in the grid, and as much of the sheet as is left in the zoom.
+    private func chartCard(
+        _ group: (name: String, metrics: [MetricID]),
+        series: [(descriptor: MetricDescriptor, points: [Sample])]? = nil,
+        plotHeight: Double
+    ) -> ChartCard {
+        let drawn = series ?? self.series(of: group)
+        return ChartCard(
+            title: group.name,
+            series: drawn,
+            window: window,
+            isUnavailable: group.metrics.allSatisfy(model.unavailable.contains),
+            plotHeight: plotHeight,
+            // The metrics the card is *drawing*, not the group's whole
+            // membership: switch one direction off and the card stops being a
+            // pair.
+            mirror: model.charts.mirror(for: drawn.map(\.descriptor)),
+            stacked: model.charts.stack(for: drawn.map(\.descriptor))
+        )
     }
 
     /// The series behind one card, in the order the card draws them.

--- a/Sources/MonitorUI/ZoomedCard.swift
+++ b/Sources/MonitorUI/ZoomedCard.swift
@@ -1,0 +1,127 @@
+import MonitorCore
+import SwiftUI
+
+/// Double-click a tile to read it properly.
+///
+/// The panel is a wall of tiles sized to be glanced at. When one of them is the
+/// reason you opened the app you want it big, and the size sliders are the
+/// wrong tool: they resize *every* card and have to be put back afterwards.
+///
+/// The zoom is a temporary window over the panel — a sheet — and Escape closes
+/// it. That leaves the toolbar's history picker and the sampling rate behind
+/// it, which is the one thing the sheet costs; what it buys is that the zoom
+/// cannot be forgotten about. Nothing stops sampling while it is open: the
+/// buffer is shared, so the panel underneath keeps filling and comes back
+/// without a gap.
+///
+/// It is a mode the panel is in, not a property a tile carries. One `@State`
+/// value on the dashboard holds it, so opening a second tile closes the first
+/// by construction, and it is `@State` rather than `PanelArrangement` because a
+/// zoom must not outlive the session or resize anything stored.
+enum ZoomLayout {
+    /// How much of the panel the zoom covers.
+    ///
+    /// Not the whole window. A margin of panel showing around the edge is what
+    /// says this is a temporary thing over the dashboard rather than a new
+    /// screen you have navigated to.
+    static let widthFraction = 0.86
+    static let heightFraction = 0.82
+
+    /// Used until the panel has been measured, and for a window so small that a
+    /// fraction of it is unreadable.
+    static let smallest = CGSize(width: 520, height: 360)
+    /// A zoom past this is no longer reading a chart, it is stretching one.
+    static let largest = CGSize(width: 1400, height: 900)
+
+    /// The sheet's size, from the panel behind it.
+    static func size(panel: CGSize) -> CGSize {
+        CGSize(
+            width: bounded(
+                panel.width * widthFraction, smallest.width, largest.width
+            ),
+            height: bounded(
+                panel.height * heightFraction, smallest.height, largest.height
+            )
+        )
+    }
+
+    /// Height for the plot area inside a zoomed chart.
+    ///
+    /// The card's own header, padding and the sheet's title bar come off the
+    /// top; what is left is the picture. A minimum, like everywhere else the
+    /// plot height is set, so a short window scrolls rather than squeezing the
+    /// chart out of the card.
+    static func plotHeight(in size: CGSize) -> Double {
+        max(PanelSize.chartHeight.minimum, size.height - chrome)
+    }
+
+    /// Edge length for a zoomed dial. Square, so the smaller side decides, and
+    /// the caption under it needs a little more room than the chrome.
+    static func dialEdge(in size: CGSize) -> Double {
+        max(PanelSize.gauge.minimum, min(size.width, size.height) - chrome)
+    }
+
+    /// The title bar, the card's header and legend, and the padding around
+    /// both. Measured rather than derived: the legend wraps, so this is the
+    /// height at which a two-line legend still leaves a chart worth looking at.
+    private static let chrome = 140.0
+
+    private static func bounded(_ value: Double, _ low: Double, _ high: Double) -> Double {
+        min(max(value, low), high)
+    }
+}
+
+/// A tile is its own identity, so `sheet(item:)` can hold one.
+extension PanelTile: Identifiable {
+    var id: String { encoded }
+}
+
+extension View {
+    /// Makes a tile open the zoom when it is double-clicked.
+    ///
+    /// A tile already carries a left-drag to reorder and a right-click to copy.
+    /// A count-2 tap gesture is the one that does not fight them: `.draggable`
+    /// claims the press only once the pointer moves, and the context menu is a
+    /// separate button.
+    func zoomable(_ tile: PanelTile, zoomed: Binding<PanelTile?>) -> some View {
+        onTapGesture(count: 2) { zoomed.wrappedValue = tile }
+    }
+}
+
+/// The frame the zoomed tile sits in: a title, a way out, and the tile.
+///
+/// The Done button carries `cancelAction`, which is what makes Escape close the
+/// sheet. A sheet with no cancel action swallows Escape, and a zoom you cannot
+/// dismiss with the key everyone reaches for is worse than no zoom.
+struct ZoomFrame<Content: View>: View {
+    let title: String
+    let size: CGSize
+    let close: () -> Void
+    @ViewBuilder let content: () -> Content
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Theme.Layout.gridSpacing) {
+            HStack {
+                Text(title)
+                    .font(.system(
+                        size: Theme.Layout.cardTitle + 3,
+                        weight: .semibold,
+                        design: .rounded
+                    ))
+                    .foregroundStyle(Theme.readout)
+                Spacer(minLength: 12)
+                Button("Done", action: close)
+                    .keyboardShortcut(.cancelAction)
+            }
+            content()
+            Spacer(minLength: 0)
+        }
+        .padding(Theme.Layout.pagePadding)
+        .frame(width: size.width, height: size.height)
+        .background(Theme.background)
+        // Double-click again to go back, which is the gesture that opened it.
+        .onTapGesture(count: 2, perform: close)
+        // Escape, for the case where the button has not taken focus.
+        .onExitCommand(perform: close)
+    }
+}

--- a/Tests/MonitorUITests/ZoomLayoutTests.swift
+++ b/Tests/MonitorUITests/ZoomLayoutTests.swift
@@ -1,0 +1,82 @@
+import CoreGraphics
+import MonitorCore
+@testable import MonitorUI
+import Testing
+
+@Suite("Zoom layout")
+struct ZoomLayoutTests {
+    @Test("The zoom leaves a margin of panel showing")
+    func leavesAMargin() {
+        let panel = CGSize(width: 1200, height: 800)
+        let zoom = ZoomLayout.size(panel: panel)
+        #expect(zoom.width < panel.width)
+        #expect(zoom.height < panel.height)
+    }
+
+    @Test("A panel that has not been measured still gets a readable zoom")
+    func unmeasuredPanel() {
+        let zoom = ZoomLayout.size(panel: .zero)
+        #expect(zoom == ZoomLayout.smallest)
+    }
+
+    @Test("A tiny window does not produce a tiny zoom")
+    func tinyWindow() {
+        let zoom = ZoomLayout.size(panel: CGSize(width: 300, height: 200))
+        #expect(zoom.width == ZoomLayout.smallest.width)
+        #expect(zoom.height == ZoomLayout.smallest.height)
+    }
+
+    @Test("A very large display does not stretch the zoom without limit")
+    func hugeDisplay() {
+        let zoom = ZoomLayout.size(panel: CGSize(width: 6000, height: 4000))
+        #expect(zoom.width == ZoomLayout.largest.width)
+        #expect(zoom.height == ZoomLayout.largest.height)
+    }
+
+    @Test("The zoom grows with the panel between its two ends")
+    func growsWithThePanel() {
+        let small = ZoomLayout.size(panel: CGSize(width: 900, height: 600))
+        let large = ZoomLayout.size(panel: CGSize(width: 1400, height: 900))
+        #expect(large.width > small.width)
+        #expect(large.height > small.height)
+    }
+
+    @Test("A zoomed chart is taller than one on the panel")
+    func plotIsTaller() {
+        let zoom = ZoomLayout.size(panel: CGSize(width: 1200, height: 800))
+        #expect(ZoomLayout.plotHeight(in: zoom) > PanelSize.chartHeight.initial)
+    }
+
+    @Test("The plot never goes below the smallest chart the panel allows")
+    func plotHasAFloor() {
+        let plot = ZoomLayout.plotHeight(in: CGSize(width: 520, height: 120))
+        #expect(plot == PanelSize.chartHeight.minimum)
+    }
+
+    @Test("A zoomed dial is bigger than the largest one on the wall")
+    func dialIsBigger() {
+        let zoom = ZoomLayout.size(panel: CGSize(width: 1200, height: 800))
+        #expect(ZoomLayout.dialEdge(in: zoom) > PanelSize.gauge.maximum)
+    }
+
+    @Test("A zoomed dial fits inside the zoom")
+    func dialFits() {
+        for panel in [
+            CGSize(width: 700, height: 500),
+            CGSize(width: 1200, height: 800),
+            CGSize(width: 6000, height: 4000),
+        ] {
+            let zoom = ZoomLayout.size(panel: panel)
+            let edge = ZoomLayout.dialEdge(in: zoom)
+            #expect(edge <= zoom.width)
+            #expect(edge <= zoom.height)
+        }
+    }
+
+    @Test("A tile identifies itself, and two tiles do not collide")
+    func tileIdentity() {
+        #expect(PanelTile.chart("Memory").id == PanelTile.chart("Memory").id)
+        #expect(PanelTile.chart("Memory").id != PanelTile.gauge("Memory").id)
+        #expect(PanelTile.gauge("cpu.total").id != PanelTile.gauge("cpu.user").id)
+    }
+}

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -434,6 +434,64 @@ would be one more thing to remember.
 The pasteboard is somewhere the user asked for it to go, once, by choosing a
 menu item. `MonitorStore` stays unlinked and the ring buffer stays in memory.
 
+## Zooming one tile
+
+The panel is a wall of tiles sized to be glanced at. When one of them is the
+reason you opened the app you want it big, and the size sliders are the wrong
+tool: they resize *every* card, and they have to be put back afterwards.
+
+**Double-click a tile to zoom it. Escape, Done, or another double-click closes
+it.**
+
+### It is a mode, not a property
+
+One `@State` value on the dashboard holds the zoomed tile. Opening a second one
+therefore closes the first by construction, rather than by anybody remembering
+to close it. It is `@State` and not `PanelArrangement` because a zoom must not
+survive a relaunch and must not resize anything stored — the tile comes back the
+size it was.
+
+### A sheet, not a second window
+
+Three answers were on the table: a sheet over the panel, the card expanded in
+place, or a real second window.
+
+A sheet won. It is temporary in a way the other two are not — Escape already
+means dismiss, and there is nothing left over to find later. A second window
+raises questions this app has not had to answer: its own toolbar, its own
+history window, whether it survives a relaunch. Expanding in place keeps the
+toolbar reachable, which the sheet does give up, but it leaves the panel in a
+state that looks like a bug if you walk away from it.
+
+The sheet costs one thing and buys one thing, and the trade is deliberate.
+
+**Nothing stops sampling while the zoom is open.** The buffer is shared, so the
+panel underneath keeps filling and comes back without a gap.
+
+### Three gestures on one tile
+
+A tile now carries a left-drag to reorder, a right-click to copy, and a
+double-click to zoom. They do not fight: `.draggable` claims the press only once
+the pointer moves, the context menu is a separate button, and a count-2 tap
+gesture leaves both alone. This is checked by running the app, not by a test —
+gesture conflicts do not show up in a green suite.
+
+### Sizes
+
+`ZoomLayout` turns the panel's size into the sheet's. The zoom is 86% of the
+panel's width and 82% of its height, bounded to 520×360 at the small end and
+1400×900 at the large one. The margin of panel left showing is what says this is
+a temporary thing over the dashboard rather than a screen you navigated to; the
+upper bound is where a zoom stops being reading a chart and starts being
+stretching one. What is left after the title bar and the card's header is the
+plot, floored at the smallest chart height the panel itself allows.
+
+### Not in scope here
+
+A zoomed chart has room for more than a bigger version of the same picture: more
+x-axis labels, and a longer history window than the panel's. Neither is done —
+the zoom draws the same card the panel does, at a larger size.
+
 ## The auto-ranging dial
 
 A benchmark can pin its dial at a known maximum. A monitor cannot: disk write


### PR DESCRIPTION
## Summary

- Double-click any card or dial to zoom it. **Escape**, **Done**, or another double-click closes it.
- The zoom is a **sheet** over the panel, not a second window and not an in-place expansion. It is temporary in the way the other two are not: Escape already means dismiss, and nothing is left over to find later. A second window would need its own toolbar, its own history window and a relaunch story; expanding in place leaves the panel in a state that reads as a bug if you walk away.
- Zoom is a **mode the panel is in**, not a property a tile carries. One `@State` value on `DashboardView` holds it, so opening a second tile closes the first by construction. It stays out of `PanelArrangement` — a zoom must not survive a relaunch or resize anything stored, and the tile comes back the size it was.
- `ZoomLayout` (`Sources/MonitorUI/ZoomedCard.swift`) turns the measured panel size into the sheet's: 86% × 82%, bounded to 520×360 and 1400×900. The margin of panel left showing is what says "temporary"; the ceiling is where a zoom stops being reading a chart and starts being stretching one.
- Sampling does not stop while the zoom is open. The buffer is shared, so the panel underneath keeps filling and comes back without a gap.
- `DashboardView.chartCard` extracted so the grid and the zoom build the same card at different plot heights, and `gaugeTile` now takes its size so the caption scales with the dial.

Closes #29

## Test plan

- [x] `swift test` — 185 tests in 21 suites pass, 10 of them new in `Tests/MonitorUITests/ZoomLayoutTests.swift`
- [x] `swiftformat Sources Tests --lint --cache ignore` clean
- [ ] `swift run monitor`: double-click a chart, then a gauge — the second closes the first
- [ ] Escape closes the zoom; so does Done; so does a second double-click
- [ ] The three gestures on a tile do not fight: drag to reorder still works, right-click still opens Copy Image / Copy Data, and neither fires on a double-click
- [ ] The panel behind the zoom has no gap in its history when the zoom closes

## Out of scope

A zoomed chart has room for more than a bigger version of the same picture — more x-axis labels, and a longer history window than the panel's. Worth a follow-up; this PR draws the same card at a larger size.