### PR TITLE
Release 1.6.0

### DIFF
--- a/Sources/MonitorCore/Version.swift
+++ b/Sources/MonitorCore/Version.swift
@@ -5,7 +5,7 @@
 /// unbundled one cannot claim different versions. Keep the literal on one
 /// line: the script's pattern expects it there.
 public enum MonitorVersion {
-    public static let string = "1.5.5"
+    public static let string = "1.6.0"
 
     /// What the app calls itself. Here beside the version because the title bar
     /// draws it, the `Window` scene names itself with it, and two spellings of


### PR DESCRIPTION
Bumps `MonitorVersion.string` to 1.6.0. The release workflow ships exactly this version (escape hatch #1).