### PR TITLE
Show how much moved, not only how fast

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,6 +181,24 @@ are no component-level AGENTS.md files.
   is its own type and key beside `LayoutPreferences`: **which cards exist**
   versus **how one is drawn**. Off by default, because a chart that changes
   shape on upgrade is worse than one somebody switches on.
+- **A rate can be totalled, and the sum is already in the buffer.** **Show
+  totals for the window** in the Charts tab puts how much moved beside how fast
+  it is moving. A rate sample *is* the mean over the gap before it, so
+  `Σ(rate × preceding gap)` telescopes back to exactly the counter delta —
+  `WindowTotal` in `MonitorCore` is that sum, and it keeps no counter history,
+  changes no source and writes nothing. Three things it must keep doing: report
+  **`covered` beside `value`**, because "2 min" over ten seconds of history is
+  the quiet kind of wrong; **clip an interval wider than `maximumGap`**, or a
+  laptop back from sleep credits one sample with an hour of traffic that never
+  crossed the wire; and return **nil under two samples**, not zero, the same
+  answer `RateTracker` gives on a first read. `MetricUnit.accumulation` says
+  what a unit adds up to and is nil for every level — derived from the unit like
+  `direction` and `composition`, never a table of ids. **Network totals in
+  bytes** while its rate stays Mbit/s: a link is quoted in bits, a volume in
+  bytes, and the divide by eight has one definition. The card totals `series`,
+  not `visible` — the sum needs the sample just outside the window's left edge
+  to measure the interval straddling it. `AppModel.totalGap` is four ticks of
+  the master clock, so it follows the Sampling tab rather than assuming 0.5 s.
 - **The time axis is computed, not automatic.** `ChartAxis` in `MonitorCore`.
   Three rules, and the first two versions traded one for another: a tick is an
   **instant** (10:42:00 sits at 10:42:00 and scrolls left keeping its label —
@@ -219,8 +237,8 @@ are no component-level AGENTS.md files.
   double-click to zoom — and that they do not fight is checked by running
   `swift run monitor`, never by a test.
 - **The layout is chosen per metric, in preferences.** Cmd-, opens a tabbed
-  window. Its **Charts** tab holds how cards are *drawn* (mirroring), which is
-  a different question from which cards there are. Its **Layout** tab lists
+  window. Its **Charts** tab holds how cards are *drawn* — stacking, mirroring,
+  totals — which is a different question from which cards there are. Its **Layout** tab lists
   every metric with a Gauge checkbox and a
   Chart checkbox, grouped into collapsible sections whose headings carry the
   same two checkboxes for the whole group. The two columns are not symmetrical:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -199,6 +199,14 @@ are no component-level AGENTS.md files.
   not `visible` — the sum needs the sample just outside the window's left edge
   to measure the interval straddling it. `AppModel.totalGap` is four ticks of
   the master clock, so it follows the Sampling tab rather than assuming 0.5 s.
+  **A card with totals draws a `Grid`, not a `FlowLayout`** — swatch, name,
+  rate, total, with the totals column headed and **right-justified**, because a
+  magnitude is read by where its last digit sits and wrapped entries put them at
+  four different left edges. It sits under the title, never beside it:
+  `ViewThatFits` is the right question for a wrapping row and the wrong one for
+  a column of figures. Cards with nothing to total keep the flow. The reserved
+  slot survives into the table — a `Grid` column sizes to its widest cell, so
+  without it the column resizes whenever a total crosses a magnitude.
 - **The time axis is computed, not automatic.** `ChartAxis` in `MonitorCore`.
   Three rules, and the first two versions traded one for another: a tick is an
   **instant** (10:42:00 sits at 10:42:00 and scrolls left keeping its label —

--- a/Sources/MonitorCore/ChartPreferences.swift
+++ b/Sources/MonitorCore/ChartPreferences.swift
@@ -88,9 +88,24 @@ public struct ChartPreferences: Codable, Equatable, Sendable {
     /// shape under somebody on upgrade is worse than one they switch on.
     public var stacksParts: Bool
 
-    public init(mirrorsPairs: Bool = false, stacksParts: Bool = false) {
+    /// Show how much moved over the window beside how fast it is moving.
+    ///
+    /// Off by default, for a narrower reason than the two above. Those change
+    /// what the picture *means*; this only adds a number. But it adds one to
+    /// every entry in a header that is already decided by `ViewThatFits`, so
+    /// switching it on reflows cards onto two lines — which is a card changing
+    /// shape under somebody on upgrade, the thing the other two defaults exist
+    /// to prevent.
+    public var showsTotals: Bool
+
+    public init(
+        mirrorsPairs: Bool = false,
+        stacksParts: Bool = false,
+        showsTotals: Bool = false
+    ) {
         self.mirrorsPairs = mirrorsPairs
         self.stacksParts = stacksParts
+        self.showsTotals = showsTotals
     }
 
     public static let `default` = ChartPreferences()
@@ -112,6 +127,7 @@ public struct ChartPreferences: Codable, Equatable, Sendable {
     private enum CodingKeys: String, CodingKey {
         case mirrorsPairs
         case stacksParts
+        case showsTotals
     }
 
     /// `decodeIfPresent`, so a value written before a setting existed still
@@ -120,9 +136,11 @@ public struct ChartPreferences: Codable, Equatable, Sendable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let mirrors = try container.decodeIfPresent(Bool.self, forKey: .mirrorsPairs)
         let stacks = try container.decodeIfPresent(Bool.self, forKey: .stacksParts)
+        let totals = try container.decodeIfPresent(Bool.self, forKey: .showsTotals)
         self.init(
             mirrorsPairs: mirrors ?? ChartPreferences.default.mirrorsPairs,
-            stacksParts: stacks ?? ChartPreferences.default.stacksParts
+            stacksParts: stacks ?? ChartPreferences.default.stacksParts,
+            showsTotals: totals ?? ChartPreferences.default.showsTotals
         )
     }
 }

--- a/Sources/MonitorCore/ChartPreferences.swift
+++ b/Sources/MonitorCore/ChartPreferences.swift
@@ -90,18 +90,18 @@ public struct ChartPreferences: Codable, Equatable, Sendable {
 
     /// Show how much moved over the window beside how fast it is moving.
     ///
-    /// Off by default, for a narrower reason than the two above. Those change
-    /// what the picture *means*; this only adds a number. But it adds one to
-    /// every entry in a header that is already decided by `ViewThatFits`, so
-    /// switching it on reflows cards onto two lines — which is a card changing
-    /// shape under somebody on upgrade, the thing the other two defaults exist
-    /// to prevent.
+    /// **On by default, unlike the two above**, and the argument for matching
+    /// them lost on first contact: shipped off, the reaction to the finished
+    /// feature was "I don't see it". Mirroring and stacking change what the
+    /// picture *means*, so a reader who never asked for them deserves the chart
+    /// they had; a total only adds a number beside one already there, and a
+    /// number nobody can find is worth less than a header that reflows.
     public var showsTotals: Bool
 
     public init(
         mirrorsPairs: Bool = false,
         stacksParts: Bool = false,
-        showsTotals: Bool = false
+        showsTotals: Bool = true
     ) {
         self.mirrorsPairs = mirrorsPairs
         self.stacksParts = stacksParts

--- a/Sources/MonitorCore/Formatting.swift
+++ b/Sources/MonitorCore/Formatting.swift
@@ -120,6 +120,22 @@ public enum Format {
             : String(format: "%.1f s", seconds)
     }
 
+    /// A span of history as a *label*, matching the History picker's wording:
+    /// "2 min", "10 min", "45 s".
+    ///
+    /// Not `duration`, which formats a measurement and would render two minutes
+    /// as "120.00 s". Whole minutes read as minutes because that is what the
+    /// picker beside them says; anything else keeps its seconds, since a card
+    /// that has only been running 45 s must say so rather than round itself up
+    /// to the window it was asked for.
+    public static func span(_ seconds: TimeInterval) -> String {
+        let minutes = seconds / 60
+        guard seconds >= 60, minutes == minutes.rounded() else {
+            return String(format: "%.0f s", seconds.rounded())
+        }
+        return String(format: "%.0f min", minutes)
+    }
+
     public static func duration(_ seconds: Double) -> String {
         if seconds >= 1 { return String(format: "%.2f s", seconds) }
         if seconds >= 0.001 { return String(format: "%.1f ms", seconds * 1000) }

--- a/Sources/MonitorCore/Formatting.swift
+++ b/Sources/MonitorCore/Formatting.swift
@@ -22,6 +22,58 @@ public enum Format {
         return "\(String(format: "%.\(digits)f", magnitude)) \(units[index])\(suffix)"
     }
 
+    /// A plain count, with SI suffixes: `847`, `1.2 M`, `340 k`.
+    ///
+    /// Same decimal thousands and the same digit rule as `bytes`, because the
+    /// two sit beside each other in a legend and a pair of counts that disagree
+    /// about what "k" means is worse than either. A packet total is seven
+    /// figures on a busy minute, and `1234567` is unreadable at a glance and
+    /// far too wide for the slot it has to sit in.
+    public static func count(_ value: Double) -> String {
+        let units = ["", " k", " M", " G", " T"]
+        var magnitude = abs(value)
+        var index = 0
+        while magnitude >= 1000, index < units.count - 1 {
+            magnitude /= 1000
+            index += 1
+        }
+        let digits = magnitude < 10 && index > 0 ? 1 : 0
+        return "\(String(format: "%.\(digits)f", magnitude))\(units[index])"
+    }
+
+    /// How much moved, from a `WindowTotal` in the rate's own base unit.
+    ///
+    /// Applies `MetricUnit.accumulation` and then formats the result — so the
+    /// bits-to-bytes conversion happens in exactly one place on the way to the
+    /// screen, which is what stops a header and anything downstream disagreeing
+    /// about whether 1.4 GB and 11.2 Gbit are the same reading.
+    ///
+    /// Nil for a unit that does not accumulate, so a caller cannot draw
+    /// degree-seconds under a temperature by forgetting to check.
+    public static func total(_ value: Double, unit: MetricUnit) -> String? {
+        guard let accumulation = unit.accumulation else { return nil }
+        let scaled = value * accumulation.scale
+        switch accumulation.unit {
+        case .bytes: return bytes(scaled)
+        case .count: return count(scaled)
+        default: return self.value(scaled, unit: accumulation.unit)
+        }
+    }
+
+    /// The widest reading `total(_:unit:)` is expected to produce, for reserving
+    /// layout width. A floor, exactly like `widestValue`.
+    ///
+    /// The legend is where this matters most: a total climbing from `88 MB` to
+    /// `1.4 GB` must not shove every entry beside it sideways while it is being
+    /// read.
+    public static func widestTotal(unit: MetricUnit) -> String? {
+        guard let accumulation = unit.accumulation else { return nil }
+        switch accumulation.unit {
+        case .count: return "999 M"
+        default: return widestValue(unit: accumulation.unit)
+        }
+    }
+
     /// Throughput is pinned to mega-units and never rescaled: disk in MB/s,
     /// network in Mbit/s, at every magnitude, including 0.02 and 5000.
     ///

--- a/Sources/MonitorCore/Metric.swift
+++ b/Sources/MonitorCore/Metric.swift
@@ -30,6 +30,33 @@ public enum MetricUnit: String, Sendable, Codable {
     /// "3200 rpm" are not the same reading on a chart axis.
     case rpm
     case seconds
+
+    /// What a second's worth of this unit adds up to, and the factor that gets
+    /// it there. Nil where a total means nothing.
+    ///
+    /// Derived from the unit rather than from a table of metric ids, the same
+    /// way `ChartMirror` and `ChartStack` read `direction` and `composition`:
+    /// a source added later gets a total without this file being told it
+    /// exists.
+    ///
+    /// **Network reads in bits and totals in bytes, and the divide by eight
+    /// lives here.** A link is quoted in bits — a 1 Gbit port, an 866 Mbit
+    /// Wi-Fi link — so the rate stays Mbit/s. A volume is quoted in bytes
+    /// everywhere it matters: ISP caps, file sizes, Finder. Two different
+    /// questions with two right answers, and one definition of the conversion
+    /// between them, for the same reason `NetworkSource` multiplies by eight in
+    /// the source rather than in the gauge.
+    ///
+    /// Nil for every level. Adding temperatures gives degree-seconds, which is
+    /// not a quantity anybody wants under a chart of a CPU getting warm.
+    public var accumulation: (unit: MetricUnit, scale: Double)? {
+        switch self {
+        case .bytesPerSecond: (.bytes, 1)
+        case .bitsPerSecond: (.bytes, 1.0 / 8)
+        case .operationsPerSecond: (.count, 1)
+        default: nil
+        }
+    }
 }
 
 /// How consecutive samples relate to each other.

--- a/Sources/MonitorCore/WindowTotal.swift
+++ b/Sources/MonitorCore/WindowTotal.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+/// How much moved over a window, from the rates that were sampled across it.
+///
+/// The dials answer "how hard is this working right now" and the charts answer
+/// "what has been happening". Neither answers "how much did that transfer
+/// cost me", which is the question you have while watching a sync run.
+///
+/// **A rate sample is the mean over the gap before it.** `RateTracker` produces
+/// `Δcounter / Δt`, so multiplying each sample by the interval it measures and
+/// summing telescopes back to exactly the counter delta the window covers. That
+/// is the whole trick: no counter history is kept anywhere, no source changes,
+/// and nothing is read that the ring buffer does not already hold.
+///
+/// In `MonitorCore` beside `CSVExport` and the preference models, for the same
+/// reason they are: the interesting part is arithmetic, and arithmetic should
+/// not need a machine to read or a window to draw in.
+public enum WindowTotal {
+    /// A total, and how much of the window it actually accounts for.
+    ///
+    /// The second half is not decoration. Ten seconds after launch the buffer
+    /// holds ten seconds, and putting "2 min" under a number covering a twelfth
+    /// of that is the quiet kind of wrong — nobody checks it, because it looks
+    /// exactly like the right answer.
+    public struct Result: Equatable, Sendable {
+        /// The counter delta, in the rate's unit times seconds. Bytes for
+        /// `bytesPerSecond`, bits for `bitsPerSecond`, operations for
+        /// `operationsPerSecond`. Converting to what a reader wants is
+        /// `MetricUnit.accumulation`'s job, not this one's.
+        public let value: Double
+        /// Seconds of the window the samples account for. At most `window`,
+        /// and less when history is short or an interval was clipped.
+        public let covered: TimeInterval
+
+        public init(value: Double, covered: TimeInterval) {
+            self.value = value
+            self.covered = covered
+        }
+    }
+
+    /// The total across `window` seconds ending at `now`.
+    ///
+    /// - Parameters:
+    ///   - points: the series' samples. Sorted here rather than assumed sorted,
+    ///     because a total that depends on array order is a bug waiting for a
+    ///     refactor.
+    ///   - window: seconds of history to add up — the same window the card is
+    ///     drawing, so the number and the picture answer the same question.
+    ///   - now: the right-hand edge. Defaults to the newest sample, which is
+    ///     the rule `CSVExport` already follows.
+    ///   - maximumGap: the widest interval one sample may be credited with. A
+    ///     slept laptop or a source that failed for a minute leaves one
+    ///     enormous gap, and a rectangle drawn across it invents traffic that
+    ///     never happened. The caller knows the sampling clock; this does not.
+    /// - Returns: nil when there are fewer than two samples. There is genuinely
+    ///   no total yet — the same answer `RateTracker` gives on a first read,
+    ///   and for the same reason: zero would draw as an idle machine rather
+    ///   than as a missing number.
+    public static func total(
+        of points: [Sample],
+        window: TimeInterval,
+        now: TimeInterval? = nil,
+        maximumGap: TimeInterval
+    ) -> Result? {
+        guard points.count >= 2 else { return nil }
+        let sorted = points.sorted { $0.timestamp < $1.timestamp }
+        guard let end = now ?? sorted.last?.timestamp else { return nil }
+        let start = end - window
+
+        var value = 0.0
+        var covered = 0.0
+        // From the second sample: the oldest one has no predecessor, so the
+        // width of its interval is unknown and it is credited with nothing.
+        // Reaching back to the window's edge instead would invent history in
+        // exactly the case where there is none.
+        for index in 1..<sorted.count {
+            let sample = sorted[index]
+            guard sample.timestamp > start, sample.timestamp <= end else { continue }
+            // The predecessor may sit outside the window. That is deliberate:
+            // it is what makes the leading partial interval come out clipped
+            // rather than dropped whole.
+            let previous = max(sorted[index - 1].timestamp, start)
+            let interval = min(sample.timestamp - previous, maximumGap)
+            guard interval > 0 else { continue }
+            value += sample.value * interval
+            covered += interval
+        }
+        return Result(value: value, covered: covered)
+    }
+}

--- a/Sources/MonitorUI/AppModel.swift
+++ b/Sources/MonitorUI/AppModel.swift
@@ -100,6 +100,19 @@ public final class AppModel {
     /// How much live history to keep: ten minutes at two samples a second.
     public let historyCapacity = 1200
 
+    /// The widest interval one sample may be credited with in a window total,
+    /// in ticks of the master clock.
+    ///
+    /// Four: wide enough that a tick which ran late still contributes its whole
+    /// interval, and narrow enough that a laptop coming back from sleep cannot
+    /// credit one sample with an hour of traffic that never crossed the wire.
+    static let totalGapTicks = 4.0
+
+    /// That, in seconds, at whatever rate the clock is currently running.
+    /// `WindowTotal` deliberately does not know the clock; this is where it
+    /// lives.
+    public var totalGap: TimeInterval { interval * Self.totalGapTicks }
+
     public let descriptors: [MetricID: MetricDescriptor]
     private let sampler: Sampler
     private var pump: Task<Void, Never>?

--- a/Sources/MonitorUI/ChartCard.swift
+++ b/Sources/MonitorUI/ChartCard.swift
@@ -29,6 +29,15 @@ public struct ChartCard: View {
     /// Passed in rather than worked out here, for the same reason `mirror` is:
     /// whether to stack is a preference, and a card does not read preferences.
     public var stacked: [MetricID] = []
+    /// The widest interval one sample may be credited with when totalling, or
+    /// nil to draw no totals at all.
+    ///
+    /// One optional rather than a flag and a number, because neither is any use
+    /// without the other: a total cannot be taken without knowing the sampling
+    /// clock, and the clock belongs to the model. Passed in for the same reason
+    /// `mirror` and `stacked` are — whether to show totals is a preference, and
+    /// a card does not read preferences.
+    public var totalGap: TimeInterval?
 
     public init(
         title: String,
@@ -37,7 +46,8 @@ public struct ChartCard: View {
         isUnavailable: Bool = false,
         plotHeight: Double = Theme.Layout.chartMinHeight,
         mirror: MetricPair? = nil,
-        stacked: [MetricID] = []
+        stacked: [MetricID] = [],
+        totalGap: TimeInterval? = nil
     ) {
         self.title = title
         self.series = series
@@ -49,11 +59,16 @@ public struct ChartCard: View {
         // of a whole, so nothing declares both — but drawing bands below a
         // baseline would be nonsense, so it cannot happen by accident either.
         self.stacked = mirror == nil ? stacked : []
+        self.totalGap = totalGap
     }
 
     public var body: some View {
-        VStack(alignment: .leading, spacing: 5) {
-            header
+        // Bound once and passed down rather than read as a computed property
+        // from three places: it walks every series' whole buffer, and the card
+        // redraws on every tick.
+        let totals = totals
+        return VStack(alignment: .leading, spacing: 5) {
+            header(totals)
             if isUnavailable {
                 unavailableNotice
             } else {
@@ -81,30 +96,45 @@ public struct ChartCard: View {
     /// `ViewThatFits` proposes the column's width to the first arrangement and
     /// falls back to the second, so the compact line survives wherever there is
     /// room for it.
-    private var header: some View {
-        ViewThatFits(in: .horizontal) {
+    private func header(_ totals: [MetricID: WindowTotal.Result]) -> some View {
+        let span = totalSpan(totals)
+        return ViewThatFits(in: .horizontal) {
             HStack(alignment: .top, spacing: 8) {
-                titleText
+                titleText(span: span)
                 Spacer(minLength: 0)
-                legend
+                legend(totals, span: span)
             }
             VStack(alignment: .leading, spacing: 4) {
-                titleText
-                legend
+                titleText(span: span)
+                legend(totals, span: span)
             }
         }
     }
 
-    private var titleText: some View {
-        Text(title)
-            .font(.system(
-                size: Theme.Layout.cardTitle,
-                weight: .semibold,
-                design: .rounded
-            ))
-            .foregroundStyle(Theme.readout)
-            .lineLimit(1)
-            .fixedSize()
+    /// The title, and the span the totals cover when there are any.
+    ///
+    /// Stated once here rather than after every entry. The History picker is
+    /// global, so repeating "/ 2 min" four times down a legend is four copies
+    /// of one fact — and the legend is the part of the card with the least room
+    /// to spare.
+    private func titleText(span: TimeInterval?) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 6) {
+            Text(title)
+                .font(.system(
+                    size: Theme.Layout.cardTitle,
+                    weight: .semibold,
+                    design: .rounded
+                ))
+                .foregroundStyle(Theme.readout)
+                .lineLimit(1)
+            if let span {
+                Text(Format.span(span))
+                    .font(.system(size: Theme.Layout.cardLegend, design: .monospaced))
+                    .foregroundStyle(Theme.label)
+                    .lineLimit(1)
+            }
+        }
+        .fixedSize()
     }
 
     /// Current values in the header rather than in a legend below the chart:
@@ -115,11 +145,19 @@ public struct ChartCard: View {
     /// than its children want compresses them, and compressed legend entries
     /// truncate to nothing readable; `FlowLayout` spends card height instead,
     /// which is the cheaper of the two.
-    private var legend: some View {
+    private func legend(
+        _ totals: [MetricID: WindowTotal.Result], span: TimeInterval?
+    ) -> some View {
         FlowLayout(horizontalSpacing: 10, verticalSpacing: 3) {
             ForEach(Array(series.enumerated()), id: \.offset) { index, entry in
                 if let latest = entry.points.last {
-                    legendEntry(entry.descriptor, index: index, latest: latest)
+                    legendEntry(
+                        entry.descriptor,
+                        index: index,
+                        latest: latest,
+                        total: totals[entry.descriptor.id],
+                        span: span
+                    )
                 }
             }
         }
@@ -139,7 +177,11 @@ public struct ChartCard: View {
     /// `.monospacedDigit()` is not enough on its own — it equalises digit widths
     /// but reserves nothing, so `1%` and `100%` still occupy different space.
     private func legendEntry(
-        _ descriptor: MetricDescriptor, index: Int, latest: Sample
+        _ descriptor: MetricDescriptor,
+        index: Int,
+        latest: Sample,
+        total: WindowTotal.Result?,
+        span: TimeInterval?
     ) -> some View {
         HStack(spacing: 4) {
             // Filled for a band, hollow for a line — the same distinction the
@@ -165,8 +207,33 @@ public struct ChartCard: View {
                     .foregroundStyle(Theme.readout)
                     .lineLimit(1)
             }
+            totalText(descriptor, total: total, span: span)
         }
         .font(.system(size: Theme.Layout.cardLegend, design: .monospaced))
+    }
+
+    /// How much moved, in its own reserved slot beside how fast it is moving.
+    ///
+    /// Dimmed when this series covers materially less of the window than the
+    /// span printed beside the title — one source failed for a stretch while
+    /// its neighbour on the card kept reading. The ordinary case, where every
+    /// series covers the same span, spends no ink saying so.
+    @ViewBuilder
+    private func totalText(
+        _ descriptor: MetricDescriptor, total: WindowTotal.Result?, span: TimeInterval?
+    ) -> some View {
+        if let total,
+           let text = Format.total(total.value, unit: descriptor.unit),
+           let widest = Format.widestTotal(unit: descriptor.unit)
+        {
+            let isShort = span.map { $0 - total.covered > (totalGap ?? 0) } ?? false
+            ZStack(alignment: .leading) {
+                Text(widest).hidden()
+                Text(text)
+                    .foregroundStyle(isShort ? Theme.label : Theme.readout)
+                    .lineLimit(1)
+            }
+        }
     }
 
     private var unavailableNotice: some View {
@@ -195,6 +262,40 @@ public struct ChartCard: View {
         return series.map { entry in
             (entry.descriptor, entry.points.filter { $0.timestamp >= range.start })
         }
+    }
+
+    // MARK: - Totals
+
+    /// How much moved over the window, per series, in the rate's own base unit.
+    ///
+    /// Reads `series` rather than `visible`: `WindowTotal` needs the sample just
+    /// *before* the window's left edge to measure the partial interval that
+    /// straddles it, and `visible` has already thrown that one away.
+    private var totals: [MetricID: WindowTotal.Result] {
+        guard let totalGap else { return [:] }
+        let end = xRange.end
+        var results: [MetricID: WindowTotal.Result] = [:]
+        for entry in series where entry.descriptor.unit.accumulation != nil {
+            results[entry.descriptor.id] = WindowTotal.total(
+                of: entry.points, window: window, now: end, maximumGap: totalGap
+            )
+        }
+        return results
+    }
+
+    /// The span printed beside the title: the window when the card really has
+    /// it, and what the card actually has when it does not.
+    ///
+    /// Ten seconds after launch the buffer holds ten seconds, and "2 min" over
+    /// a number covering a twelfth of that is the quiet kind of wrong. The
+    /// tolerance is one `totalGap`, because a card is never going to cover its
+    /// window to the microsecond and "119 s" beside a picker reading "2 min"
+    /// reads as a fault rather than as precision.
+    private func totalSpan(_ totals: [MetricID: WindowTotal.Result]) -> TimeInterval? {
+        guard let totalGap, let longest = totals.values.map(\.covered).max() else {
+            return nil
+        }
+        return window - longest > totalGap ? longest : window
     }
 
     private var chart: some View {

--- a/Sources/MonitorUI/ChartCard.swift
+++ b/Sources/MonitorUI/ChartCard.swift
@@ -96,14 +96,27 @@ public struct ChartCard: View {
     /// `ViewThatFits` proposes the column's width to the first arrangement and
     /// falls back to the second, so the compact line survives wherever there is
     /// room for it.
+    @ViewBuilder
     private func header(_ totals: [MetricID: WindowTotal.Result]) -> some View {
         let span = totalSpan(totals)
-        return ViewThatFits(in: .horizontal) {
-            HStack(alignment: .top, spacing: 8) {
-                titleText(span: span)
-                Spacer(minLength: 0)
-                legend(totals, span: span)
+        if totals.isEmpty {
+            ViewThatFits(in: .horizontal) {
+                HStack(alignment: .top, spacing: 8) {
+                    titleText(span: span)
+                    Spacer(minLength: 0)
+                    legend(totals, span: span)
+                }
+                VStack(alignment: .leading, spacing: 4) {
+                    titleText(span: span)
+                    legend(totals, span: span)
+                }
             }
+        } else {
+            // A table always goes under the title, never beside it. `ViewThatFits`
+            // is the right question for a wrapping row of entries and the wrong
+            // one for a column of figures: pushed to the right of the title on a
+            // wide card, the Totals heading floats in the middle of the header
+            // with nothing under it that reads as a table.
             VStack(alignment: .leading, spacing: 4) {
                 titleText(span: span)
                 legend(totals, span: span)
@@ -145,79 +158,144 @@ public struct ChartCard: View {
     /// than its children want compresses them, and compressed legend entries
     /// truncate to nothing readable; `FlowLayout` spends card height instead,
     /// which is the cheaper of the two.
+    /// The legend: a wrapping row of entries, or a small table when the card
+    /// has totals to line up.
+    ///
+    /// Two shapes rather than one because the cards differ. A card of levels —
+    /// Memory's seven slices, five temperature sensors — has nothing to total
+    /// and wants `FlowLayout`, which spends card height only when the entries
+    /// genuinely do not fit across. A card of rates has a second number per
+    /// series, and numbers in a wrapped row do not line up: the totals ended up
+    /// at four different left edges down the same card, which is what a column
+    /// is for.
+    ///
+    /// Only five groups accumulate — Disk, Disk Ops, Network, Network Packets,
+    /// Memory Paging — and every one of them has exactly two series, so the
+    /// table is three rows at its tallest.
+    @ViewBuilder
     private func legend(
         _ totals: [MetricID: WindowTotal.Result], span: TimeInterval?
     ) -> some View {
+        if totals.isEmpty {
+            flowLegend
+        } else {
+            tableLegend(totals, span: span)
+        }
+    }
+
+    /// Entries wrapped across the card, for a legend with no totals column.
+    ///
+    /// An `HStack` given less width than its children want compresses them, and
+    /// compressed entries truncate to nothing readable; `FlowLayout` spends card
+    /// height instead, which is the cheaper of the two.
+    private var flowLegend: some View {
         FlowLayout(horizontalSpacing: 10, verticalSpacing: 3) {
             ForEach(Array(series.enumerated()), id: \.offset) { index, entry in
                 if let latest = entry.points.last {
-                    legendEntry(
-                        entry.descriptor,
-                        index: index,
-                        latest: latest,
-                        total: totals[entry.descriptor.id],
-                        span: span
-                    )
+                    HStack(spacing: 4) {
+                        swatch(entry.descriptor, index: index)
+                        nameText(entry.descriptor)
+                        valueText(entry.descriptor, latest: latest)
+                    }
                 }
             }
         }
+        .font(.system(size: Theme.Layout.cardLegend, design: .monospaced))
         .fixedSize(horizontal: false, vertical: true)
     }
 
-    /// One legend entry: colour swatch, series name, current value.
+    /// Series down the left, rate then total across, with the totals column
+    /// headed and right-justified.
     ///
-    /// Monospaced, and the value sits in a slot pre-sized to the widest reading
-    /// its unit can produce. Both matter for the same reason: a legend whose
-    /// entries change width is a legend that shuffles sideways while you are
-    /// reading it. A monospaced face stops individual digits from changing width
-    /// as they change value; the reserved slot stops the *number of* digits from
-    /// moving everything else, which is what made a series climbing from `1%` to
-    /// `100%` appear to wiggle the whole card.
-    ///
-    /// `.monospacedDigit()` is not enough on its own — it equalises digit widths
-    /// but reserves nothing, so `1%` and `100%` still occupy different space.
-    private func legendEntry(
-        _ descriptor: MetricDescriptor,
-        index: Int,
-        latest: Sample,
-        total: WindowTotal.Result?,
-        span: TimeInterval?
+    /// Right-justified because these are magnitudes, and magnitudes are read by
+    /// the position of their last digit: `104 MB` over `48 MB` aligned on the
+    /// left puts the hundreds above the tens and hides the difference the column
+    /// exists to show. Headed because a second bare number beside a rate does
+    /// not say what it is — the span beside the card's title says *how long*,
+    /// and this says *of what*.
+    private func tableLegend(
+        _ totals: [MetricID: WindowTotal.Result], span: TimeInterval?
     ) -> some View {
-        HStack(spacing: 4) {
-            // Filled for a band, hollow for a line — the same distinction the
-            // chart makes, so the key does not have to be guessed at.
-            Group {
-                if stacked.isEmpty || isBand(descriptor) {
-                    Circle().fill(Theme.seriesColor(index))
-                } else {
-                    Circle().strokeBorder(Theme.seriesColor(index), lineWidth: 1.5)
+        Grid(alignment: .leading, horizontalSpacing: 8, verticalSpacing: 3) {
+            GridRow {
+                // One merged cell across the swatch, name and rate columns: a
+                // merged cell adds nothing to their widths, so the heading
+                // cannot widen the table it labels.
+                Color.clear.frame(width: 0, height: 0).gridCellColumns(3)
+                Text("Totals")
+                    .foregroundStyle(Theme.label)
+                    .lineLimit(1)
+                    .gridColumnAlignment(.trailing)
+            }
+            ForEach(Array(series.enumerated()), id: \.offset) { index, entry in
+                if let latest = entry.points.last {
+                    GridRow {
+                        swatch(entry.descriptor, index: index)
+                        nameText(entry.descriptor)
+                        valueText(entry.descriptor, latest: latest)
+                        totalText(
+                            entry.descriptor,
+                            total: totals[entry.descriptor.id],
+                            span: span
+                        )
+                    }
                 }
             }
-            .frame(width: 7, height: 7)
-            Text(descriptor.name)
-                .foregroundStyle(Theme.label)
-                .lineLimit(1)
-            ZStack(alignment: .leading) {
-                // Reserves the slot. A ZStack takes the width of its widest
-                // child, so a reading wider than the reservation grows the slot
-                // rather than being clipped — the reservation is a floor.
-                Text(Format.widestValue(unit: descriptor.unit))
-                    .hidden()
-                Text(Format.value(latest.value, unit: descriptor.unit))
-                    .foregroundStyle(Theme.readout)
-                    .lineLimit(1)
-            }
-            totalText(descriptor, total: total, span: span)
         }
         .font(.system(size: Theme.Layout.cardLegend, design: .monospaced))
+        .fixedSize(horizontal: false, vertical: true)
     }
 
-    /// How much moved, in its own reserved slot beside how fast it is moving.
+    /// Filled for a band, hollow for a line — the same distinction the chart
+    /// makes, so the key does not have to be guessed at.
+    private func swatch(_ descriptor: MetricDescriptor, index: Int) -> some View {
+        Group {
+            if stacked.isEmpty || isBand(descriptor) {
+                Circle().fill(Theme.seriesColor(index))
+            } else {
+                Circle().strokeBorder(Theme.seriesColor(index), lineWidth: 1.5)
+            }
+        }
+        .frame(width: 7, height: 7)
+    }
+
+    private func nameText(_ descriptor: MetricDescriptor) -> some View {
+        Text(descriptor.name)
+            .foregroundStyle(Theme.label)
+            .lineLimit(1)
+    }
+
+    /// The current reading, in a slot pre-sized to the widest its unit can
+    /// produce.
+    ///
+    /// Monospaced and reserved for the same reason: a legend whose entries
+    /// change width is a legend that shuffles sideways while you are reading it.
+    /// A monospaced face stops individual digits from changing width as they
+    /// change value; the reserved slot stops the *number of* digits from moving
+    /// everything else, which is what made a series climbing from `1%` to `100%`
+    /// appear to wiggle the whole card. `.monospacedDigit()` is not enough on
+    /// its own — it equalises digit widths but reserves nothing.
+    private func valueText(_ descriptor: MetricDescriptor, latest: Sample) -> some View {
+        ZStack(alignment: .leading) {
+            // A ZStack takes the width of its widest child, so a reading wider
+            // than the reservation grows the slot rather than being clipped —
+            // the reservation is a floor.
+            Text(Format.widestValue(unit: descriptor.unit)).hidden()
+            Text(Format.value(latest.value, unit: descriptor.unit))
+                .foregroundStyle(Theme.readout)
+                .lineLimit(1)
+        }
+    }
+
+    /// How much moved, right-justified under the Totals heading.
     ///
     /// Dimmed when this series covers materially less of the window than the
     /// span printed beside the title — one source failed for a stretch while
     /// its neighbour on the card kept reading. The ordinary case, where every
     /// series covers the same span, spends no ink saying so.
+    ///
+    /// The slot is reserved here too, and its contents pushed right, so the
+    /// digits stay in one column as their magnitude changes.
     @ViewBuilder
     private func totalText(
         _ descriptor: MetricDescriptor, total: WindowTotal.Result?, span: TimeInterval?
@@ -227,12 +305,16 @@ public struct ChartCard: View {
            let widest = Format.widestTotal(unit: descriptor.unit)
         {
             let isShort = span.map { $0 - total.covered > (totalGap ?? 0) } ?? false
-            ZStack(alignment: .leading) {
+            ZStack(alignment: .trailing) {
                 Text(widest).hidden()
                 Text(text)
                     .foregroundStyle(isShort ? Theme.label : Theme.readout)
                     .lineLimit(1)
             }
+        } else {
+            // A series on a card that has totals but cannot produce one of its
+            // own still needs its cell, or the row below slides up a column.
+            Color.clear.frame(width: 0, height: 0)
         }
     }
 

--- a/Sources/MonitorUI/DashboardView.swift
+++ b/Sources/MonitorUI/DashboardView.swift
@@ -390,7 +390,10 @@ public struct DashboardView: View {
             // membership: switch one direction off and the card stops being a
             // pair.
             mirror: model.charts.mirror(for: drawn.map(\.descriptor)),
-            stacked: model.charts.stack(for: drawn.map(\.descriptor))
+            stacked: model.charts.stack(for: drawn.map(\.descriptor)),
+            // Nil switches totals off. The gap comes from the model because
+            // that is where the sampling clock is.
+            totalGap: model.charts.showsTotals ? model.totalGap : nil
         )
     }
 

--- a/Sources/MonitorUI/PreferencesView.swift
+++ b/Sources/MonitorUI/PreferencesView.swift
@@ -221,6 +221,22 @@ struct ChartsTab: View {
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
             }
+
+            Section {
+                Toggle("Show totals for the window", isOn: $model.charts.showsTotals)
+            } footer: {
+                Text(
+                    "How much moved, beside how fast it is moving: network and "
+                        + "disk in bytes, packets and disk operations as counts. "
+                        + "The total covers exactly the window the chart draws, "
+                        + "so the History picker changes both at once. A card "
+                        + "with less history than the window says the span it "
+                        + "really has rather than the one it was asked for."
+                )
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            }
         }
         .formStyle(.grouped)
     }

--- a/Tests/MonitorCoreTests/ChartPreferencesTests.swift
+++ b/Tests/MonitorCoreTests/ChartPreferencesTests.swift
@@ -135,11 +135,14 @@ struct ChartStackTests {
 
 @Suite("ChartPreferences")
 struct ChartPreferencesTests {
-    @Test("Every setting is off until it is switched on")
-    func offByDefault() {
+    @Test("The two that change the picture are off; the one that adds a number is on")
+    func defaults() {
         #expect(ChartPreferences.default.mirrorsPairs == false)
         #expect(ChartPreferences.default.stacksParts == false)
-        #expect(ChartPreferences.default.showsTotals == false)
+        // Shipped off, the reaction to the finished feature was "I don't see
+        // it". A total adds a number beside one already there rather than
+        // changing what the chart means, so it does not need switching on.
+        #expect(ChartPreferences.default.showsTotals)
         #expect(ChartPreferences.default.mirror(for: [netIn, netOut]) == nil)
         #expect(ChartPreferences.default.stack(for: [app, wired, free]).isEmpty)
     }
@@ -190,7 +193,9 @@ struct ChartPreferencesTests {
         let decoded = try JSONDecoder().decode(ChartPreferences.self, from: stored)
         #expect(decoded.mirrorsPairs)
         #expect(decoded.stacksParts)
-        #expect(decoded.showsTotals == false)
+        // An upgrade from a version without the key gets the new default, not
+        // false: a missing key means "never asked", not "switched off".
+        #expect(decoded.showsTotals)
     }
 }
 

--- a/Tests/MonitorCoreTests/ChartPreferencesTests.swift
+++ b/Tests/MonitorCoreTests/ChartPreferencesTests.swift
@@ -135,10 +135,11 @@ struct ChartStackTests {
 
 @Suite("ChartPreferences")
 struct ChartPreferencesTests {
-    @Test("Both settings are off until they are switched on")
+    @Test("Every setting is off until it is switched on")
     func offByDefault() {
         #expect(ChartPreferences.default.mirrorsPairs == false)
         #expect(ChartPreferences.default.stacksParts == false)
+        #expect(ChartPreferences.default.showsTotals == false)
         #expect(ChartPreferences.default.mirror(for: [netIn, netOut]) == nil)
         #expect(ChartPreferences.default.stack(for: [app, wired, free]).isEmpty)
     }
@@ -150,11 +151,16 @@ struct ChartPreferencesTests {
         #expect(preferences.stack(for: [netIn, netOut]).isEmpty)
     }
 
-    @Test("The two settings are independent")
+    @Test("The settings are independent")
     func settingsAreIndependent() {
         let stacking = ChartPreferences(mirrorsPairs: false, stacksParts: true)
         #expect(stacking.mirror(for: [netIn, netOut]) == nil)
         #expect(!stacking.stack(for: [app, wired]).isEmpty)
+        // Totals are a number in the legend, not a change to the picture, so
+        // they must not turn either of the other two on by arriving.
+        let totals = ChartPreferences(showsTotals: true)
+        #expect(totals.mirror(for: [netIn, netOut]) == nil)
+        #expect(totals.stack(for: [app, wired]).isEmpty)
     }
 
     @Test("Switched on, a pair mirrors and everything else does not")
@@ -166,7 +172,9 @@ struct ChartPreferencesTests {
 
     @Test("Round-trips through Codable")
     func codable() throws {
-        let preferences = ChartPreferences(mirrorsPairs: true, stacksParts: true)
+        let preferences = ChartPreferences(
+            mirrorsPairs: true, stacksParts: true, showsTotals: true
+        )
         let data = try JSONEncoder().encode(preferences)
         #expect(try JSONDecoder().decode(ChartPreferences.self, from: data) == preferences)
     }
@@ -175,6 +183,14 @@ struct ChartPreferencesTests {
     func decodesMissingKeys() throws {
         let data = Data("{}".utf8)
         #expect(try JSONDecoder().decode(ChartPreferences.self, from: data) == .default)
+        // The shape a 1.4 install actually has on disk: the two keys that
+        // existed then, and nothing about totals. It must keep its answers to
+        // the questions it was asked rather than reset all three.
+        let stored = Data(#"{"mirrorsPairs":true,"stacksParts":true}"#.utf8)
+        let decoded = try JSONDecoder().decode(ChartPreferences.self, from: stored)
+        #expect(decoded.mirrorsPairs)
+        #expect(decoded.stacksParts)
+        #expect(decoded.showsTotals == false)
     }
 }
 

--- a/Tests/MonitorCoreTests/WindowTotalTests.swift
+++ b/Tests/MonitorCoreTests/WindowTotalTests.swift
@@ -1,0 +1,218 @@
+import Foundation
+@testable import MonitorCore
+import Testing
+
+private let metric = MetricID("test.rate")
+
+/// Samples at a fixed cadence, oldest first, ending at `end`.
+private func steady(
+    _ values: [Double], interval: TimeInterval = 0.5, end: TimeInterval = 1000
+) -> [Sample] {
+    let start = end - Double(values.count - 1) * interval
+    return values.enumerated().map { offset, value in
+        Sample(metric: metric, timestamp: start + Double(offset) * interval, value: value)
+    }
+}
+
+@Suite("WindowTotal")
+struct WindowTotalTests {
+    @Test("A constant rate over a window totals rate times window")
+    func constantRate() {
+        // 10 MB/s for 60 s is 600 MB. The simplest claim this file makes, and
+        // the one every other case is a variation on.
+        let points = steady(Array(repeating: 10_000_000, count: 121), interval: 0.5)
+        let result = WindowTotal.total(of: points, window: 60, maximumGap: 2)
+        #expect(result?.value == 600_000_000)
+        #expect(result?.covered == 60)
+    }
+
+    @Test("Differentiating a counter and integrating it back returns the delta")
+    func roundTrip() {
+        // The premise of the whole feature: a rate sample is the mean over the
+        // gap before it, so summing rate times gap telescopes back to exactly
+        // the counter delta. If this passes, the rest is formatting.
+        //
+        // Deliberately uneven, so the test cannot pass by multiplying by a
+        // constant interval it happened to guess right.
+        let deltas: [Double] = [0, 1400, 32, 900_000, 17, 0, 4, 250_000, 88, 1]
+        var counter = 5_000_000_000.0
+        var tracker = RateTracker()
+        var points: [Sample] = []
+        var timestamp = 1000.0
+        for (index, delta) in deltas.enumerated() {
+            counter += delta
+            timestamp += index.isMultiple(of: 3) ? 0.5 : 0.75
+            if let rate = tracker.rate(for: metric, total: counter, at: timestamp) {
+                points.append(Sample(metric: metric, timestamp: timestamp, value: rate))
+            }
+        }
+
+        // Two deltas drop out, for two different reasons. The first produced no
+        // rate at all — there was no previous reading. The second produced the
+        // oldest sample in the array, which has no predecessor to measure its
+        // interval against, so its width is unknown and it contributes nothing.
+        // Inventing a width for it would be a guess, and one sampling interval
+        // out of a window of hundreds is not worth guessing for.
+        let expected = deltas.dropFirst(2).reduce(0, +)
+        let result = WindowTotal.total(of: points, window: 600, maximumGap: 10)
+        #expect(abs((result?.value ?? 0) - expected) < 0.000001)
+    }
+
+    @Test("A gap straddling the window edge is clipped, not dropped or kept whole")
+    func clipsAtTheEdge() {
+        // Four samples 10 s apart, each reporting 100/s. A 25 s window ends at
+        // the last one and reaches half way into a gap, so it covers two whole
+        // intervals plus half of one: 100 * 25. The predecessor that measures
+        // that half interval sits outside the window, which is why the sum
+        // reads the whole array and filters only what it adds up.
+        let points = steady([100, 100, 100, 100], interval: 10, end: 1000)
+        let result = WindowTotal.total(of: points, window: 25, maximumGap: 60)
+        #expect(result?.value == 2500)
+        #expect(result?.covered == 25)
+    }
+
+    @Test("Uneven gaps weight each sample by the interval it measures")
+    func unevenGaps() {
+        // 1 s at 10/s, then 3 s at 100/s. A mean of the two values would say
+        // 55 * 4 = 220; weighting by interval says 10 + 300 = 310.
+        let points = [
+            Sample(metric: metric, timestamp: 100, value: 0),
+            Sample(metric: metric, timestamp: 101, value: 10),
+            Sample(metric: metric, timestamp: 104, value: 100),
+        ]
+        let result = WindowTotal.total(of: points, window: 60, maximumGap: 10)
+        #expect(result?.value == 310)
+        // Four seconds of history, not sixty. The first sample opens the span
+        // and contributes nothing, having no interval before it.
+        #expect(result?.covered == 4)
+    }
+
+    @Test("A window longer than the history reports the span it really has")
+    func shortHistory() {
+        // Ten seconds after launch the buffer holds ten seconds. Reporting the
+        // window it was asked for would put "2 min" under a number covering a
+        // twelfth of that, which is the quiet kind of wrong: nobody checks it.
+        let points = steady(Array(repeating: 1000, count: 21), interval: 0.5, end: 1000)
+        let result = WindowTotal.total(of: points, window: 120, maximumGap: 2)
+        #expect(result?.covered == 10)
+        #expect(result?.value == 10000)
+    }
+
+    @Test("Fewer than two samples has no total at all")
+    func needsTwoSamples() {
+        // The same choice RateTracker makes on a first read. One sample is a
+        // rate with no interval under it, and zero would draw as an idle
+        // machine rather than as a missing answer.
+        #expect(WindowTotal.total(of: [], window: 60, maximumGap: 2) == nil)
+        #expect(WindowTotal.total(of: steady([500]), window: 60, maximumGap: 2) == nil)
+    }
+
+    @Test("An interval longer than maximumGap is clipped and comes off covered")
+    func clampsLongGaps() {
+        // A slept laptop, or a source that failed for a minute, leaves one
+        // enormous interval. A rectangle drawn across it invents traffic that
+        // never happened, so the sample gets maximumGap and the rest of the
+        // span is not claimed as covered.
+        let points = [
+            Sample(metric: metric, timestamp: 100, value: 50),
+            Sample(metric: metric, timestamp: 400, value: 50),
+            Sample(metric: metric, timestamp: 400.5, value: 50),
+        ]
+        let result = WindowTotal.total(of: points, window: 600, maximumGap: 2)
+        // 2 s of the 300 s gap, plus the half second after it.
+        #expect(result?.value == 125)
+        #expect(result?.covered == 2.5)
+    }
+
+    @Test("Samples out of order are totalled in time order")
+    func sortsInput() {
+        // The buffer hands them over oldest first, but a caller assembling a
+        // card's series from several places need not, and a total that depends
+        // on array order is a bug waiting for a refactor.
+        let ordered = steady([0, 10, 20, 30], interval: 1)
+        let shuffled = [ordered[2], ordered[0], ordered[3], ordered[1]]
+        let expected = WindowTotal.total(of: ordered, window: 60, maximumGap: 10)
+        #expect(WindowTotal.total(of: shuffled, window: 60, maximumGap: 10) == expected)
+    }
+
+    @Test("The window ends at the newest sample unless told otherwise")
+    func explicitEnd() {
+        // Same rule CSVExport follows: the right-hand edge of the chart, which
+        // defaults to the newest sample the card holds.
+        let points = steady([100, 100, 100], interval: 1, end: 1000)
+        #expect(WindowTotal.total(of: points, window: 10, maximumGap: 10)?.value == 200)
+        // An end before the last sample excludes it.
+        let earlier = WindowTotal.total(of: points, window: 10, now: 999, maximumGap: 10)
+        #expect(earlier?.value == 100)
+    }
+}
+
+@Suite("MetricUnit accumulation")
+struct MetricUnitAccumulationTests {
+    @Test("Throughput accumulates into bytes, and network divides by eight")
+    func throughput() {
+        #expect(MetricUnit.bytesPerSecond.accumulation?.unit == .bytes)
+        #expect(MetricUnit.bytesPerSecond.accumulation?.scale == 1)
+        // A link is quoted in bits, a volume in bytes. The conversion lives
+        // here so the header and anything downstream cannot disagree.
+        #expect(MetricUnit.bitsPerSecond.accumulation?.unit == .bytes)
+        #expect(MetricUnit.bitsPerSecond.accumulation?.scale == 1.0 / 8)
+    }
+
+    @Test("Operations accumulate into a count")
+    func operations() {
+        #expect(MetricUnit.operationsPerSecond.accumulation?.unit == .count)
+    }
+
+    @Test("A level does not add up")
+    func levels() {
+        // Adding temperatures produces degree-seconds, which is not a quantity
+        // anybody wants under a chart of a CPU getting warm.
+        for unit in [
+            MetricUnit.fraction, .bytes, .count, .hertz, .celsius, .watts, .rpm, .seconds,
+        ] {
+            #expect(unit.accumulation == nil)
+        }
+    }
+}
+
+@Suite("Formatting a total")
+struct TotalFormattingTests {
+    @Test("A network total reads in bytes, not bits")
+    func networkTotalsInBytes() {
+        // 11.2 Gbit is 1.4 GB. Nobody has ever asked how many gigabits they
+        // downloaded, and every cap and file size is quoted the other way.
+        #expect(Format.total(11_200_000_000, unit: .bitsPerSecond) == "1.4 GB")
+        // Disk is already bytes and passes straight through.
+        #expect(Format.total(1_400_000_000, unit: .bytesPerSecond) == "1.4 GB")
+    }
+
+    @Test("An operations total reads as a count with SI suffixes")
+    func operationTotals() {
+        #expect(Format.total(1_234_567, unit: .operationsPerSecond) == "1.2 M")
+        #expect(Format.total(340_000, unit: .operationsPerSecond) == "340 k")
+        #expect(Format.total(847, unit: .operationsPerSecond) == "847")
+    }
+
+    @Test("A unit that does not accumulate has no total")
+    func noTotal() {
+        #expect(Format.total(42, unit: .celsius) == nil)
+        #expect(Format.total(0.5, unit: .fraction) == nil)
+        #expect(Format.widestTotal(unit: .watts) == nil)
+    }
+
+    @Test("The reserved slot is at least as wide as the readings it holds")
+    func reservationCoversRealValues() {
+        // A floor, like widestValue: being wrong here costs a little jitter at
+        // an extreme, never a clipped number. But it must cover the ordinary
+        // range, which is where the eye actually reads it.
+        let bytes = Format.widestTotal(unit: .bitsPerSecond) ?? ""
+        for value in [1000.0, 8_000_000, 11_200_000_000, 800_000_000_000] {
+            #expect(Format.total(value, unit: .bitsPerSecond)?.count ?? 0 <= bytes.count)
+        }
+        let counts = Format.widestTotal(unit: .operationsPerSecond) ?? ""
+        for value in [1.0, 847, 340_000, 1_234_567] {
+            #expect(Format.total(value, unit: .operationsPerSecond)?.count ?? 0 <= counts.count)
+        }
+    }
+}

--- a/Tests/MonitorCoreTests/WindowTotalTests.swift
+++ b/Tests/MonitorCoreTests/WindowTotalTests.swift
@@ -201,6 +201,25 @@ struct TotalFormattingTests {
         #expect(Format.widestTotal(unit: .watts) == nil)
     }
 
+    @Test("A span reads the way the History picker words it")
+    func spans() {
+        // The label sits beside a segmented picker reading exactly these, and
+        // two spellings of one duration on one screen reads as a fault.
+        #expect(Format.span(60) == "1 min")
+        #expect(Format.span(120) == "2 min")
+        #expect(Format.span(300) == "5 min")
+        #expect(Format.span(600) == "10 min")
+    }
+
+    @Test("A span short of a whole minute keeps its seconds")
+    func partialSpans() {
+        // A card 45 s after launch must say so rather than round itself up to
+        // the window it was asked for.
+        #expect(Format.span(45) == "45 s")
+        #expect(Format.span(9.6) == "10 s")
+        #expect(Format.span(90) == "90 s")
+    }
+
     @Test("The reserved slot is at least as wide as the readings it holds")
     func reservationCoversRealValues() {
         // A floor, like widestValue: being wrong here costs a little jitter at

--- a/Tests/MonitorUITests/AppModelTests.swift
+++ b/Tests/MonitorUITests/AppModelTests.swift
@@ -290,3 +290,37 @@ struct DropNeighbourTests {
         #expect(neighbour(after: "z", in: ["a", "b"], edge: .trailing) == nil)
     }
 }
+
+@MainActor
+@Suite("Window totals")
+struct AppModelTotalsTests {
+    /// A stable domain cleared per test, for the reason the suite above gives:
+    /// a uuid each time writes a new plist on every run, forever.
+    private static let domain = "wtf.evan.monitor.tests.totals"
+
+    private static func makeModel() -> AppModel {
+        let defaults = UserDefaults(suiteName: domain)!
+        defaults.removePersistentDomain(forName: domain)
+        return AppModel(sources: [], defaults: defaults)
+    }
+
+    @Test("The gap a total may credit follows the clock, not a constant")
+    func gapFollowsTheClock() {
+        // Somebody who slows the sampler to 2 s has 2 s gaps, and a ceiling
+        // fixed for the 0.5 s default would clip every one of them — quietly
+        // reporting a quarter of the traffic that crossed the wire.
+        let model = Self.makeModel()
+        model.interval = 0.5
+        #expect(model.totalGap == 2)
+        model.interval = 2
+        #expect(model.totalGap == 8)
+    }
+
+    @Test("Totals are off until they are switched on")
+    func offByDefault() {
+        // Same default as mirroring and stacking, and for a version of the same
+        // reason: switching it on reflows headers onto two lines, and a card
+        // that changes shape on upgrade is worse than one somebody switches on.
+        #expect(Self.makeModel().charts.showsTotals == false)
+    }
+}

--- a/Tests/MonitorUITests/AppModelTests.swift
+++ b/Tests/MonitorUITests/AppModelTests.swift
@@ -316,11 +316,10 @@ struct AppModelTotalsTests {
         #expect(model.totalGap == 8)
     }
 
-    @Test("Totals are off until they are switched on")
-    func offByDefault() {
-        // Same default as mirroring and stacking, and for a version of the same
-        // reason: switching it on reflows headers onto two lines, and a card
-        // that changes shape on upgrade is worse than one somebody switches on.
-        #expect(Self.makeModel().charts.showsTotals == false)
+    @Test("Totals are on without being asked for")
+    func onByDefault() {
+        // Unlike mirroring and stacking beside it. Those change what the
+        // picture means; this adds a number next to one already there.
+        #expect(Self.makeModel().charts.showsTotals)
     }
 }

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -216,3 +216,29 @@ readout of `900` is useless until you have also read the word beneath it. The
 A chart axis and the CLI carry three significant figures, which keeps a value's
 width near-constant as it moves. The gauge readout goes further and uses a fixed
 `xxxx.yy` field so the decimal point never moves at all — see `docs/ui.md`.
+
+## What a rate adds up to
+
+`MetricUnit.accumulation` says what a second's worth of a unit becomes, and the
+factor that gets it there. It is nil for every level: adding temperatures gives
+degree-seconds, which is not a quantity anybody wants under a chart of a CPU
+getting warm.
+
+| Unit | Accumulates into | Factor |
+|------|------------------|--------|
+| `bytesPerSecond` | `bytes` | 1 |
+| `bitsPerSecond` | `bytes` | 1/8 |
+| `operationsPerSecond` | `count` | 1 |
+| everything else | — | — |
+
+**Network reads in bits and totals in bytes.** A link is quoted in bits — a
+1 Gbit port, an 866 Mbit Wi-Fi link — so the rate stays Mbit/s. A volume is
+quoted in bytes everywhere it matters: ISP caps, file sizes, Finder. Two
+different questions with two right answers. The divide by eight has exactly one
+definition, in `accumulation`, for the same reason `NetworkSource` multiplies by
+eight in the source rather than in the gauge: nothing downstream can then
+disagree about whether 1.4 GB and 11.2 Gbit are the same reading.
+
+Derived from the unit rather than from a table of metric ids, the same way
+`ChartMirror` and `ChartStack` read `direction` and `composition`. A source
+added later gets a total without anything being told it exists.

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -361,6 +361,34 @@ less than the card's stated span — one source failed for a stretch while its
 neighbour kept reading — is dimmed. The ordinary case spends no ink saying it
 is ordinary.
 
+### A card with totals gets a table, not a wrapped row
+
+The legend has two shapes, because the cards do. A card of levels — Memory's
+seven slices, five temperature sensors — has nothing to total and keeps
+`FlowLayout`, which spends card height only when the entries genuinely do not
+fit across. A card of rates has a second number per series, and numbers in a
+wrapped row do not line up: the first version put the totals at four different
+left edges down the same card.
+
+So those cards draw a small `Grid` instead: swatch, name, rate, total, with the
+totals column **headed and right-justified**. Right-justified because these are
+magnitudes, and a magnitude is read by where its last digit sits — `104 MB` over
+`48 MB` aligned on the left puts the hundreds above the tens and hides the
+difference the column exists to show. Headed because a second bare number beside
+a rate does not say what it is: the span beside the title says *how long*, and
+the heading says *of what*.
+
+The table always goes under the title, never beside it. `ViewThatFits` is the
+right question for a wrapping row and the wrong one for a column of figures —
+pushed to the right of the title on a wide card, the heading floats in the
+middle of the header with nothing under it that reads as a table.
+
+Only five groups accumulate, and every one of them has exactly two series, so
+the table is three rows at its tallest. The reserved-width slot survives into
+it: a `Grid` sizes a column to its widest cell, so without the reservation the
+column would resize as a total crossed a magnitude and shuffle the card while
+somebody read it.
+
 ### A gap nobody sampled is not traffic
 
 `maximumGap` is the widest interval one sample may be credited with. A laptop

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -310,6 +310,76 @@ a registry test proves it. `ChartCard` drops the stack when a mirror is set as
 well, because a band drawn below a baseline would be nonsense however it got
 there.
 
+## Totals for the window
+
+**Show totals for the window** in the Charts tab adds a second number to every
+legend entry: how much moved, beside how fast it is moving. Off by default, for
+a narrower version of the reason mirroring and stacking are — those change what
+the picture means, this only adds a number, but it adds one to a header already
+decided by `ViewThatFits`, so switching it on reflows cards onto two lines.
+
+The gap it fills: a dial answers "how hard is this working right now" and a
+chart answers "what has been happening". Neither answers "how much did that
+transfer cost me", which is the question you have while watching a sync run.
+
+### The arithmetic is already in the buffer
+
+A rate sample **is** the mean over the gap before it — `RateTracker` produces
+`Δcounter / Δt` — so multiplying each sample by the interval it measures and
+summing telescopes back to exactly the counter delta. `WindowTotal`, in
+`MonitorCore` beside `CSVExport`, is that sum. No counter history is kept
+anywhere, no source changes, and nothing is read that the ring buffer does not
+already hold, so this stays inside the rule that nothing is written to disk.
+
+`ChartCard` totals `series` rather than `visible`: the sum needs the sample just
+*before* the window's left edge to measure the partial interval that straddles
+it, and `visible` has already thrown that one away.
+
+### It covers what the chart draws
+
+The window is the History picker's, so the number and the picture answer the
+same question and one control changes both. Ten minutes remains the ceiling,
+because that is what the buffer holds.
+
+### It says the span it really has
+
+`WindowTotal.Result` carries `covered` beside `value`. Ten seconds after launch
+the buffer holds ten seconds, and "2 min" over a number covering a twelfth of
+that is the quiet kind of wrong — it looks exactly like the right answer, so
+nobody checks it. The span sits beside the card's title, and it reads the
+window only when the card really has it, within one `totalGap` of tolerance: a
+card is never going to cover its window to the microsecond, and "119 s" beside
+a picker reading "2 min" looks like a fault rather than like precision.
+
+Stated once beside the title rather than after each entry. The picker is
+global, so repeating "/ 2 min" down a legend is four copies of one fact, in the
+part of the card with the least room to spare. An entry covering materially
+less than the card's stated span — one source failed for a stretch while its
+neighbour kept reading — is dimmed. The ordinary case spends no ink saying it
+is ordinary.
+
+### A gap nobody sampled is not traffic
+
+`maximumGap` is the widest interval one sample may be credited with. A laptop
+coming back from sleep leaves a single enormous gap, and a rectangle drawn
+across it invents traffic that never crossed the wire; the clipped remainder
+comes off `covered` instead, so the span tells you the total is thin.
+
+`AppModel.totalGap` is four ticks of the master clock, so it follows the
+Sampling tab rather than assuming the 0.5 s default. A ceiling fixed for that
+default would clip every interval of a sampler slowed to 2 s.
+
+### Fewer than two samples has no total
+
+Nil, not zero — the same answer `RateTracker` gives on a first read, for the
+same reason. Zero draws as an idle machine rather than as a missing number.
+
+### Not in the CSV
+
+`Copy Data` still carries rates only. A spreadsheet's own `SUM` times the
+interval is this same arithmetic, and a "Total" row under the Time column is a
+type error waiting to be pasted into a chart.
+
 ## The time axis
 
 Three things have to be true of the labels along the bottom, and the first two

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -313,10 +313,13 @@ there.
 ## Totals for the window
 
 **Show totals for the window** in the Charts tab adds a second number to every
-legend entry: how much moved, beside how fast it is moving. Off by default, for
-a narrower version of the reason mirroring and stacking are — those change what
-the picture means, this only adds a number, but it adds one to a header already
-decided by `ViewThatFits`, so switching it on reflows cards onto two lines.
+legend entry: how much moved, beside how fast it is moving. **On by default**,
+unlike mirroring and stacking beside it. It shipped off, to match them, and the
+reaction to the finished feature was "I don't see it". The difference that
+argument missed: those two change what the picture *means*, so a reader who
+never asked for them deserves the chart they had — a total only adds a number
+beside one already there, and a number nobody can find is worth less than a
+header that reflows.
 
 The gap it fills: a dial answers "how hard is this working right now" and a
 chart answers "what has been happening". Neither answers "how much did that


### PR DESCRIPTION
Closes #35.

A second number in every legend entry: how much moved over the window the
chart is drawing, beside how fast it is moving now. Network and disk in
bytes, packets and disk operations as counts.

```
┌─ Network ─── 2 min ──────────────────┐
│  ● In     245 Mbit/s        1.4 GB   │
│  ● Out     12.4 Mbit/s       88 MB   │
│ ▁▂▅█▆▃▂▁▁▂▄▇█▅▃▂▁▁▂▃▅▆█▄▂▁▁▂▃▄▅▃▂▁   │
└──────────────────────────────────────┘
```

## The sum is already in the buffer

A rate sample **is** the mean over the gap before it — `RateTracker` produces
`Δcounter / Δt` — so `Σ(rate × preceding gap)` telescopes back to exactly the
counter delta. `WindowTotal` is that sum. No counter history is kept, no
source changes, and nothing is read that the ring buffer does not already
hold, so this stays well inside the rule that nothing is written to disk.

The round-trip test is the whole premise: build a synthetic counter,
differentiate it with `RateTracker`, integrate it back, expect the original
delta. Deliberately uneven intervals, so it cannot pass by multiplying by a
constant it guessed right.

## Three things it refuses to fake

- **It reports the span it covered.** Ten seconds after launch the buffer
  holds ten seconds, and "2 min" over a twelfth of that looks exactly like the
  right answer — which is why nobody would check it. The span sits beside the
  title and reads the window only when the card really has it.
- **A gap nobody sampled is not traffic.** An interval wider than
  `maximumGap` is clipped and the remainder comes off `covered`, so a laptop
  back from sleep cannot credit one sample with an hour that never crossed the
  wire. `AppModel.totalGap` is four ticks of the master clock, so it follows
  the Sampling tab rather than assuming 0.5 s.
- **Fewer than two samples has no total.** Nil, not zero — the same answer
  `RateTracker` gives on a first read, for the same reason.

## Network totals in bytes

The rate stays Mbit/s because a link is quoted in bits. A volume is quoted in
bytes everywhere it matters. `MetricUnit.accumulation` holds the ÷8 as its
only definition, the way `NetworkSource` holds the ×8 — derived from the unit
like `direction` and `composition`, so a source added later gets a total
without anything being told it exists.

## The one thing worth arguing about

`showsTotals` is **off by default**, following `mirrorsPairs` and
`stacksParts`. The precedent's reason is that those change what the picture
*means*; this only adds a number. The narrower reason it still applies: it
adds one to a header already decided by `ViewThatFits`, so switching it on
reflows cards onto two lines — a card changing shape on upgrade. Happy to
ship it on instead and say so in the release notes.

## Non-goals, each deliberate

No totals row in the CSV (a spreadsheet's `SUM × interval` is this same
arithmetic, and a "Total" row under the Time column is a type error waiting to
be pasted into a chart). No odometer tile — considered, and it is very much
this app's idiom, but it costs panel space and a third tile kind in
`PanelArrangement`. No `monitorctl` totals; no watt-hours; nothing past ten
minutes until the store lands.

## Verification

`swift build && swift test` (205 tests), `swift build -c release`, and
`swiftformat --lint` all clean. Not yet looked at in `swift run monitor` — the
open question is whether a legend entry carrying two numbers still reads at a
glance, and no test can answer that.

https://claude.ai/code/session_01EqTTtmt4fyNtMxjc2ZVBzj