### PR TITLE
Totals over the window, a readable time axis, and a build stamp

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,4 +63,4 @@ jobs:
           echo "swiftformat $(swiftformat --version)"
 
       - name: Lint
-        run: swiftformat Sources Tests --lint --cache ignore
+        run: swiftformat Sources Tests Plugins --lint --cache ignore

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,7 +208,22 @@ are no component-level AGENTS.md files.
   window's **length alone, never its position** — the count drifts by one as a
   tick scrolls off, but an interval chosen by counting actual ticks flips
   between rungs as the window slides and the axis restyles itself every few
-  seconds. No AM/PM; seconds only when the interval is under a minute.
+  seconds. No AM/PM, and no leading zero on the hour; seconds only when the
+  interval is under a minute.
+  **Rule 2 now wins over rule 1**, which reverses the original order: labels
+  that collide are unreadable, which is worse than the sparse axis the old rule
+  avoided. Three things had to be right together, and getting one wrong put
+  four overlapping labels on a card with room for two. The room is the **plot**,
+  read from `chartBackground`'s proxy — never `chartOverlay`, which would
+  swallow a tile's drag; a flat allowance for the y-axis is wrong on exactly the
+  cards whose numbers are longest. Each stride is costed at the width of **its
+  own** labels, because a stride of a minute or more shows no seconds and needs
+  a third less room. And the widths are **measured**, not estimated — 32 points
+  with seconds, 20 without, 10 rotated. **Turn the time labels sideways** in the
+  Charts tab is how a narrow card gets both the fit and the two labels: rotated,
+  a label costs its line height instead of its width. `rotationEffect` turns the
+  glyphs and not the layout, so it needs `fixedSize` and then a frame, or the
+  axis reserves no height and the text draws over the chart.
 - **A card's header fits, it does not count.** Title beside legend when it fits,
   stacked when it does not, decided by `ViewThatFits`. A count of series cannot
   know how wide the words are, and since the title is `fixedSize` a header that

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@ swift run monitorctl list        # every source and the metrics it declares
 swift run monitorctl read        # read every metric once
 swift run monitorctl watch --source disk --interval 0.5
 swift run monitorctl watch --json --count 5        # machine-readable, bounded
-swiftformat Sources Tests --lint --cache ignore    # CI lint gate
+swiftformat Sources Tests Plugins --lint --cache ignore   # CI lint gate
 Scripts/make-app.sh [dest]       # wrap the release binary in monitor.app
 Scripts/make-icon.swift out.icns # draw the app icon (make-app.sh calls this)
 Scripts/notarize.sh app zip      # notarize a Developer ID build and staple it
@@ -79,6 +79,9 @@ Sources/
                    linked into the app — see "Guardrails" below.
   monitor/         the app target (@main SwiftUI App) and its AppDelegate
   monitorctl/      headless CLI harness
+Plugins/
+  StampCommit/     prebuild plugin: writes the commit into a Swift constant
+                   before every build, so the title bar cannot go stale
 Scripts/           make-app.sh, which builds monitor.app, make-icon.swift,
                    which draws its icon, and notarize.sh, which notarizes and
                    staples a Developer ID build
@@ -322,6 +325,21 @@ are no component-level AGENTS.md files.
   **`notarize.sh` rebuilds the zip after stapling** — `stapler`
   writes into the bundle, not the archive, so the uploaded copy is unstapled
   until it is made again. `docs/signing.md` is the setup.
+- **The title bar says which build this is.** `BuildStamp.label` — the commit
+  and when it was made — beside the window title, drawn in `Theme.readout`
+  rather than the title bar's secondary style, because a stamp nobody can read
+  at a glance is one nobody checks. **The two halves are sourced differently on
+  purpose.** The commit is stamped at build time by the `StampCommit` prebuild
+  plugin (`git describe --tags --always --dirty`), because a running program has
+  no other way to know it and a checked-in constant is one somebody has to
+  remember to update. The build time is read at *runtime* from the executable's
+  own modification date — stamping it too would rewrite a source file on every
+  build and recompile `MonitorCore` every time, which is the fast `swift run`
+  loop gone for a fact the filesystem already has. **Keep `-dirty`**: a build
+  with uncommitted changes is not the commit it names. The plugin writes its
+  output only when the hash changes, for the same incremental-build reason, and
+  falls back to `unknown` where there is no git — a source tarball, say. Lint
+  covers `Plugins` too: `swiftformat Sources Tests Plugins`.
 - **The version lives in `MonitorCore/Version.swift`.** The About panel reads
   it at runtime and `make-app.sh` greps that file when it writes `Info.plist`,
   so a bundled build and `swift run monitor` cannot claim different versions.
@@ -375,7 +393,7 @@ are no component-level AGENTS.md files.
 
 ### Always
 
