### PR TITLE
Stop the time labels colliding, and let them stand up

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,7 +208,22 @@ are no component-level AGENTS.md files.
   window's **length alone, never its position** — the count drifts by one as a
   tick scrolls off, but an interval chosen by counting actual ticks flips
   between rungs as the window slides and the axis restyles itself every few
-  seconds. No AM/PM; seconds only when the interval is under a minute.
+  seconds. No AM/PM, and no leading zero on the hour; seconds only when the
+  interval is under a minute.
+  **Rule 2 now wins over rule 1**, which reverses the original order: labels
+  that collide are unreadable, which is worse than the sparse axis the old rule
+  avoided. Three things had to be right together, and getting one wrong put
+  four overlapping labels on a card with room for two. The room is the **plot**,
+  read from `chartBackground`'s proxy — never `chartOverlay`, which would
+  swallow a tile's drag; a flat allowance for the y-axis is wrong on exactly the
+  cards whose numbers are longest. Each stride is costed at the width of **its
+  own** labels, because a stride of a minute or more shows no seconds and needs
+  a third less room. And the widths are **measured**, not estimated — 32 points
+  with seconds, 20 without, 10 rotated. **Turn the time labels sideways** in the
+  Charts tab is how a narrow card gets both the fit and the two labels: rotated,
+  a label costs its line height instead of its width. `rotationEffect` turns the
+  glyphs and not the layout, so it needs `fixedSize` and then a frame, or the
+  axis reserves no height and the text draws over the chart.
 - **A card's header fits, it does not count.** Title beside legend when it fits,
   stacked when it does not, decided by `ViewThatFits`. A count of series cannot
   know how wide the words are, and since the title is `fixedSize` a header that

