### PR TITLE
Fix monitord build in make-app.sh

### DIFF
--- a/Scripts/make-app.sh
+++ b/Scripts/make-app.sh
@@ -137,6 +137,8 @@ echo "Built $app"
 # level: monitor.app/ and monitord. Build it and stage the pair into
 # .build/package/, which the CI packaging step zips.
 echo "Building monitord…"
+# --show-bin-path prints the path but does not build, so build first.
+swift build -c release --product monitord
 monitord="$(swift build -c release --product monitord --show-bin-path)/monitord"
 [ -x "$monitord" ] || { echo "no binary at $monitord" >&2; exit 1; }
 


### PR DESCRIPTION
The release workflow failed to attach a zip to v1.5.2: `make-app.sh` used `swift build --show-bin-path` to locate the monitord binary, but `--show-bin-path` prints the path without building. On a fresh CI checkout the binary did not exist, so the package step failed.

Fix: build monitord first, then read its bin path. Verified from a clean state locally.