-- Run `swift build && swift test` and `swiftformat Sources Tests --lint --cache
+- Run `swift build && swift test` and `swiftformat Sources Tests Plugins --lint --cache
   ignore` before considering work done. Both are CI gates.
 - Keep `MonitorCore` free of macOS system APIs. It is the part that can be
   tested on any machine in any state, and that is worth protecting.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,6 +181,24 @@ are no component-level AGENTS.md files.
   is its own type and key beside `LayoutPreferences`: **which cards exist**
   versus **how one is drawn**. Off by default, because a chart that changes
   shape on upgrade is worse than one somebody switches on.
+- **A rate can be totalled, and the sum is already in the buffer.** **Show
+  totals for the window** in the Charts tab puts how much moved beside how fast
+  it is moving. A rate sample *is* the mean over the gap before it, so
+  `Σ(rate × preceding gap)` telescopes back to exactly the counter delta —
+  `WindowTotal` in `MonitorCore` is that sum, and it keeps no counter history,
+  changes no source and writes nothing. Three things it must keep doing: report
+  **`covered` beside `value`**, because "2 min" over ten seconds of history is
+  the quiet kind of wrong; **clip an interval wider than `maximumGap`**, or a
+  laptop back from sleep credits one sample with an hour of traffic that never
+  crossed the wire; and return **nil under two samples**, not zero, the same
+  answer `RateTracker` gives on a first read. `MetricUnit.accumulation` says
+  what a unit adds up to and is nil for every level — derived from the unit like
+  `direction` and `composition`, never a table of ids. **Network totals in
+  bytes** while its rate stays Mbit/s: a link is quoted in bits, a volume in
+  bytes, and the divide by eight has one definition. The card totals `series`,
+  not `visible` — the sum needs the sample just outside the window's left edge
+  to measure the interval straddling it. `AppModel.totalGap` is four ticks of
+  the master clock, so it follows the Sampling tab rather than assuming 0.5 s.
 - **The time axis is computed, not automatic.** `ChartAxis` in `MonitorCore`.
   Three rules, and the first two versions traded one for another: a tick is an
   **instant** (10:42:00 sits at 10:42:00 and scrolls left keeping its label —
@@ -219,8 +237,8 @@ are no component-level AGENTS.md files.
   double-click to zoom — and that they do not fight is checked by running
   `swift run monitor`, never by a test.
 - **The layout is chosen per metric, in preferences.** Cmd-, opens a tabbed
-  window. Its **Charts** tab holds how cards are *drawn* (mirroring), which is
-  a different question from which cards there are. Its **Layout** tab lists
+  window. Its **Charts** tab holds how cards are *drawn* — stacking, mirroring,
+  totals — which is a different question from which cards there are. Its **Layout** tab lists
   every metric with a Gauge checkbox and a
   Chart checkbox, grouped into collapsible sections whose headings carry the
   same two checkboxes for the whole group. The two columns are not symmetrical:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -405,6 +405,12 @@ are no component-level AGENTS.md files.
   the split buys none of the review value it looks like it buys. What it costs
   is real: a squash-merge and a **release** each, for one change. Keep the
   separable history in the commits, where it is free.
+  **This matters most for UI work, which cannot be reviewed piecemeal.** There
+  is one window. A change to a card, the axis under it and the title bar above
+  it are seen together or not at all, and the only useful question — does this
+  read better — can only be asked of the whole screen. Three pull requests
+  against one screenshot is three views of a thing nobody can look at
+  separately.
   Split only when the parts are genuinely independent of each other and could
   land in either order.
 * Make minimal, focused changes; avoid broad refactors unless requested.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -334,9 +334,15 @@ are no component-level AGENTS.md files.
   writes into the bundle, not the archive, so the uploaded copy is unstapled
   until it is made again. `docs/signing.md` is the setup.
 - **The title bar says which build this is.** `BuildStamp.label` — the commit
-  and when it was made — beside the window title, drawn in `Theme.readout`
-  rather than the title bar's secondary style, because a stamp nobody can read
-  at a glance is one nobody checks. **The two halves are sourced differently on
+  and when it was made — beside the window title, **white on black in the system
+  font**, deliberately not the panel's palette or the cards' monospaced face.
+  It is the one thing in the window that is not a reading: everything else is a
+  measurement styled to be scanned, and this is a label on the photograph, there
+  to survive being screenshotted and read back later. macOS 26 wraps toolbar
+  items in a shared glass capsule, which made it dark-on-light and clipped it,
+  so the item opts out with `sharedBackgroundVisibility(.hidden)` (gated to 26,
+  additive — earlier releases add no capsule) and paints its own. `fixedSize`,
+  because a commit truncated to look complete is worse than no stamp. **The two halves are sourced differently on
   purpose.** The commit is stamped at build time by the `StampCommit` prebuild
   plugin (`git describe --tags --always --dirty`), because a running program has
   no other way to know it and a checked-in constant is one somebody has to

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -199,6 +199,14 @@ are no component-level AGENTS.md files.
   not `visible` — the sum needs the sample just outside the window's left edge
   to measure the interval straddling it. `AppModel.totalGap` is four ticks of
   the master clock, so it follows the Sampling tab rather than assuming 0.5 s.
+  **A card with totals draws a `Grid`, not a `FlowLayout`** — swatch, name,
+  rate, total, with the totals column headed and **right-justified**, because a
+  magnitude is read by where its last digit sits and wrapped entries put them at
+  four different left edges. It sits under the title, never beside it:
+  `ViewThatFits` is the right question for a wrapping row and the wrong one for
+  a column of figures. Cards with nothing to total keep the flow. The reserved
+  slot survives into the table — a `Grid` column sizes to its widest cell, so
+  without it the column resizes whenever a total crosses a magnitude.
 - **The time axis is computed, not automatic.** `ChartAxis` in `MonitorCore`.
   Three rules, and the first two versions traded one for another: a tick is an
   **instant** (10:42:00 sits at 10:42:00 and scrolls left keeping its label —

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -339,7 +339,10 @@ are no component-level AGENTS.md files.
   (`toolbar(removing: .title)`, gated: the `.title` kind is macOS 15, so 14 gets
   an empty `navigationTitle`) so the name is not drawn twice. The `Window` scene
   keeps its real name for the Window menu and the Dock, and that name lives
-  beside the version in `MonitorVersion`. The styling is deliberately not the panel's palette or the cards' monospaced face.
+  beside the version in `MonitorVersion`. **The trailing controls need
+  `.primaryAction`, not `.automatic`** — they used to be pushed right by the
+  title taking the slack in the middle, and removing it packed them up against
+  the stamp. The styling is deliberately not the panel's palette or the cards' monospaced face.
   It is the one thing in the window that is not a reading: everything else is a
   measurement styled to be scanned, and this is a label on the photograph, there
   to survive being screenshotted and read back later. macOS 26 wraps toolbar

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -333,9 +333,13 @@ are no component-level AGENTS.md files.
   **`notarize.sh` rebuilds the zip after stapling** — `stapler`
   writes into the bundle, not the archive, so the uploaded copy is unstapled
   until it is made again. `docs/signing.md` is the setup.
-- **The title bar says which build this is.** `BuildStamp.label` — the commit
-  and when it was made — beside the window title, **white on black in the system
-  font**, deliberately not the panel's palette or the cards' monospaced face.
+- **The title bar says which build this is.** The app's name with
+  `BuildStamp.label` under it — the commit and when it was made — as one block,
+  **white on black in the system font**, with the window's own title removed
+  (`toolbar(removing: .title)`, gated: the `.title` kind is macOS 15, so 14 gets
+  an empty `navigationTitle`) so the name is not drawn twice. The `Window` scene
+  keeps its real name for the Window menu and the Dock, and that name lives
+  beside the version in `MonitorVersion`. The styling is deliberately not the panel's palette or the cards' monospaced face.
   It is the one thing in the window that is not a reading: everything else is a
   measurement styled to be scanned, and this is a label on the photograph, there
   to survive being screenshotted and read back later. macOS 26 wraps toolbar

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -397,6 +397,16 @@ are no component-level AGENTS.md files.
 
 ## Making Changes
 
+* **One pull request per piece of work, not per commit.** Related changes ship
+  together even when they touch different files and could be described
+  separately. Splitting a session's work into several pull requests is the
+  wrong default here: they end up *stacked* — each based on the one before —
+  and a stacked pull request is not independently reviewable or mergeable, so
+  the split buys none of the review value it looks like it buys. What it costs
+  is real: a squash-merge and a **release** each, for one change. Keep the
+  separable history in the commits, where it is free.
+  Split only when the parts are genuinely independent of each other and could
+  land in either order.
 * Make minimal, focused changes; avoid broad refactors unless requested.
 * Preserve existing architecture and patterns.
 * Don't introduce new dependencies without justification.

--- a/Package.swift
+++ b/Package.swift
@@ -39,7 +39,12 @@ let package = Package(
         .executable(name: "monitorctl", targets: ["monitorctl"]),
     ],
     targets: [
-        .target(name: "MonitorCore"),
+        .target(name: "MonitorCore", plugins: ["StampCommit"]),
+        // A prebuild plugin, so the commit in the title bar cannot go stale the
+        // way a checked-in constant or a manual step would. It rewrites its
+        // output only when the hash changes, which is what keeps `swift run`
+        // from recompiling MonitorCore every time.
+        .plugin(name: "StampCommit", capability: .buildTool()),
         .target(name: "MonitorSources", dependencies: ["MonitorCore"]),
         .target(name: "MonitorStore", dependencies: ["MonitorCore"]),
         // Note the absence of MonitorStore in the next three targets. That is

--- a/Plugins/StampCommit/plugin.swift
+++ b/Plugins/StampCommit/plugin.swift
@@ -1,0 +1,50 @@
+import Foundation
+import PackagePlugin
+
+/// Writes the commit this build came from into a Swift constant.
+///
+/// A prebuild command, so it runs before every build and cannot go stale the
+/// way a checked-in file or a manual step would. It writes only when the hash
+/// has actually changed: rewriting it every build would touch a source file
+/// `MonitorCore` compiles, and recompiling the whole module on every `swift
+/// run` would cost the fast dev loop the README is built around.
+///
+/// Deliberately **not** the build time as well. That changes every build by
+/// definition, so putting it here would force exactly the recompile this avoids
+/// — and it can be had for nothing at runtime from the executable's own
+/// modification date. See `BuildStamp` in `MonitorCore`.
+@main
+struct StampCommit: BuildToolPlugin {
+    func createBuildCommands(context: PluginContext, target _: Target) throws -> [Command] {
+        let directory = context.pluginWorkDirectoryURL
+        let output = directory.appending(path: "CommitStamp.generated.swift")
+        // `git describe` rather than `rev-parse`: it carries the tag when the
+        // build sits on one, which is what a release should say, and falls back
+        // to the short hash when it does not. `--dirty` because a build with
+        // uncommitted changes is not the commit it names, and a title bar that
+        // says otherwise is the quiet kind of wrong.
+        let script = #"""
+        set -u
+        cd "$SOURCE" 2>/dev/null || exit 0
+        commit=$(git describe --tags --always --dirty --abbrev=8 2>/dev/null || echo unknown)
+        printf 'enum CommitStamp { static let describe = "%s" }\n' "$commit" > "$OUT.new"
+        if [ -f "$OUT" ] && cmp -s "$OUT" "$OUT.new"; then
+            rm -f "$OUT.new"
+        else
+            mv "$OUT.new" "$OUT"
+        fi
+        """#
+        return [
+            .prebuildCommand(
+                displayName: "Stamping the commit",
+                executable: URL(fileURLWithPath: "/bin/sh"),
+                arguments: ["-c", script],
+                environment: [
+                    "SOURCE": context.package.directoryURL.path(),
+                    "OUT": output.path(),
+                ],
+                outputFilesDirectory: directory
+            ),
+        ]
+    }
+}

--- a/Sources/MonitorCore/BuildStamp.swift
+++ b/Sources/MonitorCore/BuildStamp.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+/// Which build this is: the commit it came from, and when it was made.
+///
+/// Two facts that answer one question — "am I looking at the change I just
+/// made?" — and the answer is worth having on screen rather than in an About
+/// panel two clicks away. A monitor gets left running for days, and the copy on
+/// screen is very often not the copy just built.
+///
+/// The two are sourced differently on purpose.
+///
+/// **The commit is stamped at build time** by the `StampCommit` plugin, which
+/// runs `git describe` before every build and writes `CommitStamp`. It has to
+/// be captured then: a running program has no other way to know, and a
+/// checked-in constant is a thing somebody has to remember to update, which
+/// means a title bar that eventually lies.
+///
+/// **The build time is read at runtime** from the executable's own modification
+/// date. It could have been stamped too, and stamping it would have been worse:
+/// the build time changes on every build by definition, so writing it into a
+/// source file would recompile `MonitorCore` every time and cost the fast
+/// `swift run` loop for a fact the filesystem already knows.
+public enum BuildStamp {
+    /// The commit, as `git describe --tags --always --dirty` saw it:
+    /// `v1.4.0-4-ga8e8631` on a branch, `v1.4.0` on a release, and either with
+    /// `-dirty` appended when the tree had uncommitted changes.
+    ///
+    /// The `-dirty` half is the point of using `describe` rather than a bare
+    /// hash. A build with uncommitted changes is not the commit it names, and a
+    /// title bar claiming otherwise is the quiet kind of wrong this app is
+    /// supposed to be careful about.
+    public static let commit = CommitStamp.describe
+
+    /// When the executable was written, or nil if it cannot be read.
+    ///
+    /// Nil rather than a stand-in date, for the same reason a source that
+    /// fails throws instead of reporting zero: an unknown build time must not
+    /// look like a real one.
+    public static let built: Date? = {
+        guard let url = Bundle.main.executableURL ?? executableFromArguments() else {
+            return nil
+        }
+        return try? url.resourceValues(forKeys: [.contentModificationDateKey])
+            .contentModificationDate
+    }()
+
+    /// `Bundle.main.executableURL` is nil for a plain SwiftPM binary in some
+    /// launch contexts, and `swift run monitor` is the loop this is most useful
+    /// in — so fall back to the path the process was started with.
+    private static func executableFromArguments() -> URL? {
+        guard let first = CommandLine.arguments.first else { return nil }
+        let url = URL(fileURLWithPath: first)
+        return FileManager.default.isReadableFile(atPath: url.path) ? url : nil
+    }
+
+    /// The build time as a label: `Aug 28 09:12`.
+    ///
+    /// The date as well as the clock, always. A bare time is ambiguous the
+    /// moment the window has been open overnight, which is exactly when
+    /// somebody looks at this to ask whether the app is stale. A fixed POSIX
+    /// format rather than the reader's locale, because this is a build
+    /// identifier that gets pasted into an issue, not a date being presented.
+    public static func builtLabel(_ date: Date, timeZone: TimeZone = .current) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = timeZone
+        formatter.dateFormat = "MMM d HH:mm"
+        return formatter.string(from: date)
+    }
+
+    /// Both facts on one line, for the title bar.
+    public static var label: String { label(commit: commit, built: built) }
+
+    /// The line itself, with its inputs handed over so it can be tested without
+    /// rebuilding the app to change them.
+    ///
+    /// An unreadable build time drops out and leaves the commit alone. Half an
+    /// answer beats a stand-in date that looks like the other half.
+    static func label(commit: String, built: Date?, timeZone: TimeZone = .current) -> String {
+        guard let built else { return commit }
+        return "\(commit) · \(builtLabel(built, timeZone: timeZone))"
+    }
+}

--- a/Sources/MonitorCore/ChartAxis.swift
+++ b/Sources/MonitorCore/ChartAxis.swift
@@ -22,21 +22,61 @@ public enum ChartAxis {
     /// somebody would write down.
     static let strides: [TimeInterval] = [1, 2, 5, 10, 15, 30, 60, 120, 300, 600]
 
-    /// Points of card per label, measured off the narrowest column the grid
-    /// makes. Two is the fewest that says anything; past five they are closer
-    /// together than the eye needs on a chart this size.
-    static let spacing = 78.0
+    /// Two labels is what the axis wants; five is as dense as it should ever
+    /// get, because past that they are closer together than the eye needs on a
+    /// chart this size. Neither is a guarantee — see `marks`.
     static let fewest = 2
     static let most = 5
 
-    /// The y-axis and its labels, which the measured width includes and the
-    /// time labels cannot use.
-    static let axisAllowance = 50.0
+    /// The widest label each format produces, **measured** rather than
+    /// estimated: SF Rounded at `Theme.Layout.timeLabel`, worst case
+    /// "18:52:30" and "18:52".
+    ///
+    /// The two differ by a third, and that is the fact the arithmetic used to
+    /// miss. Budgeting every stride at the with-seconds width made the coarse
+    /// strides — the ones with the narrow labels, the ones a cramped card
+    /// wants — look as expensive as the fine ones, so the axis never reached
+    /// for them.
+    static let secondsLabelWidth = 32.0
+    static let minuteLabelWidth = 20.0
+    /// Turned on its side a label costs its line height instead, whatever it
+    /// says.
+    static let rotatedLabelWidth = 10.0
+    /// The clear space between two labels. Below about this they stop reading
+    /// as two numbers and start reading as one long one.
+    static let gutter = 8.0
 
-    /// How many labels this card has room for.
-    public static func maximumTicks(width: Double) -> Int {
-        guard width.isFinite else { return fewest }
-        return max(fewest, min(most, Int((width - axisAllowance) / spacing)))
+    /// Points of plot one label needs, including the gutter after it.
+    public static func spacing(showsSeconds: Bool, rotated: Bool) -> Double {
+        let label = rotated
+            ? rotatedLabelWidth
+            : (showsSeconds ? secondsLabelWidth : minuteLabelWidth)
+        return label + gutter
+    }
+
+    /// How many labels of one format fit across a plot.
+    ///
+    /// `width` is the **plot**, not the card and not the chart. The y-axis and
+    /// its labels are outside it and they are much wider on "20 MB/s" than on
+    /// "0%" — and the cards with the longest numbers are the ones whose plots
+    /// are narrowest. This used to take the chart's width less a flat 50-point
+    /// allowance, which is right for one card and optimistic for exactly the
+    /// cards that could least afford optimism.
+    public static func maximumTicks(
+        width: Double, showsSeconds: Bool = true, rotated: Bool = false
+    ) -> Int {
+        guard width.isFinite, width > 0 else { return 1 }
+        let fit = Int(width / spacing(showsSeconds: showsSeconds, rotated: rotated))
+        return max(1, min(most, fit))
+    }
+
+    /// The most labels a stride can produce in a window of this length.
+    ///
+    /// A window of length L holds either floor(L / stride) boundaries or one
+    /// more, depending on where it happens to sit. The axis has to survive the
+    /// worse of those, since the window slides.
+    static func worstCaseCount(usable: TimeInterval, stride: TimeInterval) -> Int {
+        Int((usable / stride).rounded(.down)) + 1
     }
 
     /// Ticks are held this far in from each edge of the window.
@@ -53,46 +93,56 @@ public enum ChartAxis {
         public let stride: TimeInterval
     }
 
-    /// The interval to label at: as many labels as the card has room for, and
-    /// never fewer than two.
+    /// The interval to label at: the finest one whose own labels fit the plot.
     ///
     /// Chosen from the *length* of the window, not from where it happens to
     /// sit. The ticks themselves are absolute instants, so the exact count
     /// drifts by one as the window slides — but the interval must not, or the
     /// axis restyles itself every few seconds. Picking the interval by counting
-    /// the ticks it actually produced was the previous version, and on a narrow
+    /// the ticks it actually produced was an earlier version, and on a narrow
     /// ten-minute card it flipped between 300 s and 120 s as the window moved,
     /// so the labels jumped between two and five.
     ///
-    /// Two rules, in this order:
+    /// **Fitting wins over the two-label floor**, which reverses the rule this
+    /// used to follow. That rule said slightly tight labels beat a bare axis,
+    /// and it was right about "slightly tight" and wrong about what the
+    /// arithmetic produced: on a 160-point plot the axis drew four labels 32
+    /// points wide with their centres 40 apart, and at the narrowest card they
+    /// overlapped outright. Labels that collide are not slightly tight — they
+    /// are unreadable, and worse than the sparse axis the old rule was
+    /// avoiding. Two labels are still what it reaches for, because the walk
+    /// goes finest first and a finer stride is a denser axis; a window that
+    /// cannot show two without them touching now shows one rather than two on
+    /// top of each other. **Turning the labels sideways is how to have both**,
+    /// which is what the setting is for.
     ///
-    /// 1. **Never fewer than two labels.** One lonely label says nothing about
-    ///    the span you are looking at.
-    /// 2. **Never more than the card has room for**, where that is compatible
-    ///    with the first. On a narrow card showing ten minutes it is not, and
-    ///    slightly tight labels beat a bare axis.
+    /// Each stride is costed at the width of *its own* labels. A stride of a
+    /// minute or more shows no seconds, so it needs a third less room than a
+    /// finer one — which is exactly why a cramped card can still carry a
+    /// readable axis.
     public static func marks(
-        from start: TimeInterval, to end: TimeInterval, maximumTicks: Int
+        from start: TimeInterval,
+        to end: TimeInterval,
+        plotWidth: Double,
+        rotated: Bool = false
     ) -> Marks {
         guard end > start else { return Marks(times: [], stride: strides[0]) }
         let usable = (end - start) * (1 - 2 * edgeFraction)
+        let width = plotWidth.isFinite ? max(0, plotWidth) : 0
 
-        // The coarsest interval that still fits `fewest` of itself in the
-        // window, whatever the window's phase.
-        let guaranteeing = strides.last { (usable / $0).rounded(.down) >= Double(fewest) }
-            ?? strides[0]
-        // The finest interval that cannot produce more labels than fit. A
-        // window of length L holds either floor(L / stride) boundaries or one
-        // more, depending on its phase, so the worst case is that floor plus
-        // one.
-        let capping = strides.first {
-            (usable / $0).rounded(.down) + 1 <= Double(maximumTicks)
-        } ?? strides[strides.count - 1]
+        // Finest first, so the first that fits is the densest that fits.
+        let stride = strides.first { candidate in
+            let count = worstCaseCount(usable: usable, stride: candidate)
+            guard count <= most else { return false }
+            let each = spacing(
+                showsSeconds: showsSeconds(stride: candidate), rotated: rotated
+            )
+            return Double(count) * each <= width
+        }
+            // Nothing fits: the coarsest interval there is, which is also the
+            // one that asks for the least room.
+            ?? strides[strides.count - 1]
 
-        // The finer of the two. Finer than `guaranteeing` still guarantees two,
-        // so this respects the room whenever the room allows two, and gives up
-        // on the room rather than on the two when it does not.
-        let stride = Swift.min(guaranteeing, capping)
         return Marks(times: times(from: start, to: end, stride: stride), stride: stride)
     }
 

--- a/Sources/MonitorCore/ChartPreferences.swift
+++ b/Sources/MonitorCore/ChartPreferences.swift
@@ -88,9 +88,24 @@ public struct ChartPreferences: Codable, Equatable, Sendable {
     /// shape under somebody on upgrade is worse than one they switch on.
     public var stacksParts: Bool
 
-    public init(mirrorsPairs: Bool = false, stacksParts: Bool = false) {
+    /// Show how much moved over the window beside how fast it is moving.
+    ///
+    /// Off by default, for a narrower reason than the two above. Those change
+    /// what the picture *means*; this only adds a number. But it adds one to
+    /// every entry in a header that is already decided by `ViewThatFits`, so
+    /// switching it on reflows cards onto two lines — which is a card changing
+    /// shape under somebody on upgrade, the thing the other two defaults exist
+    /// to prevent.
+    public var showsTotals: Bool
+
+    public init(
+        mirrorsPairs: Bool = false,
+        stacksParts: Bool = false,
+        showsTotals: Bool = false
+    ) {
         self.mirrorsPairs = mirrorsPairs
         self.stacksParts = stacksParts
+        self.showsTotals = showsTotals
     }
 
     public static let `default` = ChartPreferences()
@@ -112,6 +127,7 @@ public struct ChartPreferences: Codable, Equatable, Sendable {
     private enum CodingKeys: String, CodingKey {
         case mirrorsPairs
         case stacksParts
+        case showsTotals
     }
 
     /// `decodeIfPresent`, so a value written before a setting existed still
@@ -120,9 +136,11 @@ public struct ChartPreferences: Codable, Equatable, Sendable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let mirrors = try container.decodeIfPresent(Bool.self, forKey: .mirrorsPairs)
         let stacks = try container.decodeIfPresent(Bool.self, forKey: .stacksParts)
+        let totals = try container.decodeIfPresent(Bool.self, forKey: .showsTotals)
         self.init(
             mirrorsPairs: mirrors ?? ChartPreferences.default.mirrorsPairs,
-            stacksParts: stacks ?? ChartPreferences.default.stacksParts
+            stacksParts: stacks ?? ChartPreferences.default.stacksParts,
+            showsTotals: totals ?? ChartPreferences.default.showsTotals
         )
     }
 }

--- a/Sources/MonitorCore/ChartPreferences.swift
+++ b/Sources/MonitorCore/ChartPreferences.swift
@@ -90,18 +90,18 @@ public struct ChartPreferences: Codable, Equatable, Sendable {
 
     /// Show how much moved over the window beside how fast it is moving.
     ///
-    /// Off by default, for a narrower reason than the two above. Those change
-    /// what the picture *means*; this only adds a number. But it adds one to
-    /// every entry in a header that is already decided by `ViewThatFits`, so
-    /// switching it on reflows cards onto two lines — which is a card changing
-    /// shape under somebody on upgrade, the thing the other two defaults exist
-    /// to prevent.
+    /// **On by default, unlike the two above**, and the argument for matching
+    /// them lost on first contact: shipped off, the reaction to the finished
+    /// feature was "I don't see it". Mirroring and stacking change what the
+    /// picture *means*, so a reader who never asked for them deserves the chart
+    /// they had; a total only adds a number beside one already there, and a
+    /// number nobody can find is worth less than a header that reflows.
     public var showsTotals: Bool
 
     public init(
         mirrorsPairs: Bool = false,
         stacksParts: Bool = false,
-        showsTotals: Bool = false
+        showsTotals: Bool = true
     ) {
         self.mirrorsPairs = mirrorsPairs
         self.stacksParts = stacksParts

--- a/Sources/MonitorCore/ChartPreferences.swift
+++ b/Sources/MonitorCore/ChartPreferences.swift
@@ -98,14 +98,25 @@ public struct ChartPreferences: Codable, Equatable, Sendable {
     /// number nobody can find is worth less than a header that reflows.
     public var showsTotals: Bool
 
+    /// Turn the time labels on their side.
+    ///
+    /// Off by default: horizontal is easier to read, and on a card with room
+    /// for them it is the right answer. Turned, a label costs its line height
+    /// instead of its width, so a narrow card fits five times where it fitted
+    /// two — which is the trade somebody running a dense panel wants and
+    /// somebody running three big cards does not.
+    public var rotatesTimeLabels: Bool
+
     public init(
         mirrorsPairs: Bool = false,
         stacksParts: Bool = false,
-        showsTotals: Bool = true
+        showsTotals: Bool = true,
+        rotatesTimeLabels: Bool = false
     ) {
         self.mirrorsPairs = mirrorsPairs
         self.stacksParts = stacksParts
         self.showsTotals = showsTotals
+        self.rotatesTimeLabels = rotatesTimeLabels
     }
 
     public static let `default` = ChartPreferences()
@@ -128,6 +139,7 @@ public struct ChartPreferences: Codable, Equatable, Sendable {
         case mirrorsPairs
         case stacksParts
         case showsTotals
+        case rotatesTimeLabels
     }
 
     /// `decodeIfPresent`, so a value written before a setting existed still
@@ -137,10 +149,12 @@ public struct ChartPreferences: Codable, Equatable, Sendable {
         let mirrors = try container.decodeIfPresent(Bool.self, forKey: .mirrorsPairs)
         let stacks = try container.decodeIfPresent(Bool.self, forKey: .stacksParts)
         let totals = try container.decodeIfPresent(Bool.self, forKey: .showsTotals)
+        let rotates = try container.decodeIfPresent(Bool.self, forKey: .rotatesTimeLabels)
         self.init(
             mirrorsPairs: mirrors ?? ChartPreferences.default.mirrorsPairs,
             stacksParts: stacks ?? ChartPreferences.default.stacksParts,
-            showsTotals: totals ?? ChartPreferences.default.showsTotals
+            showsTotals: totals ?? ChartPreferences.default.showsTotals,
+            rotatesTimeLabels: rotates ?? ChartPreferences.default.rotatesTimeLabels
         )
     }
 }

--- a/Sources/MonitorCore/Formatting.swift
+++ b/Sources/MonitorCore/Formatting.swift
@@ -120,6 +120,22 @@ public enum Format {
             : String(format: "%.1f s", seconds)
     }
 
+    /// A span of history as a *label*, matching the History picker's wording:
+    /// "2 min", "10 min", "45 s".
+    ///
+    /// Not `duration`, which formats a measurement and would render two minutes
+    /// as "120.00 s". Whole minutes read as minutes because that is what the
+    /// picker beside them says; anything else keeps its seconds, since a card
+    /// that has only been running 45 s must say so rather than round itself up
+    /// to the window it was asked for.
+    public static func span(_ seconds: TimeInterval) -> String {
+        let minutes = seconds / 60
+        guard seconds >= 60, minutes == minutes.rounded() else {
+            return String(format: "%.0f s", seconds.rounded())
+        }
+        return String(format: "%.0f min", minutes)
+    }
+
     public static func duration(_ seconds: Double) -> String {
         if seconds >= 1 { return String(format: "%.2f s", seconds) }
         if seconds >= 0.001 { return String(format: "%.1f ms", seconds * 1000) }

--- a/Sources/MonitorCore/Formatting.swift
+++ b/Sources/MonitorCore/Formatting.swift
@@ -22,6 +22,58 @@ public enum Format {
         return "\(String(format: "%.\(digits)f", magnitude)) \(units[index])\(suffix)"
     }
 
+    /// A plain count, with SI suffixes: `847`, `1.2 M`, `340 k`.
+    ///
+    /// Same decimal thousands and the same digit rule as `bytes`, because the
+    /// two sit beside each other in a legend and a pair of counts that disagree
+    /// about what "k" means is worse than either. A packet total is seven
+    /// figures on a busy minute, and `1234567` is unreadable at a glance and
+    /// far too wide for the slot it has to sit in.
+    public static func count(_ value: Double) -> String {
+        let units = ["", " k", " M", " G", " T"]
+        var magnitude = abs(value)
+        var index = 0
+        while magnitude >= 1000, index < units.count - 1 {
+            magnitude /= 1000
+            index += 1
+        }
+        let digits = magnitude < 10 && index > 0 ? 1 : 0
+        return "\(String(format: "%.\(digits)f", magnitude))\(units[index])"
+    }
+
+    /// How much moved, from a `WindowTotal` in the rate's own base unit.
+    ///
+    /// Applies `MetricUnit.accumulation` and then formats the result — so the
+    /// bits-to-bytes conversion happens in exactly one place on the way to the
+    /// screen, which is what stops a header and anything downstream disagreeing
+    /// about whether 1.4 GB and 11.2 Gbit are the same reading.
+    ///
+    /// Nil for a unit that does not accumulate, so a caller cannot draw
+    /// degree-seconds under a temperature by forgetting to check.
+    public static func total(_ value: Double, unit: MetricUnit) -> String? {
+        guard let accumulation = unit.accumulation else { return nil }
+        let scaled = value * accumulation.scale
+        switch accumulation.unit {
+        case .bytes: return bytes(scaled)
+        case .count: return count(scaled)
+        default: return self.value(scaled, unit: accumulation.unit)
+        }
+    }
+
+    /// The widest reading `total(_:unit:)` is expected to produce, for reserving
+    /// layout width. A floor, exactly like `widestValue`.
+    ///
+    /// The legend is where this matters most: a total climbing from `88 MB` to
+    /// `1.4 GB` must not shove every entry beside it sideways while it is being
+    /// read.
+    public static func widestTotal(unit: MetricUnit) -> String? {
+        guard let accumulation = unit.accumulation else { return nil }
+        switch accumulation.unit {
+        case .count: return "999 M"
+        default: return widestValue(unit: accumulation.unit)
+        }
+    }
+
     /// Throughput is pinned to mega-units and never rescaled: disk in MB/s,
     /// network in Mbit/s, at every magnitude, including 0.02 and 5000.
     ///

--- a/Sources/MonitorCore/Metric.swift
+++ b/Sources/MonitorCore/Metric.swift
@@ -30,6 +30,33 @@ public enum MetricUnit: String, Sendable, Codable {
     /// "3200 rpm" are not the same reading on a chart axis.
     case rpm
     case seconds
+
+    /// What a second's worth of this unit adds up to, and the factor that gets
+    /// it there. Nil where a total means nothing.
+    ///
+    /// Derived from the unit rather than from a table of metric ids, the same
+    /// way `ChartMirror` and `ChartStack` read `direction` and `composition`:
+    /// a source added later gets a total without this file being told it
+    /// exists.
+    ///
+    /// **Network reads in bits and totals in bytes, and the divide by eight
+    /// lives here.** A link is quoted in bits — a 1 Gbit port, an 866 Mbit
+    /// Wi-Fi link — so the rate stays Mbit/s. A volume is quoted in bytes
+    /// everywhere it matters: ISP caps, file sizes, Finder. Two different
+    /// questions with two right answers, and one definition of the conversion
+    /// between them, for the same reason `NetworkSource` multiplies by eight in
+    /// the source rather than in the gauge.
+    ///
+    /// Nil for every level. Adding temperatures gives degree-seconds, which is
+    /// not a quantity anybody wants under a chart of a CPU getting warm.
+    public var accumulation: (unit: MetricUnit, scale: Double)? {
+        switch self {
+        case .bytesPerSecond: (.bytes, 1)
+        case .bitsPerSecond: (.bytes, 1.0 / 8)
+        case .operationsPerSecond: (.count, 1)
+        default: nil
+        }
+    }
 }
 
 /// How consecutive samples relate to each other.

--- a/Sources/MonitorCore/Version.swift
+++ b/Sources/MonitorCore/Version.swift
@@ -6,4 +6,9 @@
 /// line: the script's pattern expects it there.
 public enum MonitorVersion {
     public static let string = "1.4.0"
+
+    /// What the app calls itself. Here beside the version because the title bar
+    /// draws it, the `Window` scene names itself with it, and two spellings of
+    /// one name is the sort of thing nobody notices until a screenshot.
+    public static let name = "Monitor"
 }

--- a/Sources/MonitorCore/WindowTotal.swift
+++ b/Sources/MonitorCore/WindowTotal.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+/// How much moved over a window, from the rates that were sampled across it.
+///
+/// The dials answer "how hard is this working right now" and the charts answer
+/// "what has been happening". Neither answers "how much did that transfer
+/// cost me", which is the question you have while watching a sync run.
+///
+/// **A rate sample is the mean over the gap before it.** `RateTracker` produces
+/// `Δcounter / Δt`, so multiplying each sample by the interval it measures and
+/// summing telescopes back to exactly the counter delta the window covers. That
+/// is the whole trick: no counter history is kept anywhere, no source changes,
+/// and nothing is read that the ring buffer does not already hold.
+///
+/// In `MonitorCore` beside `CSVExport` and the preference models, for the same
+/// reason they are: the interesting part is arithmetic, and arithmetic should
+/// not need a machine to read or a window to draw in.
+public enum WindowTotal {
+    /// A total, and how much of the window it actually accounts for.
+    ///
+    /// The second half is not decoration. Ten seconds after launch the buffer
+    /// holds ten seconds, and putting "2 min" under a number covering a twelfth
+    /// of that is the quiet kind of wrong — nobody checks it, because it looks
+    /// exactly like the right answer.
+    public struct Result: Equatable, Sendable {
+        /// The counter delta, in the rate's unit times seconds. Bytes for
+        /// `bytesPerSecond`, bits for `bitsPerSecond`, operations for
+        /// `operationsPerSecond`. Converting to what a reader wants is
+        /// `MetricUnit.accumulation`'s job, not this one's.
+        public let value: Double
+        /// Seconds of the window the samples account for. At most `window`,
+        /// and less when history is short or an interval was clipped.
+        public let covered: TimeInterval
+
+        public init(value: Double, covered: TimeInterval) {
+            self.value = value
+            self.covered = covered
+        }
+    }
+
+    /// The total across `window` seconds ending at `now`.
+    ///
+    /// - Parameters:
+    ///   - points: the series' samples. Sorted here rather than assumed sorted,
+    ///     because a total that depends on array order is a bug waiting for a
+    ///     refactor.
+    ///   - window: seconds of history to add up — the same window the card is
+    ///     drawing, so the number and the picture answer the same question.
+    ///   - now: the right-hand edge. Defaults to the newest sample, which is
+    ///     the rule `CSVExport` already follows.
+    ///   - maximumGap: the widest interval one sample may be credited with. A
+    ///     slept laptop or a source that failed for a minute leaves one
+    ///     enormous gap, and a rectangle drawn across it invents traffic that
+    ///     never happened. The caller knows the sampling clock; this does not.
+    /// - Returns: nil when there are fewer than two samples. There is genuinely
+    ///   no total yet — the same answer `RateTracker` gives on a first read,
+    ///   and for the same reason: zero would draw as an idle machine rather
+    ///   than as a missing number.
+    public static func total(
+        of points: [Sample],
+        window: TimeInterval,
+        now: TimeInterval? = nil,
+        maximumGap: TimeInterval
+    ) -> Result? {
+        guard points.count >= 2 else { return nil }
+        let sorted = points.sorted { $0.timestamp < $1.timestamp }
+        guard let end = now ?? sorted.last?.timestamp else { return nil }
+        let start = end - window
+
+        var value = 0.0
+        var covered = 0.0
+        // From the second sample: the oldest one has no predecessor, so the
+        // width of its interval is unknown and it is credited with nothing.
+        // Reaching back to the window's edge instead would invent history in
+        // exactly the case where there is none.
+        for index in 1..<sorted.count {
+            let sample = sorted[index]
+            guard sample.timestamp > start, sample.timestamp <= end else { continue }
+            // The predecessor may sit outside the window. That is deliberate:
+            // it is what makes the leading partial interval come out clipped
+            // rather than dropped whole.
+            let previous = max(sorted[index - 1].timestamp, start)
+            let interval = min(sample.timestamp - previous, maximumGap)
+            guard interval > 0 else { continue }
+            value += sample.value * interval
+            covered += interval
+        }
+        return Result(value: value, covered: covered)
+    }
+}

--- a/Sources/MonitorUI/AppModel.swift
+++ b/Sources/MonitorUI/AppModel.swift
@@ -100,6 +100,19 @@ public final class AppModel {
     /// How much live history to keep: ten minutes at two samples a second.
     public let historyCapacity = 1200
 
+    /// The widest interval one sample may be credited with in a window total,
+    /// in ticks of the master clock.
+    ///
+    /// Four: wide enough that a tick which ran late still contributes its whole
+    /// interval, and narrow enough that a laptop coming back from sleep cannot
+    /// credit one sample with an hour of traffic that never crossed the wire.
+    static let totalGapTicks = 4.0
+
+    /// That, in seconds, at whatever rate the clock is currently running.
+    /// `WindowTotal` deliberately does not know the clock; this is where it
+    /// lives.
+    public var totalGap: TimeInterval { interval * Self.totalGapTicks }
+
     public let descriptors: [MetricID: MetricDescriptor]
     private let sampler: Sampler
     private var pump: Task<Void, Never>?

--- a/Sources/MonitorUI/ChartCard.swift
+++ b/Sources/MonitorUI/ChartCard.swift
@@ -29,6 +29,15 @@ public struct ChartCard: View {
     /// Passed in rather than worked out here, for the same reason `mirror` is:
     /// whether to stack is a preference, and a card does not read preferences.
     public var stacked: [MetricID] = []
+    /// The widest interval one sample may be credited with when totalling, or
+    /// nil to draw no totals at all.
+    ///
+    /// One optional rather than a flag and a number, because neither is any use
+    /// without the other: a total cannot be taken without knowing the sampling
+    /// clock, and the clock belongs to the model. Passed in for the same reason
+    /// `mirror` and `stacked` are — whether to show totals is a preference, and
+    /// a card does not read preferences.
+    public var totalGap: TimeInterval?
 
     public init(
         title: String,
@@ -37,7 +46,8 @@ public struct ChartCard: View {
         isUnavailable: Bool = false,
         plotHeight: Double = Theme.Layout.chartMinHeight,
         mirror: MetricPair? = nil,
-        stacked: [MetricID] = []
+        stacked: [MetricID] = [],
+        totalGap: TimeInterval? = nil
     ) {
         self.title = title
         self.series = series
@@ -49,11 +59,16 @@ public struct ChartCard: View {
         // of a whole, so nothing declares both — but drawing bands below a
         // baseline would be nonsense, so it cannot happen by accident either.
         self.stacked = mirror == nil ? stacked : []
+        self.totalGap = totalGap
     }
 
     public var body: some View {
-        VStack(alignment: .leading, spacing: 5) {
-            header
+        // Bound once and passed down rather than read as a computed property
+        // from three places: it walks every series' whole buffer, and the card
+        // redraws on every tick.
+        let totals = totals
+        return VStack(alignment: .leading, spacing: 5) {
+            header(totals)
             if isUnavailable {
                 unavailableNotice
             } else {
@@ -81,30 +96,45 @@ public struct ChartCard: View {
     /// `ViewThatFits` proposes the column's width to the first arrangement and
     /// falls back to the second, so the compact line survives wherever there is
     /// room for it.
-    private var header: some View {
-        ViewThatFits(in: .horizontal) {
+    private func header(_ totals: [MetricID: WindowTotal.Result]) -> some View {
+        let span = totalSpan(totals)
+        return ViewThatFits(in: .horizontal) {
             HStack(alignment: .top, spacing: 8) {
-                titleText
+                titleText(span: span)
                 Spacer(minLength: 0)
-                legend
+                legend(totals, span: span)
             }
             VStack(alignment: .leading, spacing: 4) {
-                titleText
-                legend
+                titleText(span: span)
+                legend(totals, span: span)
             }
         }
     }
 
-    private var titleText: some View {
-        Text(title)
-            .font(.system(
-                size: Theme.Layout.cardTitle,
-                weight: .semibold,
-                design: .rounded
-            ))
-            .foregroundStyle(Theme.readout)
-            .lineLimit(1)
-            .fixedSize()
+    /// The title, and the span the totals cover when there are any.
+    ///
+    /// Stated once here rather than after every entry. The History picker is
+    /// global, so repeating "/ 2 min" four times down a legend is four copies
+    /// of one fact — and the legend is the part of the card with the least room
+    /// to spare.
+    private func titleText(span: TimeInterval?) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 6) {
+            Text(title)
+                .font(.system(
+                    size: Theme.Layout.cardTitle,
+                    weight: .semibold,
+                    design: .rounded
+                ))
+                .foregroundStyle(Theme.readout)
+                .lineLimit(1)
+            if let span {
+                Text(Format.span(span))
+                    .font(.system(size: Theme.Layout.cardLegend, design: .monospaced))
+                    .foregroundStyle(Theme.label)
+                    .lineLimit(1)
+            }
+        }
+        .fixedSize()
     }
 
     /// Current values in the header rather than in a legend below the chart:
@@ -115,11 +145,19 @@ public struct ChartCard: View {
     /// than its children want compresses them, and compressed legend entries
     /// truncate to nothing readable; `FlowLayout` spends card height instead,
     /// which is the cheaper of the two.
-    private var legend: some View {
+    private func legend(
+        _ totals: [MetricID: WindowTotal.Result], span: TimeInterval?
+    ) -> some View {
         FlowLayout(horizontalSpacing: 10, verticalSpacing: 3) {
             ForEach(Array(series.enumerated()), id: \.offset) { index, entry in
                 if let latest = entry.points.last {
-                    legendEntry(entry.descriptor, index: index, latest: latest)
+                    legendEntry(
+                        entry.descriptor,
+                        index: index,
+                        latest: latest,
+                        total: totals[entry.descriptor.id],
+                        span: span
+                    )
                 }
             }
         }
@@ -139,7 +177,11 @@ public struct ChartCard: View {
     /// `.monospacedDigit()` is not enough on its own — it equalises digit widths
     /// but reserves nothing, so `1%` and `100%` still occupy different space.
     private func legendEntry(
-        _ descriptor: MetricDescriptor, index: Int, latest: Sample
+        _ descriptor: MetricDescriptor,
+        index: Int,
+        latest: Sample,
+        total: WindowTotal.Result?,
+        span: TimeInterval?
     ) -> some View {
         HStack(spacing: 4) {
             // Filled for a band, hollow for a line — the same distinction the
@@ -165,8 +207,33 @@ public struct ChartCard: View {
                     .foregroundStyle(Theme.readout)
                     .lineLimit(1)
             }
+            totalText(descriptor, total: total, span: span)
         }
         .font(.system(size: Theme.Layout.cardLegend, design: .monospaced))
+    }
+
+    /// How much moved, in its own reserved slot beside how fast it is moving.
+    ///
+    /// Dimmed when this series covers materially less of the window than the
+    /// span printed beside the title — one source failed for a stretch while
+    /// its neighbour on the card kept reading. The ordinary case, where every
+    /// series covers the same span, spends no ink saying so.
+    @ViewBuilder
+    private func totalText(
+        _ descriptor: MetricDescriptor, total: WindowTotal.Result?, span: TimeInterval?
+    ) -> some View {
+        if let total,
+           let text = Format.total(total.value, unit: descriptor.unit),
+           let widest = Format.widestTotal(unit: descriptor.unit)
+        {
+            let isShort = span.map { $0 - total.covered > (totalGap ?? 0) } ?? false
+            ZStack(alignment: .leading) {
+                Text(widest).hidden()
+                Text(text)
+                    .foregroundStyle(isShort ? Theme.label : Theme.readout)
+                    .lineLimit(1)
+            }
+        }
     }
 
     private var unavailableNotice: some View {
@@ -195,6 +262,40 @@ public struct ChartCard: View {
         return series.map { entry in
             (entry.descriptor, entry.points.filter { $0.timestamp >= range.start })
         }
+    }
+
+    // MARK: - Totals
+
+    /// How much moved over the window, per series, in the rate's own base unit.
+    ///
+    /// Reads `series` rather than `visible`: `WindowTotal` needs the sample just
+    /// *before* the window's left edge to measure the partial interval that
+    /// straddles it, and `visible` has already thrown that one away.
+    private var totals: [MetricID: WindowTotal.Result] {
+        guard let totalGap else { return [:] }
+        let end = xRange.end
+        var results: [MetricID: WindowTotal.Result] = [:]
+        for entry in series where entry.descriptor.unit.accumulation != nil {
+            results[entry.descriptor.id] = WindowTotal.total(
+                of: entry.points, window: window, now: end, maximumGap: totalGap
+            )
+        }
+        return results
+    }
+
+    /// The span printed beside the title: the window when the card really has
+    /// it, and what the card actually has when it does not.
+    ///
+    /// Ten seconds after launch the buffer holds ten seconds, and "2 min" over
+    /// a number covering a twelfth of that is the quiet kind of wrong. The
+    /// tolerance is one `totalGap`, because a card is never going to cover its
+    /// window to the microsecond and "119 s" beside a picker reading "2 min"
+    /// reads as a fault rather than as precision.
+    private func totalSpan(_ totals: [MetricID: WindowTotal.Result]) -> TimeInterval? {
+        guard let totalGap, let longest = totals.values.map(\.covered).max() else {
+            return nil
+        }
+        return window - longest > totalGap ? longest : window
     }
 
     private var chart: some View {

--- a/Sources/MonitorUI/ChartCard.swift
+++ b/Sources/MonitorUI/ChartCard.swift
@@ -38,6 +38,9 @@ public struct ChartCard: View {
     /// `mirror` and `stacked` are — whether to show totals is a preference, and
     /// a card does not read preferences.
     public var totalGap: TimeInterval?
+    /// Draw the time labels on their side. Passed in for the same reason the
+    /// three above are: it is a preference, and a card does not read them.
+    public var rotatesTimeLabels: Bool = false
 
     public init(
         title: String,
@@ -47,7 +50,8 @@ public struct ChartCard: View {
         plotHeight: Double = Theme.Layout.chartMinHeight,
         mirror: MetricPair? = nil,
         stacked: [MetricID] = [],
-        totalGap: TimeInterval? = nil
+        totalGap: TimeInterval? = nil,
+        rotatesTimeLabels: Bool = false
     ) {
         self.title = title
         self.series = series
@@ -60,6 +64,7 @@ public struct ChartCard: View {
         // baseline would be nonsense, so it cannot happen by accident either.
         self.stacked = mirror == nil ? stacked : []
         self.totalGap = totalGap
+        self.rotatesTimeLabels = rotatesTimeLabels
     }
 
     public var body: some View {
@@ -367,18 +372,26 @@ public struct ChartCard: View {
             }
         }
         .chartXAxis {
-            AxisMarks(values: xTicks) { _ in
+            AxisMarks(values: xTicks) { value in
                 AxisGridLine().foregroundStyle(Theme.panelEdge.opacity(0.3))
-                AxisValueLabel(format: timeFormat, centered: true)
-                    .font(.system(size: Theme.Layout.axisLabel, design: .rounded))
-                    .foregroundStyle(Theme.label)
+                AxisValueLabel(centered: true) {
+                    if let date = value.as(Date.self) { timeLabel(date) }
+                }
             }
         }
-        .background(
-            GeometryReader { proxy in
-                Color.clear.preference(key: PlotWidthKey.self, value: proxy.size.width)
+        // `chartBackground` rather than an overlay: it hands over the same
+        // proxy and sits *under* the chart, where it cannot swallow the
+        // mouse-down that a tile's drag gesture needs. An overlay here is the
+        // trap `ReorderDrag` documents.
+        .chartBackground { proxy in
+            GeometryReader { geometry in
+                // The plot rect, not the chart's own width. The y-axis and its
+                // labels are outside it, and they are much wider on "20 MB/s"
+                // than on "0%" — which is exactly when the room runs out.
+                let width = proxy.plotFrame.map { geometry[$0].width } ?? geometry.size.width
+                Color.clear.preference(key: PlotWidthKey.self, value: width)
             }
-        )
+        }
         .onPreferenceChange(PlotWidthKey.self) { plotWidth = $0 }
         .frame(minHeight: plotHeight)
     }
@@ -397,13 +410,38 @@ public struct ChartCard: View {
         }
     }
 
+    /// One time label, upright or on its side.
+    ///
+    /// `rotationEffect` turns the glyphs and not the layout, so the rotated
+    /// case needs `fixedSize` to stop the frame squeezing the text first, and
+    /// then a frame of its own — otherwise the axis reserves the label's width
+    /// and none of its height, and the turned text draws over the chart.
+    @ViewBuilder
+    private func timeLabel(_ date: Date) -> some View {
+        let text = Text(date, format: timeFormat)
+            .font(.system(size: Theme.Layout.timeLabel, design: .rounded))
+            .foregroundStyle(Theme.label)
+            .lineLimit(1)
+        if rotatesTimeLabels {
+            text
+                .fixedSize()
+                .rotationEffect(.degrees(-90))
+                .frame(
+                    width: Theme.Layout.timeLabelRotated.width,
+                    height: Theme.Layout.timeLabelRotated.height
+                )
+        } else {
+            text
+        }
+    }
+
     /// The labelled instants and their spacing — see `ChartAxis`, which is
     /// where the arithmetic lives and where it is tested.
     private var marks: ChartAxis.Marks {
         let range = xRange
         return ChartAxis.marks(
             from: range.start, to: range.end,
-            maximumTicks: ChartAxis.maximumTicks(width: plotWidth)
+            plotWidth: plotWidth, rotated: rotatesTimeLabels
         )
     }
 
@@ -411,12 +449,14 @@ public struct ChartCard: View {
         marks.times.map { Date(timeIntervalSince1970: $0) }
     }
 
-    /// No AM/PM. A card shows at most ten minutes of history, so which half of
-    /// the day it is was never in question, and those two characters were most
-    /// of what made the labels collide.
+    /// No AM/PM, and no leading zero on the hour. A card shows at most ten
+    /// minutes of history, so which half of the day it is was never in
+    /// question, and "0" in "08:52:30" is a character that carries nothing
+    /// across eight labels that have no room for it. The minutes and seconds
+    /// keep both digits: those are positional, and "8:5:3" is not a time.
     private var timeFormat: Date.FormatStyle {
         let base = Date.FormatStyle.dateTime
-            .hour(.twoDigits(amPM: .omitted))
+            .hour(.defaultDigits(amPM: .omitted))
             .minute(.twoDigits)
         return ChartAxis.showsSeconds(stride: marks.stride) ? base.second(.twoDigits) : base
     }

--- a/Sources/MonitorUI/ChartCard.swift
+++ b/Sources/MonitorUI/ChartCard.swift
@@ -96,14 +96,27 @@ public struct ChartCard: View {
     /// `ViewThatFits` proposes the column's width to the first arrangement and
     /// falls back to the second, so the compact line survives wherever there is
     /// room for it.
+    @ViewBuilder
     private func header(_ totals: [MetricID: WindowTotal.Result]) -> some View {
         let span = totalSpan(totals)
-        return ViewThatFits(in: .horizontal) {
-            HStack(alignment: .top, spacing: 8) {
-                titleText(span: span)
-                Spacer(minLength: 0)
-                legend(totals, span: span)
+        if totals.isEmpty {
+            ViewThatFits(in: .horizontal) {
+                HStack(alignment: .top, spacing: 8) {
+                    titleText(span: span)
+                    Spacer(minLength: 0)
+                    legend(totals, span: span)
+                }
+                VStack(alignment: .leading, spacing: 4) {
+                    titleText(span: span)
+                    legend(totals, span: span)
+                }
             }
+        } else {
+            // A table always goes under the title, never beside it. `ViewThatFits`
+            // is the right question for a wrapping row of entries and the wrong
+            // one for a column of figures: pushed to the right of the title on a
+            // wide card, the Totals heading floats in the middle of the header
+            // with nothing under it that reads as a table.
             VStack(alignment: .leading, spacing: 4) {
                 titleText(span: span)
                 legend(totals, span: span)
@@ -145,79 +158,144 @@ public struct ChartCard: View {
     /// than its children want compresses them, and compressed legend entries
     /// truncate to nothing readable; `FlowLayout` spends card height instead,
     /// which is the cheaper of the two.
+    /// The legend: a wrapping row of entries, or a small table when the card
+    /// has totals to line up.
+    ///
+    /// Two shapes rather than one because the cards differ. A card of levels —
+    /// Memory's seven slices, five temperature sensors — has nothing to total
+    /// and wants `FlowLayout`, which spends card height only when the entries
+    /// genuinely do not fit across. A card of rates has a second number per
+    /// series, and numbers in a wrapped row do not line up: the totals ended up
+    /// at four different left edges down the same card, which is what a column
+    /// is for.
+    ///
+    /// Only five groups accumulate — Disk, Disk Ops, Network, Network Packets,
+    /// Memory Paging — and every one of them has exactly two series, so the
+    /// table is three rows at its tallest.
+    @ViewBuilder
     private func legend(
         _ totals: [MetricID: WindowTotal.Result], span: TimeInterval?
     ) -> some View {
+        if totals.isEmpty {
+            flowLegend
+        } else {
+            tableLegend(totals, span: span)
+        }
+    }
+
+    /// Entries wrapped across the card, for a legend with no totals column.
+    ///
+    /// An `HStack` given less width than its children want compresses them, and
+    /// compressed entries truncate to nothing readable; `FlowLayout` spends card
+    /// height instead, which is the cheaper of the two.
+    private var flowLegend: some View {
         FlowLayout(horizontalSpacing: 10, verticalSpacing: 3) {
             ForEach(Array(series.enumerated()), id: \.offset) { index, entry in
                 if let latest = entry.points.last {
-                    legendEntry(
-                        entry.descriptor,
-                        index: index,
-                        latest: latest,
-                        total: totals[entry.descriptor.id],
-                        span: span
-                    )
+                    HStack(spacing: 4) {
+                        swatch(entry.descriptor, index: index)
+                        nameText(entry.descriptor)
+                        valueText(entry.descriptor, latest: latest)
+                    }
                 }
             }
         }
+        .font(.system(size: Theme.Layout.cardLegend, design: .monospaced))
         .fixedSize(horizontal: false, vertical: true)
     }
 
-    /// One legend entry: colour swatch, series name, current value.
+    /// Series down the left, rate then total across, with the totals column
+    /// headed and right-justified.
     ///
-    /// Monospaced, and the value sits in a slot pre-sized to the widest reading
-    /// its unit can produce. Both matter for the same reason: a legend whose
-    /// entries change width is a legend that shuffles sideways while you are
-    /// reading it. A monospaced face stops individual digits from changing width
-    /// as they change value; the reserved slot stops the *number of* digits from
-    /// moving everything else, which is what made a series climbing from `1%` to
-    /// `100%` appear to wiggle the whole card.
-    ///
-    /// `.monospacedDigit()` is not enough on its own — it equalises digit widths
-    /// but reserves nothing, so `1%` and `100%` still occupy different space.
-    private func legendEntry(
-        _ descriptor: MetricDescriptor,
-        index: Int,
-        latest: Sample,
-        total: WindowTotal.Result?,
-        span: TimeInterval?
+    /// Right-justified because these are magnitudes, and magnitudes are read by
+    /// the position of their last digit: `104 MB` over `48 MB` aligned on the
+    /// left puts the hundreds above the tens and hides the difference the column
+    /// exists to show. Headed because a second bare number beside a rate does
+    /// not say what it is — the span beside the card's title says *how long*,
+    /// and this says *of what*.
+    private func tableLegend(
+        _ totals: [MetricID: WindowTotal.Result], span: TimeInterval?
     ) -> some View {
-        HStack(spacing: 4) {
-            // Filled for a band, hollow for a line — the same distinction the
-            // chart makes, so the key does not have to be guessed at.
-            Group {
-                if stacked.isEmpty || isBand(descriptor) {
-                    Circle().fill(Theme.seriesColor(index))
-                } else {
-                    Circle().strokeBorder(Theme.seriesColor(index), lineWidth: 1.5)
+        Grid(alignment: .leading, horizontalSpacing: 8, verticalSpacing: 3) {
+            GridRow {
+                // One merged cell across the swatch, name and rate columns: a
+                // merged cell adds nothing to their widths, so the heading
+                // cannot widen the table it labels.
+                Color.clear.frame(width: 0, height: 0).gridCellColumns(3)
+                Text("Totals")
+                    .foregroundStyle(Theme.label)
+                    .lineLimit(1)
+                    .gridColumnAlignment(.trailing)
+            }
+            ForEach(Array(series.enumerated()), id: \.offset) { index, entry in
+                if let latest = entry.points.last {
+                    GridRow {
+                        swatch(entry.descriptor, index: index)
+                        nameText(entry.descriptor)
+                        valueText(entry.descriptor, latest: latest)
+                        totalText(
+                            entry.descriptor,
+                            total: totals[entry.descriptor.id],
+                            span: span
+                        )
+                    }
                 }
             }
-            .frame(width: 7, height: 7)
-            Text(descriptor.name)
-                .foregroundStyle(Theme.label)
-                .lineLimit(1)
-            ZStack(alignment: .leading) {
-                // Reserves the slot. A ZStack takes the width of its widest
-                // child, so a reading wider than the reservation grows the slot
-                // rather than being clipped — the reservation is a floor.
-                Text(Format.widestValue(unit: descriptor.unit))
-                    .hidden()
-                Text(Format.value(latest.value, unit: descriptor.unit))
-                    .foregroundStyle(Theme.readout)
-                    .lineLimit(1)
-            }
-            totalText(descriptor, total: total, span: span)
         }
         .font(.system(size: Theme.Layout.cardLegend, design: .monospaced))
+        .fixedSize(horizontal: false, vertical: true)
     }
 
-    /// How much moved, in its own reserved slot beside how fast it is moving.
+    /// Filled for a band, hollow for a line — the same distinction the chart
+    /// makes, so the key does not have to be guessed at.
+    private func swatch(_ descriptor: MetricDescriptor, index: Int) -> some View {
+        Group {
+            if stacked.isEmpty || isBand(descriptor) {
+                Circle().fill(Theme.seriesColor(index))
+            } else {
+                Circle().strokeBorder(Theme.seriesColor(index), lineWidth: 1.5)
+            }
+        }
+        .frame(width: 7, height: 7)
+    }
+
+    private func nameText(_ descriptor: MetricDescriptor) -> some View {
+        Text(descriptor.name)
+            .foregroundStyle(Theme.label)
+            .lineLimit(1)
+    }
+
+    /// The current reading, in a slot pre-sized to the widest its unit can
+    /// produce.
+    ///
+    /// Monospaced and reserved for the same reason: a legend whose entries
+    /// change width is a legend that shuffles sideways while you are reading it.
+    /// A monospaced face stops individual digits from changing width as they
+    /// change value; the reserved slot stops the *number of* digits from moving
+    /// everything else, which is what made a series climbing from `1%` to `100%`
+    /// appear to wiggle the whole card. `.monospacedDigit()` is not enough on
+    /// its own — it equalises digit widths but reserves nothing.
+    private func valueText(_ descriptor: MetricDescriptor, latest: Sample) -> some View {
+        ZStack(alignment: .leading) {
+            // A ZStack takes the width of its widest child, so a reading wider
+            // than the reservation grows the slot rather than being clipped —
+            // the reservation is a floor.
+            Text(Format.widestValue(unit: descriptor.unit)).hidden()
+            Text(Format.value(latest.value, unit: descriptor.unit))
+                .foregroundStyle(Theme.readout)
+                .lineLimit(1)
+        }
+    }
+
+    /// How much moved, right-justified under the Totals heading.
     ///
     /// Dimmed when this series covers materially less of the window than the
     /// span printed beside the title — one source failed for a stretch while
     /// its neighbour on the card kept reading. The ordinary case, where every
     /// series covers the same span, spends no ink saying so.
+    ///
+    /// The slot is reserved here too, and its contents pushed right, so the
+    /// digits stay in one column as their magnitude changes.
     @ViewBuilder
     private func totalText(
         _ descriptor: MetricDescriptor, total: WindowTotal.Result?, span: TimeInterval?
@@ -227,12 +305,16 @@ public struct ChartCard: View {
            let widest = Format.widestTotal(unit: descriptor.unit)
         {
             let isShort = span.map { $0 - total.covered > (totalGap ?? 0) } ?? false
-            ZStack(alignment: .leading) {
+            ZStack(alignment: .trailing) {
                 Text(widest).hidden()
                 Text(text)
                     .foregroundStyle(isShort ? Theme.label : Theme.readout)
                     .lineLimit(1)
             }
+        } else {
+            // A series on a card that has totals but cannot produce one of its
+            // own still needs its cell, or the row below slides up a column.
+            Color.clear.frame(width: 0, height: 0)
         }
     }
 

--- a/Sources/MonitorUI/DashboardView.swift
+++ b/Sources/MonitorUI/DashboardView.swift
@@ -545,7 +545,13 @@ public struct DashboardView: View {
         } else {
             ToolbarItem(placement: .navigation) { buildStamp }
         }
-        ToolbarItem {
+        // `.primaryAction` rather than the default `.automatic`. The controls
+        // used to be pushed to the trailing edge by the window's title taking
+        // the slack in the middle; with the title removed, `.automatic` packed
+        // them up against the stamp on the left. Anchoring them explicitly says
+        // what the layout actually depends on, instead of leaning on something
+        // that is no longer there.
+        ToolbarItem(placement: .primaryAction) {
             Picker("History", selection: $window) {
                 Text("1 min").tag(TimeInterval(60))
                 Text("2 min").tag(TimeInterval(120))
@@ -556,7 +562,7 @@ public struct DashboardView: View {
             }
             .pickerStyle(.segmented)
         }
-        ToolbarItem {
+        ToolbarItem(placement: .primaryAction) {
             Button {
                 showsSizes.toggle()
             } label: {
@@ -567,7 +573,7 @@ public struct DashboardView: View {
                 SizePopover(model: model, gaugeCeiling: gaugeCeiling)
             }
         }
-        ToolbarItem {
+        ToolbarItem(placement: .primaryAction) {
             // The same list preferences offers, not a second one. A rate set
             // here and a rate set there are one setting, and a toolbar that
             // offered 0.25 s while the Sampling tab did not would show an empty

--- a/Sources/MonitorUI/DashboardView.swift
+++ b/Sources/MonitorUI/DashboardView.swift
@@ -390,7 +390,10 @@ public struct DashboardView: View {
             // membership: switch one direction off and the card stops being a
             // pair.
             mirror: model.charts.mirror(for: drawn.map(\.descriptor)),
-            stacked: model.charts.stack(for: drawn.map(\.descriptor))
+            stacked: model.charts.stack(for: drawn.map(\.descriptor)),
+            // Nil switches totals off. The gap comes from the model because
+            // that is where the sampling clock is.
+            totalGap: model.charts.showsTotals ? model.totalGap : nil
         )
     }
 

--- a/Sources/MonitorUI/DashboardView.swift
+++ b/Sources/MonitorUI/DashboardView.swift
@@ -488,23 +488,48 @@ public struct DashboardView: View {
     /// very often not the copy just built. The question "am I looking at the
     /// change I just made?" should not cost two clicks to answer.
     ///
-    /// Drawn in `Theme.readout` rather than left to the secondary style the
-    /// title bar would give it. A stamp nobody can read at a glance is a stamp
-    /// nobody checks, which is the same failure as not having one.
+    /// **White on black, in the system font.** Not the panel's palette and not
+    /// the monospaced face the cards use: this is the one thing in the window
+    /// that is not a reading. Everything else on screen is a measurement of the
+    /// machine, styled to be scanned; the stamp is a label on the photograph,
+    /// and its job is to survive being screenshotted and read back later.
+    ///
+    /// Which is also why it is black rather than `Theme.panel`, and not left to
+    /// the title bar's own styling. The first version borrowed the toolbar's
+    /// glass and came out as dark text on a light pill — the lowest contrast
+    /// anywhere in the window, on the one element whose entire purpose is to
+    /// still be legible in a PNG somebody opens next month.
+    ///
+    /// `fixedSize` so it is never truncated. A commit clipped to
+    /// `v1.4.0-8-gc61738cf · Aug 28 09:3` is worse than no stamp: it looks
+    /// complete.
     private var buildStamp: some View {
         Text(BuildStamp.label)
-            .font(.system(size: 10, design: .monospaced))
-            .foregroundStyle(Theme.readout)
+            .font(.body)
+            .foregroundStyle(.white)
             .lineLimit(1)
             .fixedSize()
+            .padding(.horizontal, 9)
+            .padding(.vertical, 3)
+            .background(.black, in: Capsule())
             .help("The commit this build came from, and when it was built")
             .accessibilityLabel("Build \(BuildStamp.label)")
     }
 
     @ToolbarContentBuilder
     private var toolbar: some ToolbarContent {
-        ToolbarItem(placement: .navigation) {
-            buildStamp
+        // macOS 26 wraps every toolbar item in a shared capsule, which put the
+        // stamp in the same light pill as the controls opposite — dark text on
+        // light glass, and clipped where the capsule ended. The stamp is not a
+        // control and should not dress as one, so on 26 it opts out and draws
+        // its own background. Earlier releases add no capsule and need no
+        // opt-out, which is why this is additive rather than conditional
+        // styling.
+        if #available(macOS 26.0, *) {
+            ToolbarItem(placement: .navigation) { buildStamp }
+                .sharedBackgroundVisibility(.hidden)
+        } else {
+            ToolbarItem(placement: .navigation) { buildStamp }
         }
         ToolbarItem {
             Picker("History", selection: $window) {

--- a/Sources/MonitorUI/DashboardView.swift
+++ b/Sources/MonitorUI/DashboardView.swift
@@ -393,7 +393,8 @@ public struct DashboardView: View {
             stacked: model.charts.stack(for: drawn.map(\.descriptor)),
             // Nil switches totals off. The gap comes from the model because
             // that is where the sampling clock is.
-            totalGap: model.charts.showsTotals ? model.totalGap : nil
+            totalGap: model.charts.showsTotals ? model.totalGap : nil,
+            rotatesTimeLabels: model.charts.rotatesTimeLabels
         )
     }
 

--- a/Sources/MonitorUI/DashboardView.swift
+++ b/Sources/MonitorUI/DashboardView.swift
@@ -481,8 +481,31 @@ public struct DashboardView: View {
 
     // MARK: - Toolbar
 
+    /// Which build this is, beside the window's title.
+    ///
+    /// In the title bar rather than the About panel because of how this app
+    /// gets used: a monitor is left running for days, and the copy on screen is
+    /// very often not the copy just built. The question "am I looking at the
+    /// change I just made?" should not cost two clicks to answer.
+    ///
+    /// Drawn in `Theme.readout` rather than left to the secondary style the
+    /// title bar would give it. A stamp nobody can read at a glance is a stamp
+    /// nobody checks, which is the same failure as not having one.
+    private var buildStamp: some View {
+        Text(BuildStamp.label)
+            .font(.system(size: 10, design: .monospaced))
+            .foregroundStyle(Theme.readout)
+            .lineLimit(1)
+            .fixedSize()
+            .help("The commit this build came from, and when it was built")
+            .accessibilityLabel("Build \(BuildStamp.label)")
+    }
+
     @ToolbarContentBuilder
     private var toolbar: some ToolbarContent {
+        ToolbarItem(placement: .navigation) {
+            buildStamp
+        }
         ToolbarItem {
             Picker("History", selection: $window) {
                 Text("1 min").tag(TimeInterval(60))

--- a/Sources/MonitorUI/DashboardView.swift
+++ b/Sources/MonitorUI/DashboardView.swift
@@ -96,6 +96,10 @@ public struct DashboardView: View {
         )
         .onPreferenceChange(PanelSizeKey.self) { panelSize = $0 }
         .toolbar { toolbar }
+        // The name is drawn by the stamp, which puts the build underneath it.
+        // Left in place the system would draw it a second time, beside its own
+        // copy.
+        .removingWindowTitle()
         .onAppear { model.start() }
         .onDisappear { model.stop() }
         // A sheet rather than a second window: it is temporary, Escape already
@@ -503,17 +507,27 @@ public struct DashboardView: View {
     /// `fixedSize` so it is never truncated. A commit clipped to
     /// `v1.4.0-8-gc61738cf · Aug 28 09:3` is worse than no stamp: it looks
     /// complete.
+    ///
+    /// The app's name sits on top of it and the window's own title is removed,
+    /// so the two read as one block — a heading with its build under it —
+    /// rather than as a chip parked next to a title that repeats it. A rounded
+    /// rectangle rather than a capsule now that it is two lines: a capsule's
+    /// ends bow away from a left-aligned second line.
     private var buildStamp: some View {
-        Text(BuildStamp.label)
-            .font(.body)
-            .foregroundStyle(.white)
-            .lineLimit(1)
-            .fixedSize()
-            .padding(.horizontal, 9)
-            .padding(.vertical, 3)
-            .background(.black, in: Capsule())
-            .help("The commit this build came from, and when it was built")
-            .accessibilityLabel("Build \(BuildStamp.label)")
+        VStack(alignment: .leading, spacing: 0) {
+            Text(MonitorVersion.name)
+                .font(.headline)
+            Text(BuildStamp.label)
+                .font(.caption)
+        }
+        .foregroundStyle(.white)
+        .lineLimit(1)
+        .fixedSize()
+        .padding(.horizontal, 9)
+        .padding(.vertical, 4)
+        .background(.black, in: RoundedRectangle(cornerRadius: 7))
+        .help("The commit this build came from, and when it was built")
+        .accessibilityLabel("\(MonitorVersion.name), build \(BuildStamp.label)")
     }
 
     @ToolbarContentBuilder
@@ -573,4 +587,21 @@ public struct DashboardView: View {
 #Preview {
     DashboardView()
         .frame(width: 900, height: 700)
+}
+
+private extension View {
+    /// Drop the window's own title from the toolbar.
+    ///
+    /// `ToolbarDefaultItemKind.title` arrived in macOS 15 and this package
+    /// still builds for 14, where an empty title comes to the same thing on
+    /// screen. Either way the `Window` scene keeps its real name, so the Window
+    /// menu and the Dock still say what this is.
+    @ViewBuilder
+    func removingWindowTitle() -> some View {
+        if #available(macOS 15.0, *) {
+            toolbar(removing: .title)
+        } else {
+            navigationTitle("")
+        }
+    }
 }

--- a/Sources/MonitorUI/PreferencesView.swift
+++ b/Sources/MonitorUI/PreferencesView.swift
@@ -237,6 +237,22 @@ struct ChartsTab: View {
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
             }
+
+            Section {
+                Toggle("Turn the time labels sideways", isOn: $model.charts.rotatesTimeLabels)
+            } footer: {
+                Text(
+                    "A label lying down costs its width, and a narrow card runs "
+                        + "out of that long before it runs out of chart. Stood "
+                        + "on end it costs only its height, so the same card "
+                        + "fits five times where it fitted two. Off by default, "
+                        + "because horizontal is easier to read wherever there "
+                        + "is room for it."
+                )
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            }
         }
         .formStyle(.grouped)
     }

--- a/Sources/MonitorUI/PreferencesView.swift
+++ b/Sources/MonitorUI/PreferencesView.swift
@@ -221,6 +221,22 @@ struct ChartsTab: View {
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
             }
+
+            Section {
+                Toggle("Show totals for the window", isOn: $model.charts.showsTotals)
+            } footer: {
+                Text(
+                    "How much moved, beside how fast it is moving: network and "
+                        + "disk in bytes, packets and disk operations as counts. "
+                        + "The total covers exactly the window the chart draws, "
+                        + "so the History picker changes both at once. A card "
+                        + "with less history than the window says the span it "
+                        + "really has rather than the one it was asked for."
+                )
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            }
         }
         .formStyle(.grouped)
     }

--- a/Sources/MonitorUI/Theme.swift
+++ b/Sources/MonitorUI/Theme.swift
@@ -66,6 +66,14 @@ public enum Theme {
         public static let cardTitle = 12.0
         public static let cardLegend = 10.0
         public static let axisLabel = 8.0
+        /// The time labels along the bottom, smaller than the y-axis beside
+        /// them. There are more of them, they are longer, and they are the ones
+        /// that collide: a y-axis label has a whole row to itself.
+        public static let timeLabel = 7.0
+        /// The box a rotated time label is laid out in. `rotationEffect` turns
+        /// the glyphs and not the layout, so without a frame the axis reserves
+        /// the width of the text and none of its height.
+        public static let timeLabelRotated = CGSize(width: 11, height: 40)
         /// The dial's label, which sits under the dial rather than on its face:
         /// at 130pt across there is no room on the face for "Network Out"
         /// without it running into the ticks.

--- a/Sources/monitor/MonitorApp.swift
+++ b/Sources/monitor/MonitorApp.swift
@@ -1,4 +1,5 @@
 import AppKit
+import MonitorCore
 import MonitorUI
 import SwiftUI
 
@@ -19,7 +20,7 @@ struct MonitorApp: App {
     @State private var model = AppModel()
 
     var body: some Scene {
-        Window("Monitor", id: "monitor") {
+        Window(MonitorVersion.name, id: "monitor") {
             DashboardView(model: model)
                 .frame(minWidth: 720, minHeight: 560)
         }

--- a/Tests/MonitorCoreTests/BuildStampTests.swift
+++ b/Tests/MonitorCoreTests/BuildStampTests.swift
@@ -1,0 +1,54 @@
+import Foundation
+@testable import MonitorCore
+import Testing
+
+@Suite("BuildStamp")
+struct BuildStampTests {
+    private static let utc = TimeZone(identifier: "UTC")!
+
+    @Test("The commit is stamped, not left blank")
+    func commitIsStamped() {
+        // The plugin runs before every build, so a blank here means it did not
+        // run at all — which is silent otherwise, since the title bar would
+        // simply show nothing where the commit belongs.
+        #expect(!BuildStamp.commit.isEmpty)
+    }
+
+    @Test("Both facts land on one line")
+    func labelCarriesBoth() {
+        let built = Date(timeIntervalSince1970: 1_756_374_720)
+        let label = BuildStamp.label(
+            commit: "v1.4.0-4-ga8e8631",
+            built: built,
+            timeZone: Self.utc
+        )
+        #expect(label == "v1.4.0-4-ga8e8631 · Aug 28 09:52")
+    }
+
+    @Test("An unreadable build time leaves the commit alone")
+    func missingBuildTime() {
+        // Half an answer beats a stand-in date that looks like the other half —
+        // the same rule the sources follow when a read fails.
+        #expect(BuildStamp.label(commit: "abc1234", built: nil) == "abc1234")
+    }
+
+    @Test("The build time carries the date, not only the clock")
+    func dateNotJustTime() {
+        // A bare time is ambiguous the moment the window has been open
+        // overnight, which is exactly when somebody checks whether the app on
+        // screen is the one they just built.
+        let label = BuildStamp.builtLabel(
+            Date(timeIntervalSince1970: 1_756_374_720), timeZone: Self.utc
+        )
+        #expect(label == "Aug 28 09:52")
+    }
+
+    @Test("A build time is found for this very binary")
+    func readsItsOwnDate() throws {
+        // The test bundle is an executable too, so the runtime half is
+        // exercised rather than only the formatting around it.
+        let built = try #require(BuildStamp.built)
+        #expect(built.timeIntervalSince1970 > 1_700_000_000)
+        #expect(built <= Date())
+    }
+}

--- a/Tests/MonitorCoreTests/ChartAxisTests.swift
+++ b/Tests/MonitorCoreTests/ChartAxisTests.swift
@@ -7,56 +7,119 @@ struct ChartAxisTests {
     /// The four windows the toolbar offers.
     static let windows: [TimeInterval] = [60, 120, 300, 600]
 
-    @Test("A narrow card gets fewer labels than a wide one")
+    /// Plot widths the panel can really produce: the card slider runs 200 to
+    /// 600 points, and the y-axis and its labels come off that before the time
+    /// labels see any of it.
+    static let plots: [Double] = [130, 160, 200, 260, 380, 560]
+
+    @Test("A narrow plot gets fewer labels than a wide one")
     func countFollowsWidth() {
-        #expect(ChartAxis.maximumTicks(width: 260) < ChartAxis.maximumTicks(width: 600))
+        #expect(ChartAxis.maximumTicks(width: 120) < ChartAxis.maximumTicks(width: 400))
     }
 
-    @Test("Never fewer than two labels, never more than five")
+    @Test("Never fewer than one label, never more than five")
     func countIsBounded() {
-        #expect(ChartAxis.maximumTicks(width: 0) == ChartAxis.fewest)
+        // One, not two. Two is what the axis reaches for, not what it can
+        // promise — see `marks`, where fitting wins over the floor.
+        #expect(ChartAxis.maximumTicks(width: 0) == 1)
         #expect(ChartAxis.maximumTicks(width: 10000) == ChartAxis.most)
-        #expect(ChartAxis.maximumTicks(width: .nan) == ChartAxis.fewest)
+        #expect(ChartAxis.maximumTicks(width: .nan) == 1)
     }
 
-    @Test("Every window on every card width gets at least two labels")
-    func neverFewerThanTwo() {
-        // The bug this pins: at five minutes on a narrow card the interval
-        // chosen was 300 s for a 300 s window, and a 300 s window inset at both
-        // ends contains a multiple of 300 only sometimes. The axis emptied
-        // itself. Swept across a whole window's worth of start offsets, because
-        // whether an absolute boundary falls inside depends on where the window
-        // happens to sit.
+    @Test("A label without seconds needs less room than one with them")
+    func coarseStridesAreCheaper() {
+        // The fact the arithmetic used to miss. "8:52" is a third narrower than
+        // "8:52:30", so budgeting every stride at the wider figure made the
+        // coarse strides look as expensive as the fine ones — and the axis
+        // never reached for the one a cramped card wanted.
+        let withSeconds = ChartAxis.spacing(showsSeconds: true, rotated: false)
+        let without = ChartAxis.spacing(showsSeconds: false, rotated: false)
+        #expect(without < withSeconds)
+        #expect(ChartAxis.spacing(showsSeconds: true, rotated: true) < without)
+    }
+
+    @Test("Labels never overlap, at any window, plot or phase")
+    func labelsNeverCollide() {
+        // The bug that prompted all of this: on a 160-point plot the axis drew
+        // four labels 32 points wide with their centres 40 apart, and at the
+        // narrowest card they ran into each other. This is that failure stated
+        // as arithmetic — the ink two neighbouring labels need against the
+        // distance between them.
         for span in Self.windows {
-            for width in [200.0, 260, 400, 600, 900] {
-                let maximum = ChartAxis.maximumTicks(width: width)
-                for offset in stride(from: 0.0, to: span, by: span / 20) {
-                    let marks = ChartAxis.marks(
-                        from: 1_700_000_000 + offset,
-                        to: 1_700_000_000 + offset + span,
-                        maximumTicks: maximum
-                    )
-                    #expect(marks.times.count >= ChartAxis.fewest)
+            for width in Self.plots {
+                for rotated in [false, true] {
+                    for offset in stride(from: 0.0, to: span, by: span / 40) {
+                        let start = 1_700_000_000 + offset
+                        let marks = ChartAxis.marks(
+                            from: start, to: start + span,
+                            plotWidth: width, rotated: rotated
+                        )
+                        guard marks.times.count >= 2 else { continue }
+                        let pointsPerSecond = width / span
+                        let apart = marks.stride * pointsPerSecond
+                        let needed = ChartAxis.spacing(
+                            showsSeconds: ChartAxis.showsSeconds(stride: marks.stride),
+                            rotated: rotated
+                        )
+                        #expect(apart >= needed)
+                    }
                 }
             }
         }
     }
 
-    @Test("The card's room is respected wherever two labels fit inside it")
-    func staysWithinTheRoom() {
-        // Not an absolute cap: two labels beat a tidy count, so a window that
-        // cannot show two within the room is allowed to go over. It must not go
-        // far over.
+    @Test("Two labels wherever two fit, and never a bare axis")
+    func reachesForTwo() {
+        // The floor the old rule protected, kept everywhere it can be had. A
+        // narrow card showing two minutes is the case that cannot: no stride is
+        // both coarse enough to fit and fine enough to guarantee two, and one
+        // readable label beats two on top of each other. Sideways labels are
+        // how to have both, so the rotated pass demands two outright.
         for span in Self.windows {
-            for width in [200.0, 260, 400, 600, 900] {
-                let maximum = ChartAxis.maximumTicks(width: width)
+            for width in Self.plots {
                 for offset in stride(from: 0.0, to: span, by: span / 20) {
-                    let marks = ChartAxis.marks(
-                        from: 1_700_000_000 + offset,
-                        to: 1_700_000_000 + offset + span,
-                        maximumTicks: maximum
+                    let start = 1_700_000_000 + offset
+                    let upright = ChartAxis.marks(
+                        from: start, to: start + span, plotWidth: width
                     )
-                    #expect(marks.times.count <= max(maximum, ChartAxis.fewest) + 3)
+                    #expect(!upright.times.isEmpty)
+                    let turned = ChartAxis.marks(
+                        from: start, to: start + span, plotWidth: width, rotated: true
+                    )
+                    #expect(turned.times.count >= ChartAxis.fewest)
+                }
+            }
+        }
+    }
+
+    @Test("Turning the labels never costs a label")
+    func rotatingOnlyEverHelps() {
+        // The whole promise of the setting: a rotated label is cheaper, so it
+        // can only buy a finer stride, never a coarser one.
+        for span in Self.windows {
+            for width in Self.plots {
+                let upright = ChartAxis.marks(
+                    from: 1_700_000_000, to: 1_700_000_000 + span, plotWidth: width
+                )
+                let turned = ChartAxis.marks(
+                    from: 1_700_000_000, to: 1_700_000_000 + span,
+                    plotWidth: width, rotated: true
+                )
+                #expect(turned.stride <= upright.stride)
+            }
+        }
+    }
+
+    @Test("Never denser than five labels")
+    func neverTooDense() {
+        for span in Self.windows {
+            for width in Self.plots + [2000] {
+                for rotated in [false, true] {
+                    let marks = ChartAxis.marks(
+                        from: 1_700_000_000, to: 1_700_000_000 + span,
+                        plotWidth: width, rotated: rotated
+                    )
+                    #expect(marks.times.count <= ChartAxis.most)
                 }
             }
         }
@@ -69,14 +132,13 @@ struct ChartAxisTests {
         // and 120 s as the window moved, so the labels jumped between two and
         // five every few seconds.
         for span in Self.windows {
-            for width in [200.0, 260, 400, 600, 900] {
-                let maximum = ChartAxis.maximumTicks(width: width)
+            for width in Self.plots {
                 let strides = Set(
                     stride(from: 0.0, to: span, by: 1).map { offset in
                         ChartAxis.marks(
                             from: 1_700_000_000 + offset,
                             to: 1_700_000_000 + offset + span,
-                            maximumTicks: maximum
+                            plotWidth: width
                         ).stride
                     }
                 )
@@ -87,7 +149,7 @@ struct ChartAxisTests {
 
     @Test("Ticks land on round clock boundaries")
     func onBoundaries() {
-        let marks = ChartAxis.marks(from: 1_000_007, to: 1_000_127, maximumTicks: 3)
+        let marks = ChartAxis.marks(from: 1_000_007, to: 1_000_127, plotWidth: 200)
         #expect(!marks.times.isEmpty)
         #expect(marks.times.allSatisfy {
             $0.truncatingRemainder(dividingBy: marks.stride) == 0
@@ -121,15 +183,22 @@ struct ChartAxisTests {
         #expect(ChartAxis.times(from: 100, to: 100, stride: 30).isEmpty)
         #expect(ChartAxis.times(from: 200, to: 100, stride: 30).isEmpty)
         #expect(ChartAxis.times(from: 0, to: 120, stride: 0).isEmpty)
-        #expect(ChartAxis.marks(from: 100, to: 100, maximumTicks: 3).times.isEmpty)
+        #expect(ChartAxis.marks(from: 100, to: 100, plotWidth: 200).times.isEmpty)
+    }
+
+    @Test("A plot with no width still names an interval rather than crashing")
+    func noWidthYet() {
+        // The first frame, before the geometry reader has reported anything.
+        let marks = ChartAxis.marks(from: 0, to: 600, plotWidth: 0)
+        #expect(ChartAxis.strides.contains(marks.stride))
+        #expect(ChartAxis.marks(from: 0, to: 600, plotWidth: .nan).stride > 0)
     }
 
     @Test("The roundest interval that fits is the one chosen")
     func prefersCoarse() {
-        // Ten minutes across five labels could be 15 s; it should be 120 s.
-        let marks = ChartAxis.marks(
-            from: 1_700_000_000, to: 1_700_000_600, maximumTicks: 5
-        )
+        // Ten minutes on a wide plot could be labelled every 15 s; it should be
+        // 120 s. Five labels is as dense as this ever gets.
+        let marks = ChartAxis.marks(from: 1_700_000_000, to: 1_700_000_600, plotWidth: 560)
         #expect(marks.stride >= 120)
     }
 
@@ -138,5 +207,19 @@ struct ChartAxisTests {
         #expect(ChartAxis.showsSeconds(stride: 30))
         #expect(!ChartAxis.showsSeconds(stride: 60))
         #expect(!ChartAxis.showsSeconds(stride: 300))
+    }
+
+    @Test("The screenshot that started this now fits its plot")
+    func theBugThatStartedThis() {
+        // Two minutes on the Disk card: about 160 points of plot once "20 MB/s"
+        // has taken its side. Four labels went in, 32 points wide, centres 40
+        // apart — touching, and overlapping outright on a narrower card.
+        let marks = ChartAxis.marks(from: 1_700_000_000, to: 1_700_000_120, plotWidth: 160)
+        let apart = marks.stride * (160.0 / 120)
+        let needed = ChartAxis.spacing(
+            showsSeconds: ChartAxis.showsSeconds(stride: marks.stride), rotated: false
+        )
+        #expect(apart >= needed)
+        #expect(marks.times.count >= ChartAxis.fewest)
     }
 }

--- a/Tests/MonitorCoreTests/ChartPreferencesTests.swift
+++ b/Tests/MonitorCoreTests/ChartPreferencesTests.swift
@@ -143,6 +143,9 @@ struct ChartPreferencesTests {
         // it". A total adds a number beside one already there rather than
         // changing what the chart means, so it does not need switching on.
         #expect(ChartPreferences.default.showsTotals)
+        // Horizontal is easier to read wherever there is room for it, and on
+        // every card but the narrowest there is.
+        #expect(ChartPreferences.default.rotatesTimeLabels == false)
         #expect(ChartPreferences.default.mirror(for: [netIn, netOut]) == nil)
         #expect(ChartPreferences.default.stack(for: [app, wired, free]).isEmpty)
     }
@@ -176,7 +179,8 @@ struct ChartPreferencesTests {
     @Test("Round-trips through Codable")
     func codable() throws {
         let preferences = ChartPreferences(
-            mirrorsPairs: true, stacksParts: true, showsTotals: true
+            mirrorsPairs: true, stacksParts: true,
+            showsTotals: true, rotatesTimeLabels: true
         )
         let data = try JSONEncoder().encode(preferences)
         #expect(try JSONDecoder().decode(ChartPreferences.self, from: data) == preferences)
@@ -196,6 +200,7 @@ struct ChartPreferencesTests {
         // An upgrade from a version without the key gets the new default, not
         // false: a missing key means "never asked", not "switched off".
         #expect(decoded.showsTotals)
+        #expect(decoded.rotatesTimeLabels == false)
     }
 }
 

--- a/Tests/MonitorCoreTests/ChartPreferencesTests.swift
+++ b/Tests/MonitorCoreTests/ChartPreferencesTests.swift
@@ -135,11 +135,14 @@ struct ChartStackTests {
 
 @Suite("ChartPreferences")
 struct ChartPreferencesTests {
-    @Test("Every setting is off until it is switched on")
-    func offByDefault() {
+    @Test("The two that change the picture are off; the one that adds a number is on")
+    func defaults() {
         #expect(ChartPreferences.default.mirrorsPairs == false)
         #expect(ChartPreferences.default.stacksParts == false)
-        #expect(ChartPreferences.default.showsTotals == false)
+        // Shipped off, the reaction to the finished feature was "I don't see
+        // it". A total adds a number beside one already there rather than
+        // changing what the chart means, so it does not need switching on.
+        #expect(ChartPreferences.default.showsTotals)
         #expect(ChartPreferences.default.mirror(for: [netIn, netOut]) == nil)
         #expect(ChartPreferences.default.stack(for: [app, wired, free]).isEmpty)
     }
@@ -190,7 +193,9 @@ struct ChartPreferencesTests {
         let decoded = try JSONDecoder().decode(ChartPreferences.self, from: stored)
         #expect(decoded.mirrorsPairs)
         #expect(decoded.stacksParts)
-        #expect(decoded.showsTotals == false)
+        // An upgrade from a version without the key gets the new default, not
+        // false: a missing key means "never asked", not "switched off".
+        #expect(decoded.showsTotals)
     }
 }
 

--- a/Tests/MonitorCoreTests/ChartPreferencesTests.swift
+++ b/Tests/MonitorCoreTests/ChartPreferencesTests.swift
@@ -135,10 +135,11 @@ struct ChartStackTests {
 
 @Suite("ChartPreferences")
 struct ChartPreferencesTests {
-    @Test("Both settings are off until they are switched on")
+    @Test("Every setting is off until it is switched on")
     func offByDefault() {
         #expect(ChartPreferences.default.mirrorsPairs == false)
         #expect(ChartPreferences.default.stacksParts == false)
+        #expect(ChartPreferences.default.showsTotals == false)
         #expect(ChartPreferences.default.mirror(for: [netIn, netOut]) == nil)
         #expect(ChartPreferences.default.stack(for: [app, wired, free]).isEmpty)
     }
@@ -150,11 +151,16 @@ struct ChartPreferencesTests {
         #expect(preferences.stack(for: [netIn, netOut]).isEmpty)
     }
 
-    @Test("The two settings are independent")
+    @Test("The settings are independent")
     func settingsAreIndependent() {
         let stacking = ChartPreferences(mirrorsPairs: false, stacksParts: true)
         #expect(stacking.mirror(for: [netIn, netOut]) == nil)
         #expect(!stacking.stack(for: [app, wired]).isEmpty)
+        // Totals are a number in the legend, not a change to the picture, so
+        // they must not turn either of the other two on by arriving.
+        let totals = ChartPreferences(showsTotals: true)
+        #expect(totals.mirror(for: [netIn, netOut]) == nil)
+        #expect(totals.stack(for: [app, wired]).isEmpty)
     }
 
     @Test("Switched on, a pair mirrors and everything else does not")
@@ -166,7 +172,9 @@ struct ChartPreferencesTests {
 
     @Test("Round-trips through Codable")
     func codable() throws {
-        let preferences = ChartPreferences(mirrorsPairs: true, stacksParts: true)
+        let preferences = ChartPreferences(
+            mirrorsPairs: true, stacksParts: true, showsTotals: true
+        )
         let data = try JSONEncoder().encode(preferences)
         #expect(try JSONDecoder().decode(ChartPreferences.self, from: data) == preferences)
     }
@@ -175,6 +183,14 @@ struct ChartPreferencesTests {
     func decodesMissingKeys() throws {
         let data = Data("{}".utf8)
         #expect(try JSONDecoder().decode(ChartPreferences.self, from: data) == .default)
+        // The shape a 1.4 install actually has on disk: the two keys that
+        // existed then, and nothing about totals. It must keep its answers to
+        // the questions it was asked rather than reset all three.
+        let stored = Data(#"{"mirrorsPairs":true,"stacksParts":true}"#.utf8)
+        let decoded = try JSONDecoder().decode(ChartPreferences.self, from: stored)
+        #expect(decoded.mirrorsPairs)
+        #expect(decoded.stacksParts)
+        #expect(decoded.showsTotals == false)
     }
 }
 

--- a/Tests/MonitorCoreTests/WindowTotalTests.swift
+++ b/Tests/MonitorCoreTests/WindowTotalTests.swift
@@ -1,0 +1,218 @@
+import Foundation
+@testable import MonitorCore
+import Testing
+
+private let metric = MetricID("test.rate")
+
+/// Samples at a fixed cadence, oldest first, ending at `end`.
+private func steady(
+    _ values: [Double], interval: TimeInterval = 0.5, end: TimeInterval = 1000
+) -> [Sample] {
+    let start = end - Double(values.count - 1) * interval
+    return values.enumerated().map { offset, value in
+        Sample(metric: metric, timestamp: start + Double(offset) * interval, value: value)
+    }
+}
+
+@Suite("WindowTotal")
+struct WindowTotalTests {
+    @Test("A constant rate over a window totals rate times window")
+    func constantRate() {
+        // 10 MB/s for 60 s is 600 MB. The simplest claim this file makes, and
+        // the one every other case is a variation on.
+        let points = steady(Array(repeating: 10_000_000, count: 121), interval: 0.5)
+        let result = WindowTotal.total(of: points, window: 60, maximumGap: 2)
+        #expect(result?.value == 600_000_000)
+        #expect(result?.covered == 60)
+    }
+
+    @Test("Differentiating a counter and integrating it back returns the delta")
+    func roundTrip() {
+        // The premise of the whole feature: a rate sample is the mean over the
+        // gap before it, so summing rate times gap telescopes back to exactly
+        // the counter delta. If this passes, the rest is formatting.
+        //
+        // Deliberately uneven, so the test cannot pass by multiplying by a
+        // constant interval it happened to guess right.
+        let deltas: [Double] = [0, 1400, 32, 900_000, 17, 0, 4, 250_000, 88, 1]
+        var counter = 5_000_000_000.0
+        var tracker = RateTracker()
+        var points: [Sample] = []
+        var timestamp = 1000.0
+        for (index, delta) in deltas.enumerated() {
+            counter += delta
+            timestamp += index.isMultiple(of: 3) ? 0.5 : 0.75
+            if let rate = tracker.rate(for: metric, total: counter, at: timestamp) {
+                points.append(Sample(metric: metric, timestamp: timestamp, value: rate))
+            }
+        }
+
+        // Two deltas drop out, for two different reasons. The first produced no
+        // rate at all — there was no previous reading. The second produced the
+        // oldest sample in the array, which has no predecessor to measure its
+        // interval against, so its width is unknown and it contributes nothing.
+        // Inventing a width for it would be a guess, and one sampling interval
+        // out of a window of hundreds is not worth guessing for.
+        let expected = deltas.dropFirst(2).reduce(0, +)
+        let result = WindowTotal.total(of: points, window: 600, maximumGap: 10)
+        #expect(abs((result?.value ?? 0) - expected) < 0.000001)
+    }
+
+    @Test("A gap straddling the window edge is clipped, not dropped or kept whole")
+    func clipsAtTheEdge() {
+        // Four samples 10 s apart, each reporting 100/s. A 25 s window ends at
+        // the last one and reaches half way into a gap, so it covers two whole
+        // intervals plus half of one: 100 * 25. The predecessor that measures
+        // that half interval sits outside the window, which is why the sum
+        // reads the whole array and filters only what it adds up.
+        let points = steady([100, 100, 100, 100], interval: 10, end: 1000)
+        let result = WindowTotal.total(of: points, window: 25, maximumGap: 60)
+        #expect(result?.value == 2500)
+        #expect(result?.covered == 25)
+    }
+
+    @Test("Uneven gaps weight each sample by the interval it measures")
+    func unevenGaps() {
+        // 1 s at 10/s, then 3 s at 100/s. A mean of the two values would say
+        // 55 * 4 = 220; weighting by interval says 10 + 300 = 310.
+        let points = [
+            Sample(metric: metric, timestamp: 100, value: 0),
+            Sample(metric: metric, timestamp: 101, value: 10),
+            Sample(metric: metric, timestamp: 104, value: 100),
+        ]
+        let result = WindowTotal.total(of: points, window: 60, maximumGap: 10)
+        #expect(result?.value == 310)
+        // Four seconds of history, not sixty. The first sample opens the span
+        // and contributes nothing, having no interval before it.
+        #expect(result?.covered == 4)
+    }
+
+    @Test("A window longer than the history reports the span it really has")
+    func shortHistory() {
+        // Ten seconds after launch the buffer holds ten seconds. Reporting the
+        // window it was asked for would put "2 min" under a number covering a
+        // twelfth of that, which is the quiet kind of wrong: nobody checks it.
+        let points = steady(Array(repeating: 1000, count: 21), interval: 0.5, end: 1000)
+        let result = WindowTotal.total(of: points, window: 120, maximumGap: 2)
+        #expect(result?.covered == 10)
+        #expect(result?.value == 10000)
+    }
+
+    @Test("Fewer than two samples has no total at all")
+    func needsTwoSamples() {
+        // The same choice RateTracker makes on a first read. One sample is a
+        // rate with no interval under it, and zero would draw as an idle
+        // machine rather than as a missing answer.
+        #expect(WindowTotal.total(of: [], window: 60, maximumGap: 2) == nil)
+        #expect(WindowTotal.total(of: steady([500]), window: 60, maximumGap: 2) == nil)
+    }
+
+    @Test("An interval longer than maximumGap is clipped and comes off covered")
+    func clampsLongGaps() {
+        // A slept laptop, or a source that failed for a minute, leaves one
+        // enormous interval. A rectangle drawn across it invents traffic that
+        // never happened, so the sample gets maximumGap and the rest of the
+        // span is not claimed as covered.
+        let points = [
+            Sample(metric: metric, timestamp: 100, value: 50),
+            Sample(metric: metric, timestamp: 400, value: 50),
+            Sample(metric: metric, timestamp: 400.5, value: 50),
+        ]
+        let result = WindowTotal.total(of: points, window: 600, maximumGap: 2)
+        // 2 s of the 300 s gap, plus the half second after it.
+        #expect(result?.value == 125)
+        #expect(result?.covered == 2.5)
+    }
+
+    @Test("Samples out of order are totalled in time order")
+    func sortsInput() {
+        // The buffer hands them over oldest first, but a caller assembling a
+        // card's series from several places need not, and a total that depends
+        // on array order is a bug waiting for a refactor.
+        let ordered = steady([0, 10, 20, 30], interval: 1)
+        let shuffled = [ordered[2], ordered[0], ordered[3], ordered[1]]
+        let expected = WindowTotal.total(of: ordered, window: 60, maximumGap: 10)
+        #expect(WindowTotal.total(of: shuffled, window: 60, maximumGap: 10) == expected)
+    }
+
+    @Test("The window ends at the newest sample unless told otherwise")
+    func explicitEnd() {
+        // Same rule CSVExport follows: the right-hand edge of the chart, which
+        // defaults to the newest sample the card holds.
+        let points = steady([100, 100, 100], interval: 1, end: 1000)
+        #expect(WindowTotal.total(of: points, window: 10, maximumGap: 10)?.value == 200)
+        // An end before the last sample excludes it.
+        let earlier = WindowTotal.total(of: points, window: 10, now: 999, maximumGap: 10)
+        #expect(earlier?.value == 100)
+    }
+}
+
+@Suite("MetricUnit accumulation")
+struct MetricUnitAccumulationTests {
+    @Test("Throughput accumulates into bytes, and network divides by eight")
+    func throughput() {
+        #expect(MetricUnit.bytesPerSecond.accumulation?.unit == .bytes)
+        #expect(MetricUnit.bytesPerSecond.accumulation?.scale == 1)
+        // A link is quoted in bits, a volume in bytes. The conversion lives
+        // here so the header and anything downstream cannot disagree.
+        #expect(MetricUnit.bitsPerSecond.accumulation?.unit == .bytes)
+        #expect(MetricUnit.bitsPerSecond.accumulation?.scale == 1.0 / 8)
+    }
+
+    @Test("Operations accumulate into a count")
+    func operations() {
+        #expect(MetricUnit.operationsPerSecond.accumulation?.unit == .count)
+    }
+
+    @Test("A level does not add up")
+    func levels() {
+        // Adding temperatures produces degree-seconds, which is not a quantity
+        // anybody wants under a chart of a CPU getting warm.
+        for unit in [
+            MetricUnit.fraction, .bytes, .count, .hertz, .celsius, .watts, .rpm, .seconds,
+        ] {
+            #expect(unit.accumulation == nil)
+        }
+    }
+}
+
+@Suite("Formatting a total")
+struct TotalFormattingTests {
+    @Test("A network total reads in bytes, not bits")
+    func networkTotalsInBytes() {
+        // 11.2 Gbit is 1.4 GB. Nobody has ever asked how many gigabits they
+        // downloaded, and every cap and file size is quoted the other way.
+        #expect(Format.total(11_200_000_000, unit: .bitsPerSecond) == "1.4 GB")
+        // Disk is already bytes and passes straight through.
+        #expect(Format.total(1_400_000_000, unit: .bytesPerSecond) == "1.4 GB")
+    }
+
+    @Test("An operations total reads as a count with SI suffixes")
+    func operationTotals() {
+        #expect(Format.total(1_234_567, unit: .operationsPerSecond) == "1.2 M")
+        #expect(Format.total(340_000, unit: .operationsPerSecond) == "340 k")
+        #expect(Format.total(847, unit: .operationsPerSecond) == "847")
+    }
+
+    @Test("A unit that does not accumulate has no total")
+    func noTotal() {
+        #expect(Format.total(42, unit: .celsius) == nil)
+        #expect(Format.total(0.5, unit: .fraction) == nil)
+        #expect(Format.widestTotal(unit: .watts) == nil)
+    }
+
+    @Test("The reserved slot is at least as wide as the readings it holds")
+    func reservationCoversRealValues() {
+        // A floor, like widestValue: being wrong here costs a little jitter at
+        // an extreme, never a clipped number. But it must cover the ordinary
+        // range, which is where the eye actually reads it.
+        let bytes = Format.widestTotal(unit: .bitsPerSecond) ?? ""
+        for value in [1000.0, 8_000_000, 11_200_000_000, 800_000_000_000] {
+            #expect(Format.total(value, unit: .bitsPerSecond)?.count ?? 0 <= bytes.count)
+        }
+        let counts = Format.widestTotal(unit: .operationsPerSecond) ?? ""
+        for value in [1.0, 847, 340_000, 1_234_567] {
+            #expect(Format.total(value, unit: .operationsPerSecond)?.count ?? 0 <= counts.count)
+        }
+    }
+}

--- a/Tests/MonitorCoreTests/WindowTotalTests.swift
+++ b/Tests/MonitorCoreTests/WindowTotalTests.swift
@@ -201,6 +201,25 @@ struct TotalFormattingTests {
         #expect(Format.widestTotal(unit: .watts) == nil)
     }
 
+    @Test("A span reads the way the History picker words it")
+    func spans() {
+        // The label sits beside a segmented picker reading exactly these, and
+        // two spellings of one duration on one screen reads as a fault.
+        #expect(Format.span(60) == "1 min")
+        #expect(Format.span(120) == "2 min")
+        #expect(Format.span(300) == "5 min")
+        #expect(Format.span(600) == "10 min")
+    }
+
+    @Test("A span short of a whole minute keeps its seconds")
+    func partialSpans() {
+        // A card 45 s after launch must say so rather than round itself up to
+        // the window it was asked for.
+        #expect(Format.span(45) == "45 s")
+        #expect(Format.span(9.6) == "10 s")
+        #expect(Format.span(90) == "90 s")
+    }
+
     @Test("The reserved slot is at least as wide as the readings it holds")
     func reservationCoversRealValues() {
         // A floor, like widestValue: being wrong here costs a little jitter at

--- a/Tests/MonitorUITests/AppModelTests.swift
+++ b/Tests/MonitorUITests/AppModelTests.swift
@@ -290,3 +290,37 @@ struct DropNeighbourTests {
         #expect(neighbour(after: "z", in: ["a", "b"], edge: .trailing) == nil)
     }
 }
+
+@MainActor
+@Suite("Window totals")
+struct AppModelTotalsTests {
+    /// A stable domain cleared per test, for the reason the suite above gives:
+    /// a uuid each time writes a new plist on every run, forever.
+    private static let domain = "wtf.evan.monitor.tests.totals"
+
+    private static func makeModel() -> AppModel {
+        let defaults = UserDefaults(suiteName: domain)!
+        defaults.removePersistentDomain(forName: domain)
+        return AppModel(sources: [], defaults: defaults)
+    }
+
+    @Test("The gap a total may credit follows the clock, not a constant")
+    func gapFollowsTheClock() {
+        // Somebody who slows the sampler to 2 s has 2 s gaps, and a ceiling
+        // fixed for the 0.5 s default would clip every one of them — quietly
+        // reporting a quarter of the traffic that crossed the wire.
+        let model = Self.makeModel()
+        model.interval = 0.5
+        #expect(model.totalGap == 2)
+        model.interval = 2
+        #expect(model.totalGap == 8)
+    }
+
+    @Test("Totals are off until they are switched on")
+    func offByDefault() {
+        // Same default as mirroring and stacking, and for a version of the same
+        // reason: switching it on reflows headers onto two lines, and a card
+        // that changes shape on upgrade is worse than one somebody switches on.
+        #expect(Self.makeModel().charts.showsTotals == false)
+    }
+}

--- a/Tests/MonitorUITests/AppModelTests.swift
+++ b/Tests/MonitorUITests/AppModelTests.swift
@@ -316,11 +316,10 @@ struct AppModelTotalsTests {
         #expect(model.totalGap == 8)
     }
 
-    @Test("Totals are off until they are switched on")
-    func offByDefault() {
-        // Same default as mirroring and stacking, and for a version of the same
-        // reason: switching it on reflows headers onto two lines, and a card
-        // that changes shape on upgrade is worse than one somebody switches on.
-        #expect(Self.makeModel().charts.showsTotals == false)
+    @Test("Totals are on without being asked for")
+    func onByDefault() {
+        // Unlike mirroring and stacking beside it. Those change what the
+        // picture means; this adds a number next to one already there.
+        #expect(Self.makeModel().charts.showsTotals)
     }
 }

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -216,3 +216,29 @@ readout of `900` is useless until you have also read the word beneath it. The
 A chart axis and the CLI carry three significant figures, which keeps a value's
 width near-constant as it moves. The gauge readout goes further and uses a fixed
 `xxxx.yy` field so the decimal point never moves at all — see `docs/ui.md`.
+
+## What a rate adds up to
+
+`MetricUnit.accumulation` says what a second's worth of a unit becomes, and the
+factor that gets it there. It is nil for every level: adding temperatures gives
+degree-seconds, which is not a quantity anybody wants under a chart of a CPU
+getting warm.
+
+| Unit | Accumulates into | Factor |
+|------|------------------|--------|
+| `bytesPerSecond` | `bytes` | 1 |
+| `bitsPerSecond` | `bytes` | 1/8 |
+| `operationsPerSecond` | `count` | 1 |
+| everything else | — | — |
+
+**Network reads in bits and totals in bytes.** A link is quoted in bits — a
+1 Gbit port, an 866 Mbit Wi-Fi link — so the rate stays Mbit/s. A volume is
+quoted in bytes everywhere it matters: ISP caps, file sizes, Finder. Two
+different questions with two right answers. The divide by eight has exactly one
+definition, in `accumulation`, for the same reason `NetworkSource` multiplies by
+eight in the source rather than in the gauge: nothing downstream can then
+disagree about whether 1.4 GB and 11.2 Gbit are the same reading.
+
+Derived from the unit rather than from a table of metric ids, the same way
+`ChartMirror` and `ChartStack` read `direction` and `composition`. A source
+added later gets a total without anything being told it exists.

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -953,9 +953,23 @@ because of how the app gets used — a monitor is left running for days, and the
 copy on screen is very often not the copy just built. "Am I looking at the
 change I just made?" should not cost two clicks.
 
-Drawn in `Theme.readout`, not the secondary style the title bar would otherwise
-give it. A stamp nobody can read at a glance is a stamp nobody checks, which is
-the same failure as not having one.
+**White on black, in the system font** — not the panel's palette, and not the
+monospaced face the cards use. This is the one thing in the window that is not a
+reading. Everything else is a measurement of the machine, styled to be scanned;
+the stamp is a label on the photograph, and its job is to survive being
+screenshotted and read back later.
+
+The first version left it to the title bar's own styling and came out as dark
+text on a light glass pill — the lowest contrast anywhere in the window, on the
+element whose whole purpose is to still be legible in a PNG somebody opens next
+month. macOS 26 wraps every toolbar item in that shared capsule, so the item
+opts out with `sharedBackgroundVisibility(.hidden)` and paints its own. Earlier
+releases add no capsule and need no opt-out, which is why the call is gated and
+additive rather than two sets of styling.
+
+`fixedSize`, so it is never truncated. A commit clipped to
+`v1.4.0-8-gc61738cf · Aug 28 09:3` is worse than no stamp at all: it looks
+complete.
 
 ### Two facts, two sources
 

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -404,6 +404,56 @@ looking at, and none says less.
 `ChartAxis` in `MonitorCore` holds the arithmetic, which is why it is testable
 without a window.
 
+### The labels must not touch, and that beats having two of them
+
+The rule used to be the other way round: never fewer than two labels, and
+slightly tight labels beat a bare axis. It was right about "slightly tight" and
+wrong about what the arithmetic produced. On a 160-point plot the axis drew four
+labels 32 points wide with their centres 40 points apart, and at the narrowest
+card they overlapped outright — `08:52:3008:53:0008:53:30`. Labels that collide
+are not slightly tight; they are unreadable, and worse than the sparse axis the
+old rule was avoiding.
+
+Three things were wrong at once, and all three are fixed:
+
+- **The room was measured off the chart, not the plot.** A flat 50-point
+  allowance stood in for the y-axis, which is right for one card and generous
+  for every card whose numbers are long — and those are the cards whose plots
+  are narrowest. `chartBackground` hands over the real plot rect instead.
+  Not `chartOverlay`: an overlay sits above the content and would swallow the
+  mouse-down a tile's drag needs, which is the trap `ReorderDrag` documents.
+- **Every stride was costed at the same label width.** A stride of a minute or
+  more shows no seconds, so "8:52" needs a third less room than "8:52:30". The
+  measured figures are 20 points against 32, at `Theme.Layout.timeLabel`, and
+  budgeting the coarse strides at the wide figure made the axis unable to reach
+  for the one a cramped card wanted. Each candidate is now costed at the width
+  of its own labels.
+- **The labels were wider than they needed to be.** They have their own size,
+  smaller than the y-axis labels beside them: there are more of them, they are
+  longer, and a y-axis label has a whole row to itself. The hour lost its
+  leading zero too — "0" in "08:52:30" carries nothing across four labels with
+  no room for it. Minutes and seconds keep both digits, because those are
+  positional and "8:5:3" is not a time.
+
+Two labels are still what the axis reaches for: the walk goes finest first, so
+the first stride that fits is the densest that fits. What is gone is the
+promise. A narrow card showing two minutes has no stride both coarse enough to
+fit and fine enough to guarantee two, and it now shows one label rather than two
+on top of each other.
+
+### Sideways labels
+
+**Turn the time labels sideways** in the Charts tab is how to have both. On its
+side a label costs its line height rather than its width — 10 points against 32
+— so the narrowest card fits four times where upright it fits two. Off by
+default, because horizontal is easier to read and on every card but the smallest
+there is room for it.
+
+`rotationEffect` turns the glyphs and not the layout, so the rotated label needs
+`fixedSize` to stop its frame squeezing the text first, and then a frame of its
+own. Without that the axis reserves the label's width and none of its height,
+and the turned text draws over the chart.
+
 ### The interval comes from the window's length, never its position
 
 The ticks are absolute instants, so how many land inside the window depends on

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -947,9 +947,25 @@ same chart.
 
 ## Which build is this?
 
-The title bar carries the commit and the build time, next to the window's name:
-`v1.4.0-4-ga8e8631 · Aug 28 09:52`. It is there rather than in the About panel
-because of how the app gets used — a monitor is left running for days, and the
+The title bar carries the app's name with the commit and the build time under
+it:
+
+```
+Monitor
+v1.4.0-9-g909767d9 · Aug 28 09:40
+```
+
+One block, so it reads as a heading with its build beneath rather than as a chip
+parked beside a title repeating it. The window's own title is removed
+(`toolbar(removing: .title)`, or an empty `navigationTitle` on macOS 14, where
+`ToolbarDefaultItemKind.title` does not exist) or the system would draw the name
+a second time. The `Window` scene keeps its real name either way, so the Window
+menu and the Dock still say what this is, and that name lives beside the version
+in `MonitorVersion` — two spellings of one name is the sort of thing nobody
+notices until a screenshot.
+
+It is in the title bar rather than in the About panel because of how the app gets
+used — a monitor is left running for days, and the
 copy on screen is very often not the copy just built. "Am I looking at the
 change I just made?" should not cost two clicks.
 

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -916,3 +916,39 @@ One needle colour for every gauge. A needle that changes colour per metric turns
 a dashboard into a fruit salad and stops the eye reading position, which is the
 only thing a needle is for. Chart series colours avoid red/green pairs on the
 same chart.
+
+## Which build is this?
+
+The title bar carries the commit and the build time, next to the window's name:
+`v1.4.0-4-ga8e8631 · Aug 28 09:52`. It is there rather than in the About panel
+because of how the app gets used — a monitor is left running for days, and the
+copy on screen is very often not the copy just built. "Am I looking at the
+change I just made?" should not cost two clicks.
+
+Drawn in `Theme.readout`, not the secondary style the title bar would otherwise
+give it. A stamp nobody can read at a glance is a stamp nobody checks, which is
+the same failure as not having one.
+
+### Two facts, two sources
+
+**The commit is stamped at build time.** The `StampCommit` plugin runs
+`git describe --tags --always --dirty --abbrev=8` before every build and writes
+`CommitStamp`. It has to be captured then: a running program has no other way to
+know which commit it came from, and a checked-in constant is something somebody
+has to remember to update — which means a title bar that eventually lies.
+
+`describe` rather than a bare hash, for the `-dirty`. A build with uncommitted
+changes is not the commit it names, and saying so is the difference between a
+stamp you can trust and one you have to double-check.
+
+**The build time is read at runtime**, from the executable's own modification
+date. It could have been stamped alongside the commit, and that would have been
+worse: the build time changes on every build by definition, so writing it into a
+source file would recompile `MonitorCore` every time and cost the fast
+`swift run` loop — for a fact the filesystem already knows. The plugin writes
+its own output only when the hash has actually changed, for the same reason.
+
+Where either is unavailable it drops out rather than being filled in: no git
+gives `unknown`, and an unreadable executable date leaves the commit on its own.
+Half an answer beats a stand-in that looks like the other half — the same rule
+the sources follow when a read fails.

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -361,6 +361,34 @@ less than the card's stated span — one source failed for a stretch while its
 neighbour kept reading — is dimmed. The ordinary case spends no ink saying it
 is ordinary.
 
+### A card with totals gets a table, not a wrapped row
+
+The legend has two shapes, because the cards do. A card of levels — Memory's
+seven slices, five temperature sensors — has nothing to total and keeps
+`FlowLayout`, which spends card height only when the entries genuinely do not
+fit across. A card of rates has a second number per series, and numbers in a
+wrapped row do not line up: the first version put the totals at four different
+left edges down the same card.
+
+So those cards draw a small `Grid` instead: swatch, name, rate, total, with the
+totals column **headed and right-justified**. Right-justified because these are
+magnitudes, and a magnitude is read by where its last digit sits — `104 MB` over
+`48 MB` aligned on the left puts the hundreds above the tens and hides the
+difference the column exists to show. Headed because a second bare number beside
+a rate does not say what it is: the span beside the title says *how long*, and
+the heading says *of what*.
+
+The table always goes under the title, never beside it. `ViewThatFits` is the
+right question for a wrapping row and the wrong one for a column of figures —
+pushed to the right of the title on a wide card, the heading floats in the
+middle of the header with nothing under it that reads as a table.
+
+Only five groups accumulate, and every one of them has exactly two series, so
+the table is three rows at its tallest. The reserved-width slot survives into
+it: a `Grid` sizes a column to its widest cell, so without the reservation the
+column would resize as a total crossed a magnitude and shuffle the card while
+somebody read it.
+
 ### A gap nobody sampled is not traffic
 
 `maximumGap` is the widest interval one sample may be credited with. A laptop

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -964,6 +964,13 @@ menu and the Dock still say what this is, and that name lives beside the version
 in `MonitorVersion` — two spellings of one name is the sort of thing nobody
 notices until a screenshot.
 
+Removing the title cost the toolbar something that was not obvious until it was
+gone: the title was taking the slack in the middle, and it was that, not the
+items' own placement, pushing the History picker and the size and rate controls
+to the trailing edge. Without it `.automatic` packed them up against the stamp.
+They are `.primaryAction` now, which says what the layout actually depends on
+rather than leaning on something that is no longer there.
+
 It is in the title bar rather than in the About panel because of how the app gets
 used — a monitor is left running for days, and the
 copy on screen is very often not the copy just built. "Am I looking at the

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -310,6 +310,76 @@ a registry test proves it. `ChartCard` drops the stack when a mirror is set as
 well, because a band drawn below a baseline would be nonsense however it got
 there.
 
+## Totals for the window
+
+**Show totals for the window** in the Charts tab adds a second number to every
+legend entry: how much moved, beside how fast it is moving. Off by default, for
+a narrower version of the reason mirroring and stacking are — those change what
+the picture means, this only adds a number, but it adds one to a header already
+decided by `ViewThatFits`, so switching it on reflows cards onto two lines.
+
+The gap it fills: a dial answers "how hard is this working right now" and a
+chart answers "what has been happening". Neither answers "how much did that
+transfer cost me", which is the question you have while watching a sync run.
+
+### The arithmetic is already in the buffer
+
+A rate sample **is** the mean over the gap before it — `RateTracker` produces
+`Δcounter / Δt` — so multiplying each sample by the interval it measures and
+summing telescopes back to exactly the counter delta. `WindowTotal`, in
+`MonitorCore` beside `CSVExport`, is that sum. No counter history is kept
+anywhere, no source changes, and nothing is read that the ring buffer does not
+already hold, so this stays inside the rule that nothing is written to disk.
+
+`ChartCard` totals `series` rather than `visible`: the sum needs the sample just
+*before* the window's left edge to measure the partial interval that straddles
+it, and `visible` has already thrown that one away.
+
+### It covers what the chart draws
+
+The window is the History picker's, so the number and the picture answer the
+same question and one control changes both. Ten minutes remains the ceiling,
+because that is what the buffer holds.
+
+### It says the span it really has
+
+`WindowTotal.Result` carries `covered` beside `value`. Ten seconds after launch
+the buffer holds ten seconds, and "2 min" over a number covering a twelfth of
+that is the quiet kind of wrong — it looks exactly like the right answer, so
+nobody checks it. The span sits beside the card's title, and it reads the
+window only when the card really has it, within one `totalGap` of tolerance: a
+card is never going to cover its window to the microsecond, and "119 s" beside
+a picker reading "2 min" looks like a fault rather than like precision.
+
+Stated once beside the title rather than after each entry. The picker is
+global, so repeating "/ 2 min" down a legend is four copies of one fact, in the
+part of the card with the least room to spare. An entry covering materially
+less than the card's stated span — one source failed for a stretch while its
+neighbour kept reading — is dimmed. The ordinary case spends no ink saying it
+is ordinary.
+
+### A gap nobody sampled is not traffic
+
+`maximumGap` is the widest interval one sample may be credited with. A laptop
+coming back from sleep leaves a single enormous gap, and a rectangle drawn
+across it invents traffic that never crossed the wire; the clipped remainder
+comes off `covered` instead, so the span tells you the total is thin.
+
+`AppModel.totalGap` is four ticks of the master clock, so it follows the
+Sampling tab rather than assuming the 0.5 s default. A ceiling fixed for that
+default would clip every interval of a sampler slowed to 2 s.
+
+### Fewer than two samples has no total
+
+Nil, not zero — the same answer `RateTracker` gives on a first read, for the
+same reason. Zero draws as an idle machine rather than as a missing number.
+
+### Not in the CSV
+
+`Copy Data` still carries rates only. A spreadsheet's own `SUM` times the
+interval is this same arithmetic, and a "Total" row under the Time column is a
+type error waiting to be pasted into a chart.
+
 ## The time axis
 
 Three things have to be true of the labels along the bottom, and the first two

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -313,10 +313,13 @@ there.
 ## Totals for the window
 
 **Show totals for the window** in the Charts tab adds a second number to every
-legend entry: how much moved, beside how fast it is moving. Off by default, for
-a narrower version of the reason mirroring and stacking are — those change what
-the picture means, this only adds a number, but it adds one to a header already
-decided by `ViewThatFits`, so switching it on reflows cards onto two lines.
+legend entry: how much moved, beside how fast it is moving. **On by default**,
+unlike mirroring and stacking beside it. It shipped off, to match them, and the
+reaction to the finished feature was "I don't see it". The difference that
+argument missed: those two change what the picture *means*, so a reader who
+never asked for them deserves the chart they had — a total only adds a number
+beside one already there, and a number nobody can find is worth less than a
+header that reflows.
 
 The gap it fills: a dial answers "how hard is this working right now" and a
 chart answers "what has been happening". Neither answers "how much did that


### PR DESCRIPTION
Closes #35.

Three related pieces of one session, in one pull request because they were only
ever mergeable in order — see the commits for the separable history.

## 1. Totals over the window

Every legend entry gains a second number: how much moved over the window the
chart draws, beside how fast it is moving now. Network and disk in bytes,
packets and disk operations as counts.

```
Disk                     5 s
                      Totals
● Read   12.8 MB/s     35 MB
● Write  13.0 MB/s     14 MB
```

**The sum is already in the buffer.** A rate sample *is* the mean over the gap
before it, so `Σ(rate × preceding gap)` telescopes back to exactly the counter
delta. No counter history, no source changes, nothing read that the ring buffer
does not already hold — so it stays well inside the rule that v1 writes nothing
to disk. The round-trip test is the premise: differentiate a synthetic counter
with `RateTracker`, integrate it back, expect the original delta.

Three things it refuses to fake:

- **It reports the span it covered.** Ten seconds after launch the buffer holds
  ten seconds, and "2 min" over a twelfth of that looks exactly like the right
  answer — which is why nobody would check it.
- **A gap nobody sampled is not traffic.** An interval wider than `maximumGap`
  is clipped, so a laptop back from sleep cannot credit one sample with an hour
  that never crossed the wire. `AppModel.totalGap` follows the Sampling tab
  rather than assuming 0.5 s.
- **Fewer than two samples has no total** — nil, not zero, the same answer
  `RateTracker` gives on a first read.

**Network totals in bytes** while the rate stays Mbit/s: a link is quoted in
bits, a volume in bytes. `MetricUnit.accumulation` holds the ÷8 as its only
definition, derived from the unit like `direction` and `composition`.

A card with totals draws a `Grid` — headed, right-justified — rather than the
wrapping `FlowLayout`. A magnitude is read by where its last digit sits, and
wrapped entries put them at four different left edges.

## 2. A time axis that does not collide

From a screenshot: `08:52:3008:53:0008:53:30`. Three things were wrong at once.

- **The room was measured off the chart, not the plot.** A flat 50-point
  allowance stood in for the y-axis — right for one card, generous for every
  card whose numbers are long, which are the cards whose plots are narrowest.
  Now read from the real plot rect via `chartBackground`. Not `chartOverlay`:
  an overlay would swallow the mouse-down a tile's drag needs.
- **Every stride was costed at the same label width**, though a stride of a
  minute or more shows no seconds. Measured: 20 points against 32.
- **The labels were wider than they needed to be** — own size now, and the hour
  loses its leading zero.

**Rule 2 now beats rule 1.** "Never fewer than two labels" used to win on the
grounds that slightly tight beats bare. Right about slightly tight, wrong about
the output: four labels 32 points wide with centres 40 apart. Two labels are
still what the walk reaches for; what is gone is the promise.

**Turn the time labels sideways**, new in the Charts tab, off by default: on its
side a label costs its line height, so the narrowest card fits four times where
upright it fits two.

## 3. A build stamp in the title bar

```
Monitor
v1.4.0-11-g0ac6bafa · Aug 28 09:56
```

There to identify which build produced which screenshot. White on black in the
system font — deliberately not the panel's palette or the cards' monospaced
face. It is the one thing in the window that is not a reading: everything else
is a measurement styled to be scanned, and this is a label on the photograph.

**Two facts, two sources.** The commit is stamped at build time by a new
`StampCommit` prebuild plugin (`git describe --tags --always --dirty`) — a
running program has no other way to know, and a checked-in constant is one
somebody has to remember to update. The build time is read at runtime from the
executable's modification date: stamping it too would rewrite a source file on
every build and recompile `MonitorCore` every time, for a fact the filesystem
already has. The plugin rewrites its output only when the hash changes, for the
same reason.

Three things this turned up on the way:

- macOS 26 wraps toolbar items in a shared glass capsule, which made the stamp
  dark-on-light and clipped it. It opts out with
  `sharedBackgroundVisibility(.hidden)`, gated to 26 and additive.
- The window's own title is removed, or the name draws twice. `toolbar(removing:)`
  is macOS 14 but the `.title` kind is 15, so 14 gets an empty `navigationTitle`.
- Removing the title cost the toolbar its trailing alignment — the title had been
  taking the slack in the middle, not the items' placement. They are
  `.primaryAction` now, which says what the layout actually depends on.

## Verification

215 tests in 26 suites, `swift build -c release`, and `swiftformat Sources Tests
Plugins --lint` all clean. Lint now covers `Plugins`; `ci.yml` updated to match.

`ChartAxisTests` is rewritten against the new contract, keeping every existing
claim and adding the ones this needed — chiefly **labels never overlap**, swept
across every window, six plot widths, both orientations and forty phases each.

All three pieces were looked at in the running app and revised from what they
actually looked like, which is where most of the above came from.

https://claude.ai/code/session_01EqTTtmt4fyNtMxjc2ZVBzj