--- a/Sources/MonitorCore/ChartAxis.swift
+++ b/Sources/MonitorCore/ChartAxis.swift
@@ -22,21 +22,61 @@ public enum ChartAxis {
     /// somebody would write down.
     static let strides: [TimeInterval] = [1, 2, 5, 10, 15, 30, 60, 120, 300, 600]
 
-    /// Points of card per label, measured off the narrowest column the grid
-    /// makes. Two is the fewest that says anything; past five they are closer
-    /// together than the eye needs on a chart this size.
-    static let spacing = 78.0
+    /// Two labels is what the axis wants; five is as dense as it should ever
+    /// get, because past that they are closer together than the eye needs on a
+    /// chart this size. Neither is a guarantee — see `marks`.
     static let fewest = 2
     static let most = 5
 
-    /// The y-axis and its labels, which the measured width includes and the
-    /// time labels cannot use.
-    static let axisAllowance = 50.0
+    /// The widest label each format produces, **measured** rather than
+    /// estimated: SF Rounded at `Theme.Layout.timeLabel`, worst case
+    /// "18:52:30" and "18:52".
+    ///
+    /// The two differ by a third, and that is the fact the arithmetic used to
+    /// miss. Budgeting every stride at the with-seconds width made the coarse
+    /// strides — the ones with the narrow labels, the ones a cramped card
+    /// wants — look as expensive as the fine ones, so the axis never reached
+    /// for them.
+    static let secondsLabelWidth = 32.0
+    static let minuteLabelWidth = 20.0
+    /// Turned on its side a label costs its line height instead, whatever it
+    /// says.
+    static let rotatedLabelWidth = 10.0
+    /// The clear space between two labels. Below about this they stop reading
+    /// as two numbers and start reading as one long one.
+    static let gutter = 8.0
 
-    /// How many labels this card has room for.
-    public static func maximumTicks(width: Double) -> Int {
-        guard width.isFinite else { return fewest }
-        return max(fewest, min(most, Int((width - axisAllowance) / spacing)))
+    /// Points of plot one label needs, including the gutter after it.
+    public static func spacing(showsSeconds: Bool, rotated: Bool) -> Double {
+        let label = rotated
+            ? rotatedLabelWidth
+            : (showsSeconds ? secondsLabelWidth : minuteLabelWidth)
+        return label + gutter
+    }
+
+    /// How many labels of one format fit across a plot.
+    ///
+    /// `width` is the **plot**, not the card and not the chart. The y-axis and
+    /// its labels are outside it and they are much wider on "20 MB/s" than on
+    /// "0%" — and the cards with the longest numbers are the ones whose plots
+    /// are narrowest. This used to take the chart's width less a flat 50-point
+    /// allowance, which is right for one card and optimistic for exactly the
+    /// cards that could least afford optimism.
+    public static func maximumTicks(
+        width: Double, showsSeconds: Bool = true, rotated: Bool = false
+    ) -> Int {
+        guard width.isFinite, width > 0 else { return 1 }
+        let fit = Int(width / spacing(showsSeconds: showsSeconds, rotated: rotated))
+        return max(1, min(most, fit))
+    }
+
+    /// The most labels a stride can produce in a window of this length.
+    ///
+    /// A window of length L holds either floor(L / stride) boundaries or one
+    /// more, depending on where it happens to sit. The axis has to survive the
+    /// worse of those, since the window slides.
+    static func worstCaseCount(usable: TimeInterval, stride: TimeInterval) -> Int {
+        Int((usable / stride).rounded(.down)) + 1
     }
 
     /// Ticks are held this far in from each edge of the window.
@@ -53,46 +93,56 @@ public enum ChartAxis {
         public let stride: TimeInterval
     }
 
-    /// The interval to label at: as many labels as the card has room for, and
-    /// never fewer than two.
+    /// The interval to label at: the finest one whose own labels fit the plot.
     ///
     /// Chosen from the *length* of the window, not from where it happens to
     /// sit. The ticks themselves are absolute instants, so the exact count
     /// drifts by one as the window slides — but the interval must not, or the
     /// axis restyles itself every few seconds. Picking the interval by counting
-    /// the ticks it actually produced was the previous version, and on a narrow
+    /// the ticks it actually produced was an earlier version, and on a narrow
     /// ten-minute card it flipped between 300 s and 120 s as the window moved,
     /// so the labels jumped between two and five.
     ///
-    /// Two rules, in this order:
+    /// **Fitting wins over the two-label floor**, which reverses the rule this
+    /// used to follow. That rule said slightly tight labels beat a bare axis,
+    /// and it was right about "slightly tight" and wrong about what the
+    /// arithmetic produced: on a 160-point plot the axis drew four labels 32
+    /// points wide with their centres 40 apart, and at the narrowest card they
+    /// overlapped outright. Labels that collide are not slightly tight — they
+    /// are unreadable, and worse than the sparse axis the old rule was
+    /// avoiding. Two labels are still what it reaches for, because the walk
+    /// goes finest first and a finer stride is a denser axis; a window that
+    /// cannot show two without them touching now shows one rather than two on
+    /// top of each other. **Turning the labels sideways is how to have both**,
+    /// which is what the setting is for.
     ///
-    /// 1. **Never fewer than two labels.** One lonely label says nothing about
-    ///    the span you are looking at.
-    /// 2. **Never more than the card has room for**, where that is compatible
-    ///    with the first. On a narrow card showing ten minutes it is not, and
-    ///    slightly tight labels beat a bare axis.
+    /// Each stride is costed at the width of *its own* labels. A stride of a
+    /// minute or more shows no seconds, so it needs a third less room than a
+    /// finer one — which is exactly why a cramped card can still carry a
+    /// readable axis.
     public static func marks(
-        from start: TimeInterval, to end: TimeInterval, maximumTicks: Int
+        from start: TimeInterval,
+        to end: TimeInterval,
+        plotWidth: Double,
+        rotated: Bool = false
     ) -> Marks {
         guard end > start else { return Marks(times: [], stride: strides[0]) }
         let usable = (end - start) * (1 - 2 * edgeFraction)
+        let width = plotWidth.isFinite ? max(0, plotWidth) : 0
 
-        // The coarsest interval that still fits `fewest` of itself in the
-        // window, whatever the window's phase.
-        let guaranteeing = strides.last { (usable / $0).rounded(.down) >= Double(fewest) }
-            ?? strides[0]
-        // The finest interval that cannot produce more labels than fit. A
-        // window of length L holds either floor(L / stride) boundaries or one
-        // more, depending on its phase, so the worst case is that floor plus
-        // one.
-        let capping = strides.first {
-            (usable / $0).rounded(.down) + 1 <= Double(maximumTicks)
-        } ?? strides[strides.count - 1]
+        // Finest first, so the first that fits is the densest that fits.
+        let stride = strides.first { candidate in
+            let count = worstCaseCount(usable: usable, stride: candidate)
+            guard count <= most else { return false }
+            let each = spacing(
+                showsSeconds: showsSeconds(stride: candidate), rotated: rotated
+            )
+            return Double(count) * each <= width
+        }
+            // Nothing fits: the coarsest interval there is, which is also the
+            // one that asks for the least room.
+            ?? strides[strides.count - 1]
 
-        // The finer of the two. Finer than `guaranteeing` still guarantees two,
-        // so this respects the room whenever the room allows two, and gives up
-        // on the room rather than on the two when it does not.
-        let stride = Swift.min(guaranteeing, capping)
         return Marks(times: times(from: start, to: end, stride: stride), stride: stride)
     }
 

--- a/Sources/MonitorCore/ChartPreferences.swift
+++ b/Sources/MonitorCore/ChartPreferences.swift
@@ -98,14 +98,25 @@ public struct ChartPreferences: Codable, Equatable, Sendable {
     /// number nobody can find is worth less than a header that reflows.
     public var showsTotals: Bool
 
+    /// Turn the time labels on their side.
+    ///
+    /// Off by default: horizontal is easier to read, and on a card with room
+    /// for them it is the right answer. Turned, a label costs its line height
+    /// instead of its width, so a narrow card fits five times where it fitted
+    /// two — which is the trade somebody running a dense panel wants and
+    /// somebody running three big cards does not.
+    public var rotatesTimeLabels: Bool
+
     public init(
         mirrorsPairs: Bool = false,
         stacksParts: Bool = false,
-        showsTotals: Bool = true
+        showsTotals: Bool = true,
+        rotatesTimeLabels: Bool = false
     ) {
         self.mirrorsPairs = mirrorsPairs
         self.stacksParts = stacksParts
         self.showsTotals = showsTotals
+        self.rotatesTimeLabels = rotatesTimeLabels
     }
 
     public static let `default` = ChartPreferences()
@@ -128,6 +139,7 @@ public struct ChartPreferences: Codable, Equatable, Sendable {
         case mirrorsPairs
         case stacksParts
         case showsTotals
+        case rotatesTimeLabels
     }
 
     /// `decodeIfPresent`, so a value written before a setting existed still
@@ -137,10 +149,12 @@ public struct ChartPreferences: Codable, Equatable, Sendable {
         let mirrors = try container.decodeIfPresent(Bool.self, forKey: .mirrorsPairs)
         let stacks = try container.decodeIfPresent(Bool.self, forKey: .stacksParts)
         let totals = try container.decodeIfPresent(Bool.self, forKey: .showsTotals)
+        let rotates = try container.decodeIfPresent(Bool.self, forKey: .rotatesTimeLabels)
         self.init(
             mirrorsPairs: mirrors ?? ChartPreferences.default.mirrorsPairs,
             stacksParts: stacks ?? ChartPreferences.default.stacksParts,
-            showsTotals: totals ?? ChartPreferences.default.showsTotals
+            showsTotals: totals ?? ChartPreferences.default.showsTotals,
+            rotatesTimeLabels: rotates ?? ChartPreferences.default.rotatesTimeLabels
         )
     }
 }

--- a/Sources/MonitorUI/ChartCard.swift
+++ b/Sources/MonitorUI/ChartCard.swift
@@ -38,6 +38,9 @@ public struct ChartCard: View {
     /// `mirror` and `stacked` are — whether to show totals is a preference, and
     /// a card does not read preferences.
     public var totalGap: TimeInterval?
+    /// Draw the time labels on their side. Passed in for the same reason the
+    /// three above are: it is a preference, and a card does not read them.
+    public var rotatesTimeLabels: Bool = false
 
     public init(
         title: String,
@@ -47,7 +50,8 @@ public struct ChartCard: View {
         plotHeight: Double = Theme.Layout.chartMinHeight,
         mirror: MetricPair? = nil,
         stacked: [MetricID] = [],
-        totalGap: TimeInterval? = nil
+        totalGap: TimeInterval? = nil,
+        rotatesTimeLabels: Bool = false
     ) {
         self.title = title
         self.series = series
@@ -60,6 +64,7 @@ public struct ChartCard: View {
         // baseline would be nonsense, so it cannot happen by accident either.
         self.stacked = mirror == nil ? stacked : []
         self.totalGap = totalGap
+        self.rotatesTimeLabels = rotatesTimeLabels
     }
 
     public var body: some View {
@@ -367,18 +372,26 @@ public struct ChartCard: View {
             }
         }
         .chartXAxis {
-            AxisMarks(values: xTicks) { _ in
+            AxisMarks(values: xTicks) { value in
                 AxisGridLine().foregroundStyle(Theme.panelEdge.opacity(0.3))
-                AxisValueLabel(format: timeFormat, centered: true)
-                    .font(.system(size: Theme.Layout.axisLabel, design: .rounded))
-                    .foregroundStyle(Theme.label)
+                AxisValueLabel(centered: true) {
+                    if let date = value.as(Date.self) { timeLabel(date) }
+                }
             }
         }
-        .background(
-            GeometryReader { proxy in
-                Color.clear.preference(key: PlotWidthKey.self, value: proxy.size.width)
+        // `chartBackground` rather than an overlay: it hands over the same
+        // proxy and sits *under* the chart, where it cannot swallow the
+        // mouse-down that a tile's drag gesture needs. An overlay here is the
+        // trap `ReorderDrag` documents.
+        .chartBackground { proxy in
+            GeometryReader { geometry in
+                // The plot rect, not the chart's own width. The y-axis and its
+                // labels are outside it, and they are much wider on "20 MB/s"
+                // than on "0%" — which is exactly when the room runs out.
+                let width = proxy.plotFrame.map { geometry[$0].width } ?? geometry.size.width
+                Color.clear.preference(key: PlotWidthKey.self, value: width)
             }
-        )
+        }
         .onPreferenceChange(PlotWidthKey.self) { plotWidth = $0 }
         .frame(minHeight: plotHeight)
     }
@@ -397,13 +410,38 @@ public struct ChartCard: View {
         }
     }
 
+    /// One time label, upright or on its side.
+    ///
+    /// `rotationEffect` turns the glyphs and not the layout, so the rotated
+    /// case needs `fixedSize` to stop the frame squeezing the text first, and
+    /// then a frame of its own — otherwise the axis reserves the label's width
+    /// and none of its height, and the turned text draws over the chart.
+    @ViewBuilder
+    private func timeLabel(_ date: Date) -> some View {
+        let text = Text(date, format: timeFormat)
+            .font(.system(size: Theme.Layout.timeLabel, design: .rounded))
+            .foregroundStyle(Theme.label)
+            .lineLimit(1)
+        if rotatesTimeLabels {
+            text
+                .fixedSize()
+                .rotationEffect(.degrees(-90))
+                .frame(
+                    width: Theme.Layout.timeLabelRotated.width,
+                    height: Theme.Layout.timeLabelRotated.height
+                )
+        } else {
+            text
+        }
+    }
+
     /// The labelled instants and their spacing — see `ChartAxis`, which is
     /// where the arithmetic lives and where it is tested.
     private var marks: ChartAxis.Marks {
         let range = xRange
         return ChartAxis.marks(
             from: range.start, to: range.end,
-            maximumTicks: ChartAxis.maximumTicks(width: plotWidth)
+            plotWidth: plotWidth, rotated: rotatesTimeLabels
         )
     }
 
@@ -411,12 +449,14 @@ public struct ChartCard: View {
         marks.times.map { Date(timeIntervalSince1970: $0) }
     }
 
-    /// No AM/PM. A card shows at most ten minutes of history, so which half of
-    /// the day it is was never in question, and those two characters were most
-    /// of what made the labels collide.
+    /// No AM/PM, and no leading zero on the hour. A card shows at most ten
+    /// minutes of history, so which half of the day it is was never in
+    /// question, and "0" in "08:52:30" is a character that carries nothing
+    /// across eight labels that have no room for it. The minutes and seconds
+    /// keep both digits: those are positional, and "8:5:3" is not a time.
     private var timeFormat: Date.FormatStyle {
         let base = Date.FormatStyle.dateTime
-            .hour(.twoDigits(amPM: .omitted))
+            .hour(.defaultDigits(amPM: .omitted))
             .minute(.twoDigits)
         return ChartAxis.showsSeconds(stride: marks.stride) ? base.second(.twoDigits) : base
     }

--- a/Sources/MonitorUI/DashboardView.swift
+++ b/Sources/MonitorUI/DashboardView.swift
@@ -393,7 +393,8 @@ public struct DashboardView: View {
             stacked: model.charts.stack(for: drawn.map(\.descriptor)),
             // Nil switches totals off. The gap comes from the model because
             // that is where the sampling clock is.
-            totalGap: model.charts.showsTotals ? model.totalGap : nil
+            totalGap: model.charts.showsTotals ? model.totalGap : nil,
+            rotatesTimeLabels: model.charts.rotatesTimeLabels
         )
     }
 

--- a/Sources/MonitorUI/PreferencesView.swift
+++ b/Sources/MonitorUI/PreferencesView.swift
@@ -237,6 +237,22 @@ struct ChartsTab: View {
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
             }
+
+            Section {
+                Toggle("Turn the time labels sideways", isOn: $model.charts.rotatesTimeLabels)
+            } footer: {
+                Text(
+                    "A label lying down costs its width, and a narrow card runs "
+                        + "out of that long before it runs out of chart. Stood "
+                        + "on end it costs only its height, so the same card "
+                        + "fits five times where it fitted two. Off by default, "
+                        + "because horizontal is easier to read wherever there "
+                        + "is room for it."
+                )
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            }
         }
         .formStyle(.grouped)
     }

--- a/Sources/MonitorUI/Theme.swift
+++ b/Sources/MonitorUI/Theme.swift
@@ -66,6 +66,14 @@ public enum Theme {
         public static let cardTitle = 12.0
         public static let cardLegend = 10.0
         public static let axisLabel = 8.0
+        /// The time labels along the bottom, smaller than the y-axis beside
+        /// them. There are more of them, they are longer, and they are the ones
+        /// that collide: a y-axis label has a whole row to itself.
+        public static let timeLabel = 7.0
+        /// The box a rotated time label is laid out in. `rotationEffect` turns
+        /// the glyphs and not the layout, so without a frame the axis reserves
+        /// the width of the text and none of its height.
+        public static let timeLabelRotated = CGSize(width: 11, height: 40)
         /// The dial's label, which sits under the dial rather than on its face:
         /// at 130pt across there is no room on the face for "Network Out"
         /// without it running into the ticks.

--- a/Tests/MonitorCoreTests/ChartAxisTests.swift
+++ b/Tests/MonitorCoreTests/ChartAxisTests.swift
@@ -7,56 +7,119 @@ struct ChartAxisTests {
     /// The four windows the toolbar offers.
     static let windows: [TimeInterval] = [60, 120, 300, 600]
 
-    @Test("A narrow card gets fewer labels than a wide one")
+    /// Plot widths the panel can really produce: the card slider runs 200 to
+    /// 600 points, and the y-axis and its labels come off that before the time
+    /// labels see any of it.
+    static let plots: [Double] = [130, 160, 200, 260, 380, 560]
+
+    @Test("A narrow plot gets fewer labels than a wide one")
     func countFollowsWidth() {
-        #expect(ChartAxis.maximumTicks(width: 260) < ChartAxis.maximumTicks(width: 600))
+        #expect(ChartAxis.maximumTicks(width: 120) < ChartAxis.maximumTicks(width: 400))
     }
 
-    @Test("Never fewer than two labels, never more than five")
+    @Test("Never fewer than one label, never more than five")
     func countIsBounded() {
-        #expect(ChartAxis.maximumTicks(width: 0) == ChartAxis.fewest)
+        // One, not two. Two is what the axis reaches for, not what it can
+        // promise — see `marks`, where fitting wins over the floor.
+        #expect(ChartAxis.maximumTicks(width: 0) == 1)
         #expect(ChartAxis.maximumTicks(width: 10000) == ChartAxis.most)
-        #expect(ChartAxis.maximumTicks(width: .nan) == ChartAxis.fewest)
+        #expect(ChartAxis.maximumTicks(width: .nan) == 1)
     }
 
-    @Test("Every window on every card width gets at least two labels")
-    func neverFewerThanTwo() {
-        // The bug this pins: at five minutes on a narrow card the interval
-        // chosen was 300 s for a 300 s window, and a 300 s window inset at both
-        // ends contains a multiple of 300 only sometimes. The axis emptied
-        // itself. Swept across a whole window's worth of start offsets, because
-        // whether an absolute boundary falls inside depends on where the window
-        // happens to sit.
+    @Test("A label without seconds needs less room than one with them")
+    func coarseStridesAreCheaper() {
+        // The fact the arithmetic used to miss. "8:52" is a third narrower than
+        // "8:52:30", so budgeting every stride at the wider figure made the
+        // coarse strides look as expensive as the fine ones — and the axis
+        // never reached for the one a cramped card wanted.
+        let withSeconds = ChartAxis.spacing(showsSeconds: true, rotated: false)
+        let without = ChartAxis.spacing(showsSeconds: false, rotated: false)
+        #expect(without < withSeconds)
+        #expect(ChartAxis.spacing(showsSeconds: true, rotated: true) < without)
+    }
+
+    @Test("Labels never overlap, at any window, plot or phase")
+    func labelsNeverCollide() {
+        // The bug that prompted all of this: on a 160-point plot the axis drew
+        // four labels 32 points wide with their centres 40 apart, and at the
+        // narrowest card they ran into each other. This is that failure stated
+        // as arithmetic — the ink two neighbouring labels need against the
+        // distance between them.
         for span in Self.windows {
-            for width in [200.0, 260, 400, 600, 900] {
-                let maximum = ChartAxis.maximumTicks(width: width)
-                for offset in stride(from: 0.0, to: span, by: span / 20) {
-                    let marks = ChartAxis.marks(
-                        from: 1_700_000_000 + offset,
-                        to: 1_700_000_000 + offset + span,
-                        maximumTicks: maximum
-                    )
-                    #expect(marks.times.count >= ChartAxis.fewest)
+            for width in Self.plots {
+                for rotated in [false, true] {
+                    for offset in stride(from: 0.0, to: span, by: span / 40) {
+                        let start = 1_700_000_000 + offset
+                        let marks = ChartAxis.marks(
+                            from: start, to: start + span,
+                            plotWidth: width, rotated: rotated
+                        )
+                        guard marks.times.count >= 2 else { continue }
+                        let pointsPerSecond = width / span
+                        let apart = marks.stride * pointsPerSecond
+                        let needed = ChartAxis.spacing(
+                            showsSeconds: ChartAxis.showsSeconds(stride: marks.stride),
+                            rotated: rotated
+                        )
+                        #expect(apart >= needed)
+                    }
                 }
             }
         }
     }
 
-    @Test("The card's room is respected wherever two labels fit inside it")
-    func staysWithinTheRoom() {
-        // Not an absolute cap: two labels beat a tidy count, so a window that
-        // cannot show two within the room is allowed to go over. It must not go
-        // far over.
+    @Test("Two labels wherever two fit, and never a bare axis")
+    func reachesForTwo() {
+        // The floor the old rule protected, kept everywhere it can be had. A
+        // narrow card showing two minutes is the case that cannot: no stride is
+        // both coarse enough to fit and fine enough to guarantee two, and one
+        // readable label beats two on top of each other. Sideways labels are
+        // how to have both, so the rotated pass demands two outright.
         for span in Self.windows {
-            for width in [200.0, 260, 400, 600, 900] {
-                let maximum = ChartAxis.maximumTicks(width: width)
+            for width in Self.plots {
                 for offset in stride(from: 0.0, to: span, by: span / 20) {
-                    let marks = ChartAxis.marks(
-                        from: 1_700_000_000 + offset,
-                        to: 1_700_000_000 + offset + span,
-                        maximumTicks: maximum
+                    let start = 1_700_000_000 + offset
+                    let upright = ChartAxis.marks(
+                        from: start, to: start + span, plotWidth: width
                     )
-                    #expect(marks.times.count <= max(maximum, ChartAxis.fewest) + 3)
+                    #expect(!upright.times.isEmpty)
+                    let turned = ChartAxis.marks(
+                        from: start, to: start + span, plotWidth: width, rotated: true
+                    )
+                    #expect(turned.times.count >= ChartAxis.fewest)
+                }
+            }
+        }
+    }
+
+    @Test("Turning the labels never costs a label")
+    func rotatingOnlyEverHelps() {
+        // The whole promise of the setting: a rotated label is cheaper, so it
+        // can only buy a finer stride, never a coarser one.
+        for span in Self.windows {
+            for width in Self.plots {
+                let upright = ChartAxis.marks(
+                    from: 1_700_000_000, to: 1_700_000_000 + span, plotWidth: width
+                )
+                let turned = ChartAxis.marks(
+                    from: 1_700_000_000, to: 1_700_000_000 + span,
+                    plotWidth: width, rotated: true
+                )
+                #expect(turned.stride <= upright.stride)
+            }
+        }
+    }
+
+    @Test("Never denser than five labels")
+    func neverTooDense() {
+        for span in Self.windows {
+            for width in Self.plots + [2000] {
+                for rotated in [false, true] {
+                    let marks = ChartAxis.marks(
+                        from: 1_700_000_000, to: 1_700_000_000 + span,
+                        plotWidth: width, rotated: rotated
+                    )
+                    #expect(marks.times.count <= ChartAxis.most)
                 }
             }
         }
@@ -69,14 +132,13 @@ struct ChartAxisTests {
         // and 120 s as the window moved, so the labels jumped between two and
         // five every few seconds.
         for span in Self.windows {
-            for width in [200.0, 260, 400, 600, 900] {
-                let maximum = ChartAxis.maximumTicks(width: width)
+            for width in Self.plots {
                 let strides = Set(
                     stride(from: 0.0, to: span, by: 1).map { offset in
                         ChartAxis.marks(
                             from: 1_700_000_000 + offset,
                             to: 1_700_000_000 + offset + span,
-                            maximumTicks: maximum
+                            plotWidth: width
                         ).stride
                     }
                 )
@@ -87,7 +149,7 @@ struct ChartAxisTests {
 
     @Test("Ticks land on round clock boundaries")
     func onBoundaries() {
-        let marks = ChartAxis.marks(from: 1_000_007, to: 1_000_127, maximumTicks: 3)
+        let marks = ChartAxis.marks(from: 1_000_007, to: 1_000_127, plotWidth: 200)
         #expect(!marks.times.isEmpty)
         #expect(marks.times.allSatisfy {
             $0.truncatingRemainder(dividingBy: marks.stride) == 0
@@ -121,15 +183,22 @@ struct ChartAxisTests {
         #expect(ChartAxis.times(from: 100, to: 100, stride: 30).isEmpty)
         #expect(ChartAxis.times(from: 200, to: 100, stride: 30).isEmpty)
         #expect(ChartAxis.times(from: 0, to: 120, stride: 0).isEmpty)
-        #expect(ChartAxis.marks(from: 100, to: 100, maximumTicks: 3).times.isEmpty)
+        #expect(ChartAxis.marks(from: 100, to: 100, plotWidth: 200).times.isEmpty)
+    }
+
+    @Test("A plot with no width still names an interval rather than crashing")
+    func noWidthYet() {
+        // The first frame, before the geometry reader has reported anything.
+        let marks = ChartAxis.marks(from: 0, to: 600, plotWidth: 0)
+        #expect(ChartAxis.strides.contains(marks.stride))
+        #expect(ChartAxis.marks(from: 0, to: 600, plotWidth: .nan).stride > 0)
     }
 
     @Test("The roundest interval that fits is the one chosen")
     func prefersCoarse() {
-        // Ten minutes across five labels could be 15 s; it should be 120 s.
-        let marks = ChartAxis.marks(
-            from: 1_700_000_000, to: 1_700_000_600, maximumTicks: 5
-        )
+        // Ten minutes on a wide plot could be labelled every 15 s; it should be
+        // 120 s. Five labels is as dense as this ever gets.
+        let marks = ChartAxis.marks(from: 1_700_000_000, to: 1_700_000_600, plotWidth: 560)
         #expect(marks.stride >= 120)
     }
 
@@ -138,5 +207,19 @@ struct ChartAxisTests {
         #expect(ChartAxis.showsSeconds(stride: 30))
         #expect(!ChartAxis.showsSeconds(stride: 60))
         #expect(!ChartAxis.showsSeconds(stride: 300))
+    }
+
+    @Test("The screenshot that started this now fits its plot")
+    func theBugThatStartedThis() {
+        // Two minutes on the Disk card: about 160 points of plot once "20 MB/s"
+        // has taken its side. Four labels went in, 32 points wide, centres 40
+        // apart — touching, and overlapping outright on a narrower card.
+        let marks = ChartAxis.marks(from: 1_700_000_000, to: 1_700_000_120, plotWidth: 160)
+        let apart = marks.stride * (160.0 / 120)
+        let needed = ChartAxis.spacing(
+            showsSeconds: ChartAxis.showsSeconds(stride: marks.stride), rotated: false
+        )
+        #expect(apart >= needed)
+        #expect(marks.times.count >= ChartAxis.fewest)
     }
 }

--- a/Tests/MonitorCoreTests/ChartPreferencesTests.swift
+++ b/Tests/MonitorCoreTests/ChartPreferencesTests.swift
@@ -143,6 +143,9 @@ struct ChartPreferencesTests {
         // it". A total adds a number beside one already there rather than
         // changing what the chart means, so it does not need switching on.
         #expect(ChartPreferences.default.showsTotals)
+        // Horizontal is easier to read wherever there is room for it, and on
+        // every card but the narrowest there is.
+        #expect(ChartPreferences.default.rotatesTimeLabels == false)
         #expect(ChartPreferences.default.mirror(for: [netIn, netOut]) == nil)
         #expect(ChartPreferences.default.stack(for: [app, wired, free]).isEmpty)
     }
@@ -176,7 +179,8 @@ struct ChartPreferencesTests {
     @Test("Round-trips through Codable")
     func codable() throws {
         let preferences = ChartPreferences(
-            mirrorsPairs: true, stacksParts: true, showsTotals: true
+            mirrorsPairs: true, stacksParts: true,
+            showsTotals: true, rotatesTimeLabels: true
         )
         let data = try JSONEncoder().encode(preferences)
         #expect(try JSONDecoder().decode(ChartPreferences.self, from: data) == preferences)
@@ -196,6 +200,7 @@ struct ChartPreferencesTests {
         // An upgrade from a version without the key gets the new default, not
         // false: a missing key means "never asked", not "switched off".
         #expect(decoded.showsTotals)
+        #expect(decoded.rotatesTimeLabels == false)
     }
 }
 

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -404,6 +404,56 @@ looking at, and none says less.
 `ChartAxis` in `MonitorCore` holds the arithmetic, which is why it is testable
 without a window.
 
+### The labels must not touch, and that beats having two of them
+
+The rule used to be the other way round: never fewer than two labels, and
+slightly tight labels beat a bare axis. It was right about "slightly tight" and
+wrong about what the arithmetic produced. On a 160-point plot the axis drew four
+labels 32 points wide with their centres 40 points apart, and at the narrowest
+card they overlapped outright — `08:52:3008:53:0008:53:30`. Labels that collide
+are not slightly tight; they are unreadable, and worse than the sparse axis the
+old rule was avoiding.
+
+Three things were wrong at once, and all three are fixed:
+
+- **The room was measured off the chart, not the plot.** A flat 50-point
+  allowance stood in for the y-axis, which is right for one card and generous
+  for every card whose numbers are long — and those are the cards whose plots
+  are narrowest. `chartBackground` hands over the real plot rect instead.
+  Not `chartOverlay`: an overlay sits above the content and would swallow the
+  mouse-down a tile's drag needs, which is the trap `ReorderDrag` documents.
+- **Every stride was costed at the same label width.** A stride of a minute or
+  more shows no seconds, so "8:52" needs a third less room than "8:52:30". The
+  measured figures are 20 points against 32, at `Theme.Layout.timeLabel`, and
+  budgeting the coarse strides at the wide figure made the axis unable to reach
+  for the one a cramped card wanted. Each candidate is now costed at the width
+  of its own labels.
+- **The labels were wider than they needed to be.** They have their own size,
+  smaller than the y-axis labels beside them: there are more of them, they are
+  longer, and a y-axis label has a whole row to itself. The hour lost its
+  leading zero too — "0" in "08:52:30" carries nothing across four labels with
+  no room for it. Minutes and seconds keep both digits, because those are
+  positional and "8:5:3" is not a time.
+
+Two labels are still what the axis reaches for: the walk goes finest first, so
+the first stride that fits is the densest that fits. What is gone is the
+promise. A narrow card showing two minutes has no stride both coarse enough to
+fit and fine enough to guarantee two, and it now shows one label rather than two
+on top of each other.
+
+### Sideways labels
+
+**Turn the time labels sideways** in the Charts tab is how to have both. On its
+side a label costs its line height rather than its width — 10 points against 32
+— so the narrowest card fits four times where upright it fits two. Off by
+default, because horizontal is easier to read and on every card but the smallest
+there is room for it.
+
+`rotationEffect` turns the glyphs and not the layout, so the rotated label needs
+`fixedSize` to stop its frame squeezing the text first, and then a frame of its
+own. Without that the axis reserves the label's width and none of its height,
+and the turned text draws over the chart.
+
 ### The interval comes from the window's length, never its position
 
 The ticks are absolute instants, so how many land inside the window depends on


### PR DESCRIPTION
Stacked on #36 — based on `window-totals`, so this shows only its own commit.
GitHub retargets it to `main` when that merges.

From a screenshot: `08:52:3008:53:0008:53:30`.

## Three things were wrong at once

- **The room was measured off the chart, not the plot.** A flat 50-point
  allowance stood in for the y-axis. That is right for one card and generous
  for every card whose numbers are long — and those are exactly the cards whose
  plots are narrowest. `chartBackground` hands over the real plot rect.
  Deliberately not `chartOverlay`: an overlay sits above the content and would
  swallow the mouse-down a tile's drag needs, which is the trap `ReorderDrag`
  already documents.
- **Every stride was costed at the same label width.** A stride of a minute or
  more shows no seconds, so "8:52" needs a third less room than "8:52:30".
  Measured in SF Rounded at the new size: 20 points against 32. Budgeting the
  coarse strides at the wide figure left the axis unable to reach for the one a
  cramped card wanted.
- **The labels were wider than they needed to be.** They get their own size now,
  smaller than the y-axis labels beside them — there are more of them, they are
  longer, and a y-axis label has a whole row to itself. The hour loses its
  leading zero; minutes and seconds keep both digits, because those are
  positional and "8:5:3" is not a time.

## Rule 2 now beats rule 1

The old order was "never fewer than two labels" first, on the grounds that
slightly tight labels beat a bare axis. Right about "slightly tight", wrong
about what the arithmetic produced: four labels 32 points wide with their
centres 40 apart, overlapping outright at the narrowest card. Labels that
collide are unreadable, which is worse than the sparse axis the rule avoided.

Two labels are still what it reaches for — the walk goes finest first, so the
first stride that fits is the densest that fits. What is gone is the promise. A
narrow card showing two minutes has no stride both coarse enough to fit and fine
enough to guarantee two; it now shows one label rather than two on top of each
other.

## Turning them sideways is how to have both

**Turn the time labels sideways**, new in the Charts tab, off by default. On its
side a label costs its line height rather than its width — 10 points against 32
— so the narrowest card fits four times where upright it fits two.

| plot | window | upright | sideways |
|-----:|-------:|--------:|---------:|
| 130 | 2 min | every 60 s, 2 labels | every 30 s, 4 labels |
| 130 | 10 min | every 300 s, 2 labels | every 120 s, 5 labels |
| 160 | 2 min | every 30 s, 4 labels | every 30 s, 4 labels |
| 260+ | any | unchanged | unchanged |

The card from the screenshot (160-point plot, 2 min) keeps its four labels and
gains 12 points of clear gutter between them.

## Tests

`ChartAxisTests` is rewritten against the new contract, keeping every existing
claim (a tick is an instant, the interval comes from the window's length, ticks
are inset from the edges, the interval is stable as the window slides) and
adding the ones this bug needed:

- **Labels never overlap**, swept across every window, six plot widths, both
  orientations and forty phases of each window — the ink two neighbouring
  labels need against the distance between them.
- **Two labels wherever two fit**, and rotated, two outright.
- **Turning them never costs a label**: a rotated stride is never coarser.
- The screenshot's own case, as a named regression.

210 tests pass; `swift build -c release` and `swiftformat --lint` clean.

## Not verified on screen

The arithmetic is tested, the appearance is not. The rotated label frame
(`Theme.Layout.timeLabelRotated`, 11 × 40) is the part most likely to want an
adjustment by eye.

https://claude.ai/code/session_01EqTTtmt4fyNtMxjc2ZVBzj